### PR TITLE
Fix stack overflow in RegistryKeyWrapper

### DIFF
--- a/src/XMakeBuildEngine/Utilities/RegistryKeyWrapper.cs
+++ b/src/XMakeBuildEngine/Utilities/RegistryKeyWrapper.cs
@@ -226,6 +226,7 @@ namespace Microsoft.Build.Internal
                         if (ExceptionHandling.NotExpectedRegistryException(ex))
                             throw;
 
+                        _attemptedToOpenRegistryKey = true;
                         throw new RegistryException(ex.Message, Name, ex);
                     }
                     finally


### PR DESCRIPTION
If OpenSubKey() fails in the WrappedKey property, a RegistryException
is thrown. This exception is created using the value of Name as
argument, but the Name getter will end making another attempt to
open the registry key, which causes and infinite loop and a stack
overflow. The solution is to set the _attemptedToOpenRegistryKey
flag before trying to get the Name.