### PR TITLE
Fix casing of file references in csprojs

### DIFF
--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -86,7 +86,7 @@
     <Compile Include="..\Shared\TempFileUtilities.cs">
       <Link>TempFileUtilities.cs</Link>
     </Compile>
-    <Compile Include="..\Shared\XmakeAttributes.cs">
+    <Compile Include="..\Shared\XMakeAttributes.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="..\Shared\INodeEndpoint.cs" />

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -574,7 +574,7 @@
     <Compile Include="RequiresFramework35SP1Assembly.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="Sgen.cs">
+    <Compile Include="SGen.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="SignFile.cs">


### PR DESCRIPTION
Building these projects on a case-sensitive file system revealed that the file casing
is different on disk. Fixed the reference in csprojs to match the name on disk.