### PR TITLE
Prevent TypeLoadExcpetion

### DIFF
--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -653,6 +653,7 @@
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <!-- If TargetRetailBuildFramework is set to true, reference the public key version. Otherwise reference the project. -->
     <Reference Condition=" '$(TargetRetailBuildFramework)' == 'true' " Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />


### PR DESCRIPTION
Fixes #48 

As I mentioned in the issue notes, I don't know if this is the *right* solution for this project, but here's a pull request that causes the TPL data flow assembly to be copied to the bin folder.