### PR TITLE
Copy .mdb files 

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -348,7 +348,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <ItemGroup Condition="'$(_DebugSymbolsProduced)' == 'true'">
     <_DebugSymbolsIntermediatePath Include="$(IntermediateOutputPath)$(TargetName).compile.pdb" Condition="'$(OutputType)' == 'winmdobj' and '@(_DebugSymbolsIntermediatePath)' == ''"/>
-    <_DebugSymbolsIntermediatePath Include="$(IntermediateOutputPath)$(TargetName).pdb" Condition="'$(OutputType)' != 'winmdobj' and '@(_DebugSymbolsIntermediatePath)' == ''"/>
+    <_DebugSymbolsIntermediatePathPDB Include="$(IntermediateOutputPath)$(TargetName).pdb" Condition="'$(OutputType)' != 'winmdobj' and '@(_DebugSymbolsIntermediatePath)' == ''"/>
+    <_DebugSymbolsIntermediatePathMDB Include="$(IntermediateOutputPath)$(TargetName)$(TargetExt).mdb" Condition="'$(OS)' != 'Windows_NT' and '$(OutputType)' != 'winmdobj' and '@(_DebugSymbolsIntermediatePath)' == ''"/>
+    <_DebugSymbolsIntermediatePath Include="@(_DebugSymbolsIntermediatePathPDB);@(_DebugSymbolsIntermediatePathMDB)" Condition="'$(OutputType)' != 'winmdobj' and '@(_DebugSymbolsIntermediatePath)' == ''"/>
     <_DebugSymbolsOutputPath Include="@(_DebugSymbolsIntermediatePath->'$(OutDir)%(Filename)%(Extension)')" />
   </ItemGroup>
 
@@ -569,6 +571,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         -->
     <AllowedReferenceRelatedFileExtensions Condition=" '$(AllowedReferenceRelatedFileExtensions)' == '' ">
       .pdb;
+      .mdb;
       .xml;
       .pri
     </AllowedReferenceRelatedFileExtensions>
@@ -2875,6 +2878,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       BeforeCompile;
       _TimeStampBeforeCompile;
       CoreCompile;
+      _CheckOutputFiles;
       _TimeStampAfterCompile;
       AfterCompile;
     </CompileDependsOn>
@@ -3044,6 +3048,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_AssemblyTimestampAfterCompile>%(IntermediateAssembly.ModifiedTime)</_AssemblyTimestampAfterCompile>
     </PropertyGroup>
 
+  </Target>
+
+  <!--
+    ============================================================
+                                        _CheckOutputFiles
+
+    Update the list of output files.
+    ============================================================
+    -->
+  <Target Name="_CheckOutputFiles" Condition="'@(_DebugSymbolsIntermediatePathPDB)' != '' or '@(_DebugSymbolsIntermediatePathMDB)' != ''">
+    <ItemGroup Condition="'$(_DebugSymbolsProduced)' == 'true'">
+      <_DebugSymbolsIntermediatePath Remove="@(_DebugSymbolsIntermediatePath)" Condition="!Exists(%(_DebugSymbolsIntermediatePath.FullPath))"/>
+      <_DebugSymbolsOutputPath Remove="@(_DebugSymbolsOutputPath)" />
+      <_DebugSymbolsOutputPath Include="@(_DebugSymbolsIntermediatePath->'$(OutDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
   </Target>
 
   <!--
@@ -4211,12 +4230,25 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Record the .pdb if one was produced. -->
     <PropertyGroup>
-      <_DebugSymbolsProduced Condition="!Exists('@(_DebugSymbolsIntermediatePath)')">false</_DebugSymbolsProduced>
+      <_DebugSymbolsProducedPDB Condition="!Exists('@(_DebugSymbolsIntermediatePathPDB)')">false</_DebugSymbolsProducedPDB>
     </PropertyGroup>
 
     <ItemGroup>
-      <FileWrites Include="@(_DebugSymbolsIntermediatePath)" Condition="'$(_DebugSymbolsProduced)'=='true'"/>
+      <FileWrites Include="@(_DebugSymbolsIntermediatePathPDB)" Condition="'$(_DebugSymbolsProducedPDB)'!='false'"/>
     </ItemGroup>
+    
+    <!-- Record the .mdb if one was produced. -->
+    <PropertyGroup>
+      <_DebugSymbolsProducedMDB Condition="!Exists('@(_DebugSymbolsIntermediatePathMDB)')">false</_DebugSymbolsProducedMDB>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <FileWrites Include="@(_DebugSymbolsIntermediatePathMDB)" Condition="'$(_DebugSymbolsProducedMDB)'!='false'"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_DebugSymbolsProduced Condition="'$(_DebugSymbolsProducedPDB)' == 'false' and '$(_DebugSymbolsProducedMDB)' == 'false'">false</_DebugSymbolsProduced>
+    </PropertyGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
Copy .mdb files when they are generated by the compiler instead of .pdb files.