### PR TITLE
[Nefarious Grammar] Bad sentence structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿# Microsoft.Build (MSBuild)
-The Microsoft Build Engine is a platform for building applications. This engine, which is also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software. Visual Studio uses MSBuild, but it doesn't depend on Visual Studio. By invoking msbuild.exe on your project or solution file, you can orchestrate and build products in environments where Visual Studio isn't installed.
+The Microsoft Build Engine is a platform for building applications. This engine, which is also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software. Visual Studio uses MSBuild, but MSBuild *does not* depend on Visual Studio. By invoking msbuild.exe on your project or solution file, you can orchestrate and build products in environments where Visual Studio isn't installed.
 
 For more information on MSBuild, see the [MSDN documentation](https://msdn.microsoft.com/en-us/library/dd393574(v=vs.120).aspx).
 


### PR DESCRIPTION
```
Visual Studio uses MSBuild, but it (VisualStudio) doesn't depend on Visual Studio.
^ Subject          ^ Object     ^ Subject Reference
```
 doesn't make sense.

I haven't been able to sleep.

This will put my mind at ease:

> Visual Studio uses MSBuild, but MSBuild *does not* depend on Visual Studio.
