### PR TITLE
Make MSBuild Unix aware.

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -217,9 +217,17 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static Dictionary<string, string> GetEnvironmentVariables()
         {
+            Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
+            if (PlatformUtilities.IsUnix){
+                    // Mono  does have expensive security checks
+                    foreach (DictionaryEntry ke in Environment.GetEnvironmentVariables ()){
+                            table.Add ((string)ke.Key, (string)ke.Value);
+                    }
+                    return table;
+            }
             char[] block = GetEnvironmentCharArray();
 
-            Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
+            
 
             // Copy strings out, parsing into pairs and inserting into the table.
             // The first few environment variable entries start with an '='!

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -27,6 +27,10 @@ namespace Microsoft.Build.Shared
                 // fall back to default ANSI encoding if we have problems
                 s_currentOemEncoding = Encoding.Default;
 
+                if (PlatformUtilities.IsUnix){
+                        // The Mono default encoding is already the system encoding.
+                        return s_currentOemEncoding;
+                }
                 try
                 {
                     // get the current OEM code page

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -309,6 +309,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal unsafe static string NormalizePath(string path)
         {
+            if (PlatformUtilities.IsUnix)
+                return Path.GetFullPath (path);
+            
             ErrorUtilities.VerifyThrowArgumentLength(path, "path");
 
             int errorCode = 0; // 0 == success in Win32
@@ -740,6 +743,9 @@ namespace Microsoft.Build.Shared
         {
             fullPath = AttemptToShortenPath(fullPath);
 
+            if (PlatformUtilities.IsUnix)
+                return Directory.Exists (fullPath);
+            
             NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA data = new NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA();
             bool success = false;
 
@@ -761,6 +767,9 @@ namespace Microsoft.Build.Shared
         internal static bool FileExistsNoThrow(string fullPath)
         {
             fullPath = AttemptToShortenPath(fullPath);
+
+            if (PlatformUtilities.IsUnix)
+                    return File.Exists (fullPath);
 
             NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA data = new NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA();
             bool success = false;
@@ -784,6 +793,9 @@ namespace Microsoft.Build.Shared
         {
             fullPath = AttemptToShortenPath(fullPath);
 
+            if (PlatformUtilities.IsUnix)
+                return Directory.Exists (fullPath) || File.Exists (fullPath);
+            
             NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA data = new NativeMethodsShared.WIN32_FILE_ATTRIBUTE_DATA();
             bool success = false;
 

--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -76,13 +76,22 @@ namespace Microsoft.Build.Collections
         /// We need a static contructor to retrieve the running ProcessorArchitecture that way we can
         /// Avoid using optimized code that will not run correctly on IA64 due to alignment issues
         /// </summary>
+
+        //
+        // The side effect of this is to set s_runningProcessorArchitecture, which is not used
+        // in any of the code that has been released, so we skip it for Unix.
+        //
         static MSBuildNameIgnoreCaseComparer()
         {
-            NativeMethodsShared.SYSTEM_INFO systemInfo = new NativeMethodsShared.SYSTEM_INFO();
-
-            NativeMethodsShared.GetSystemInfo(ref systemInfo);
-
-            s_runningProcessorArchitecture = systemInfo.wProcessorArchitecture;
+            if (PlatformUtilities.IsUnix){
+                return;
+            } else {
+                NativeMethodsShared.SYSTEM_INFO systemInfo = new NativeMethodsShared.SYSTEM_INFO();
+                
+                NativeMethodsShared.GetSystemInfo(ref systemInfo);
+                
+                s_runningProcessorArchitecture = systemInfo.wProcessorArchitecture;
+            }
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -828,6 +828,9 @@ namespace Microsoft.Build.BackEnd
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.GC.Collect", Justification = "We're trying to get rid of memory because we're running low, so we need to collect NOW in order to free it up ASAP")]
         private void CheckMemoryUsage()
         {
+                if (PlatformUtilities.IsUnix)
+                        return;
+                
             // Jeffrey Richter suggests that when the memory load in the system exceeds 80% it is a good
             // idea to start finding ways to unload unnecessary data to prevent memory starvation.  We use this metric in
             // our calculations below.

--- a/src/XMakeBuildEngine/Logging/BaseConsoleLogger.cs
+++ b/src/XMakeBuildEngine/Logging/BaseConsoleLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -342,19 +342,23 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         internal void IsRunningWithCharacterFileType()
         {
-            // Get the std out handle
-            IntPtr stdHandle = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
-
-            if (stdHandle != Microsoft.Build.BackEnd.NativeMethods.InvalidHandle)
-            {
-                uint fileType = NativeMethodsShared.GetFileType(stdHandle);
-
-                // The std out is a char type(LPT or Console)
-                runningWithCharacterFileType = (fileType == NativeMethodsShared.FILE_TYPE_CHAR);
-            }
-            else
-            {
-                runningWithCharacterFileType = false;
+            if (PlatformUtilities.IsRunningOnUnix){
+                runningWithCharacterFileType = !Console.IsInputRedirected && !Console.IsOutputRedirected;
+            } else {
+                // Get the std out handle
+                IntPtr stdHandle = NativeMethodsShared.GetStdHandle(NativeMethodsShared.STD_OUTPUT_HANDLE);
+                
+                if (stdHandle != Microsoft.Build.BackEnd.NativeMethods.InvalidHandle)
+                {
+                    uint fileType = NativeMethodsShared.GetFileType(stdHandle);
+                
+                    // The std out is a char type(LPT or Console)
+                    runningWithCharacterFileType = (fileType == NativeMethodsShared.FILE_TYPE_CHAR);
+                }
+                else
+                {
+                    runningWithCharacterFileType = false;
+                }
             }
         }
 

--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -539,7 +539,10 @@ namespace Microsoft.Build.Tasks
         protected override string GenerateFullPathToTool()
         {
             // Get the fully qualified path to cmd.exe
-            return ToolLocationHelper.GetPathToSystemFile("cmd.exe");
+            if (PlatformUtilities.IsUnix)
+                return "sh";
+            else 
+                return ToolLocationHelper.GetPathToSystemFile("cmd.exe");
         }
 
         /// <summary>


### PR DESCRIPTION
Uses the standard .NET APIs when running on Unix instead of
using P/Invoke.   In the future, we could introduce a Mono.Posix
dependency to call into the Unix native APIs in a portable way, but
for now this is fine.