### PR TITLE
dir.targets: correctly enclose 'Exists' condition in single quotes

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -49,7 +49,7 @@
     <!-- Download latest nuget.exe -->
     <DownloadFile FileName="$(NuGetToolPath)"
                   Address="http://nuget.org/nuget.exe" 
-                  Condition="!Exists($(NuGetToolPath))" />
+                  Condition="!Exists('$(NuGetToolPath)')" />
 
     <!-- Restore build tools -->
     <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget\packages.config&quot;" StandardOutputImportance="Low" />


### PR DESCRIPTION
According to MSDN (http://msdn.microsoft.com/en-us/library/7szfhaft.aspx), the
single quotes can be left off for "simple alphanumeric strings or boolean values".
This is not the case here (it is a property), so we should use single quotes.

Note that MSBuild ignores this, but it results in a parser error on Mono's xbuild.