### PR TITLE
Fix NuGet restore

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -24,6 +24,7 @@
     <NugetRestoreCommand>$(NugetRestoreCommand) install</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) -OutputDirectory "$(PackagesDir.TrimEnd('\/'.ToCharArray()))"</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) $(NuGetConfigCommandLine)</NugetRestoreCommand>
+    <NugetRestoreCommand Condition="'$(OS)' != 'Windows_NT'">mono $(NuGetRestoreCommand)</NugetRestoreCommand>
   </PropertyGroup>
   
   <!-- Set default Configuration and Platform -->

--- a/dir.props
+++ b/dir.props
@@ -15,6 +15,7 @@
 
   <!-- Common nuget properties -->
   <PropertyGroup>
+    <NuGetDir>$(PackagesDir)</NuGetDir>
     <NuGetToolPath>$(PackagesDir)NuGet.exe</NuGetToolPath>
     <NuGetConfigFile>$(SourceDir).nuget$([System.IO.Path]::DirectorySeparatorChar)NuGet.Config</NuGetConfigFile>
     <NuGetConfigCommandLine>-ConfigFile "$(NuGetConfigFile)"</NuGetConfigCommandLine>

--- a/dir.targets
+++ b/dir.targets
@@ -44,19 +44,39 @@
   <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
 
   <Target Name="_RestoreBuildTools"
+          Condition="'$(OS)' == 'Windows_NT'"
           Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
           Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
 
-    <!-- Download latest nuget.exe -->
     <DownloadFile FileName="$(NuGetToolPath)"
                   Address="http://nuget.org/nuget.exe" 
-                  Condition="!Exists('$(NuGetToolPath)')" />
+                  Condition="'$(OS)' == 'Windows_NT' AND !Exists('$(NuGetToolPath)')" />
 
     <!-- Restore build tools -->
     <!-- 
     <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" StandardOutputImportance="Low" />
     -->    
     <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" />
+    <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
+           Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
+  </Target>
+
+  <Target Name="_RestoreBuildTools"
+          Condition="'$(OS)' != 'Windows_NT'"
+          Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
+          Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
+
+    <MakeDir Directories="$(NuGetDir)" Condition="!Exists('$(NuGetDir)')" />
+
+    <Exec Command="curl -s -o $(NuGetToolPath) https://api.nuget.org/downloads/nuget.exe" Condition="!Exists('$(NuGetToolPath)')" />
+
+    <Exec Command="chmod +x $(NuGetToolPath)" />
+
+    <!-- Restore build tools -->
+    <!-- 
+    <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" StandardOutputImportance="Low" />
+    -->    
+    <Exec Command="mono $(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" />
     <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
   </Target>

--- a/dir.targets
+++ b/dir.targets
@@ -44,39 +44,20 @@
   <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
 
   <Target Name="_RestoreBuildTools"
-          Condition="'$(OS)' == 'Windows_NT'"
           Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
           Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
 
     <DownloadFile FileName="$(NuGetToolPath)"
                   Address="http://nuget.org/nuget.exe" 
-                  Condition="!Exists('$(NuGetToolPath)')" />
+                  Condition="!Exists('$(NuGetToolPath)') AND '$(OS)' == 'Windows_NT'" />
+
+    <Exec Command="curl -sSL --create-dirs -s -o $(NuGetToolPath) https://api.nuget.org/downloads/nuget.exe" Condition="!Exists('$(NuGetToolPath)') AND '$(OS)' != 'Windows_NT'" />
 
     <!-- Restore build tools -->
     <!-- 
     <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" StandardOutputImportance="Low" />
     -->    
     <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" />
-    <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
-           Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
-  </Target>
-
-  <Target Name="_RestoreBuildTools"
-          Condition="'$(OS)' != 'Windows_NT'"
-          Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
-          Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
-
-    <MakeDir Directories="$(NuGetDir)" Condition="!Exists('$(NuGetDir)')" />
-
-    <Exec Command="curl -s -o $(NuGetToolPath) https://api.nuget.org/downloads/nuget.exe" Condition="!Exists('$(NuGetToolPath)')" />
-
-    <Exec Command="chmod +x $(NuGetToolPath)" />
-
-    <!-- Restore build tools -->
-    <!-- 
-    <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" StandardOutputImportance="Low" />
-    -->    
-    <Exec Command="mono $(NugetRestoreCommand) &quot;$(SourceDir).nuget/packages.config&quot;" />
     <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
   </Target>

--- a/dir.targets
+++ b/dir.targets
@@ -50,7 +50,7 @@
 
     <DownloadFile FileName="$(NuGetToolPath)"
                   Address="http://nuget.org/nuget.exe" 
-                  Condition="'$(OS)' == 'Windows_NT' AND !Exists('$(NuGetToolPath)')" />
+                  Condition="!Exists('$(NuGetToolPath)')" />
 
     <!-- Restore build tools -->
     <!-- 


### PR DESCRIPTION
The targets files bootstrap NuGet.exe by downloading it on demand using
inline C# code via CodeTaskFactory.  This is not supported on xbuild
hence a build on a fresh enlistment will fail.

This change fixes that by using curl to bootstrap NuGet.exe in a
non-windows environment.