### PR TITLE
Changed 'canceled' back to 'cancelled"

### DIFF
--- a/src/Shared/TaskHostTaskCancelled.cs
+++ b/src/Shared/TaskHostTaskCancelled.cs
@@ -3,7 +3,7 @@
 //-----------------------------------------------------------------------
 // </copyright>
 // <summary>A packet which informs the task host that the task it is 
-// currently executing has been canceled.</summary>
+// currently executing has been cancelled.</summary>
 //-----------------------------------------------------------------------
 
 using System;
@@ -15,7 +15,7 @@ namespace Microsoft.Build.BackEnd
 {
     /// <summary>
     /// TaskHostTaskCancelled informs the task host that the task it is 
-    /// currently executing has been canceled.
+    /// currently executing has been cancelled.
     /// </summary>
     internal class TaskHostTaskCancelled : INodePacket
     {
@@ -40,7 +40,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="translator">The translator to use.</param>
         public void Translate(INodePacketTranslator translator)
         {
-            // Do nothing -- this packet doesn't contain any parameters. 
+            // Do nothing -- this packet doesn't contain any parameters.
         }
 
         /// <summary>


### PR DESCRIPTION
This is why I shouldn't make commits after midnight - it was pointed out that my previous change (#13) that cancelled was valid spelling and then my OCD kicked in.