### PR TITLE
Fix Mono crash when getting the MSBuild version

### DIFF
--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -381,7 +381,8 @@ namespace Microsoft.Build.Evaluation
                     // Use .CodeBase instead of .Location, because .Location doesn't
                     // work when Microsoft.Build.dll has been shadow-copied, for example
                     // in scenarios where NUnit is loading Microsoft.Build.
-                    s_engineVersion = new Version(FileVersionInfo.GetVersionInfo(FileUtilities.ExecutingAssemblyPath).ProductVersion);
+                    var versionInfo = FileVersionInfo.GetVersionInfo(FileUtilities.ExecutingAssemblyPath);
+                    s_engineVersion = new Version (versionInfo.ProductMajorPart, versionInfo.ProductMinorPart, versionInfo.ProductBuildPart, versionInfo.ProductPrivatePart);
                 }
 
                 return s_engineVersion;


### PR DESCRIPTION
The implementation of GetVersionInfo() in Mono doesn't set the ProductVersion property, so ProjectCollection.Version crashes when trying to construct the Version object from an empty string.

As a workaround, the Version object can be created using the individual components of the product version, which are properly filled by Mono. That's also more efficient that relying on string version parsing.