### PR TITLE
Removing redundant contructors (empty is provided by default)

### DIFF
--- a/src/XMakeTasks/FileIO/ReadLinesFromFile.cs
+++ b/src/XMakeTasks/FileIO/ReadLinesFromFile.cs
@@ -18,13 +18,6 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class ReadLinesFromFile : TaskExtension
     {
-        /// <summary>
-        /// Construct.
-        /// </summary>
-        public ReadLinesFromFile()
-        {
-        }
-
         private ITaskItem _file = null;
         private ITaskItem[] _lines = new TaskItem[0];
 

--- a/src/XMakeTasks/FileIO/WriteLinesToFile.cs
+++ b/src/XMakeTasks/FileIO/WriteLinesToFile.cs
@@ -19,13 +19,6 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class WriteLinesToFile : TaskExtension
     {
-        /// <summary>
-        /// Construct.
-        /// </summary>
-        public WriteLinesToFile()
-        {
-        }
-
         private ITaskItem _file = null;
         private ITaskItem[] _lines = null;
         private bool _overwrite = false;

--- a/src/XMakeTasks/ListOperators/FindUnderPath.cs
+++ b/src/XMakeTasks/ListOperators/FindUnderPath.cs
@@ -16,13 +16,6 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class FindUnderPath : TaskExtension
     {
-        /// <summary>
-        /// Construct.
-        /// </summary>
-        public FindUnderPath()
-        {
-        }
-
         private bool _updateToAbsolutePaths = false;
         private ITaskItem _path = null;
         private ITaskItem[] _files = new TaskItem[0];

--- a/src/XMakeTasks/ListOperators/RemoveDuplicates.cs
+++ b/src/XMakeTasks/ListOperators/RemoveDuplicates.cs
@@ -15,13 +15,6 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class RemoveDuplicates : TaskExtension
     {
-        /// <summary>
-        /// Construct.
-        /// </summary>
-        public RemoveDuplicates()
-        {
-        }
-
         private ITaskItem[] _inputs = new TaskItem[0];
         private ITaskItem[] _filtered = null;
 


### PR DESCRIPTION
Those constructors seem to be totally unnecessary, as compiler generates empty ones by default