### PR TITLE
XPlat compatibility changes

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
@@ -391,6 +392,11 @@ namespace Microsoft.Build.Shared
         private static string s_frameworkCurrentPath;
 
         /// <summary>
+        /// The regex for matching Mono framework paths
+        /// </summary>
+        private static Regex s_frameworkPathRegex;
+
+        /// <summary>
         /// Gets the currently running framework path
         /// </summary>
         internal static string FrameworkCurrentPath
@@ -428,6 +434,62 @@ namespace Microsoft.Build.Shared
 
                 return s_frameworkBasePath;
             }
+        }
+
+        /// <summary>
+        ///  Regex for framework paths under MONO
+        /// </summary>
+        internal static Regex FrameworkPathRegex
+        {
+            get
+            {
+                return s_frameworkPathRegex
+                       ?? (s_frameworkPathRegex =
+                           new Regex(FrameworkBasePath + @"/(?:xbuild/)?v?(\d+)\.(\d+)(?:[.\d]*/?)?(.*)?"));
+            }
+        }
+
+        /// <summary>
+        ///  Check if the path is in the framework path on Unix/Mono.
+        ///  Verify that the path in one of the version directory.
+        /// </summary>
+        internal static string FixFrameworkPath(string path)
+        {
+            // Only valid for Linux/Mono
+            if (!IsUnix || !IsMono)
+            {
+                return null;
+            }
+
+            // Check if this is a framework path in the version
+            // directory.
+            Match m = FrameworkPathRegex.Match(path);
+            if (!m.Success || m.Groups.Count <= 1 ||
+                string.IsNullOrEmpty(m.Groups[1].Value) ||
+                string.IsNullOrEmpty(m.Groups[2].Value))
+            {
+                return null;
+            }
+
+            // We matched. We only care about the 2nd and 3rd captures, which tells us
+            // us the version number.
+            int majorVersion;
+            if (!int.TryParse(m.Groups[1].Value, out majorVersion)) {
+                return null;
+            }
+
+            // Based on the version directory, find the correct path.
+            string root = majorVersion > 4 ?
+                Path.Combine(
+                              FrameworkBasePath,
+                              "xbuild",
+                              m.Groups[1].Value + '.' + m.Groups[2].Value,
+                              "bin") :
+                Path.Combine(
+                              FrameworkBasePath,
+                              m.Groups[1].Value + '.' + m.Groups[2].Value);
+            string lastChar = path.EndsWith("/") ? "/" : "";
+            return string.IsNullOrEmpty(m.Groups[3].Value) ? root + lastChar : Path.Combine(root, m.Groups[3].Value);
         }
 
         #endregion

--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -1308,6 +1308,7 @@ namespace Microsoft.Build.Evaluation
             if (!NativeMethodsShared.IsWindows)
             {
                 builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.osName, NativeMethodsShared.OSName));
+                builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.frameworkToolsRoot,  NativeMethodsShared.FrameworkBasePath));
             }
 
             if (String.IsNullOrEmpty(_projectRootElement.FullPath))

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -253,6 +253,7 @@ namespace Microsoft.Build.Evaluation
             string result = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options);
             result = PropertyExpander<P>.ExpandPropertiesLeaveEscaped(result, _properties, options, elementLocation, _usedUninitializedProperties);
             result = ItemExpander.ExpandItemVectorsIntoString<I>(this, result, _items, options, elementLocation);
+            result = FileUtilities.MaybeAdjustFilePath(result);
 
             return result;
         }
@@ -320,6 +321,7 @@ namespace Microsoft.Build.Evaluation
 
             expression = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options);
             expression = PropertyExpander<P>.ExpandPropertiesLeaveEscaped(expression, _properties, options, elementLocation, _usedUninitializedProperties);
+            expression = FileUtilities.MaybeAdjustFilePath(expression);
 
             List<T> result = new List<T>();
 
@@ -1017,7 +1019,7 @@ namespace Microsoft.Build.Evaluation
                 // If we have only a single result, then just return it
                 if (results == null && expression.Length == sourceIndex)
                 {
-                    return lastResult;
+                    return lastResult == null ? null : FileUtilities.MaybeAdjustFilePath(lastResult.ToString());
                 }
                 else
                 {
@@ -1042,14 +1044,14 @@ namespace Microsoft.Build.Evaluation
                             // Create a combined result string from the result components that we've gathered
                             foreach (object component in results)
                             {
-                                result.Append(component.ToString());
+                                result.Append(FileUtilities.MaybeAdjustFilePath(component.ToString()));
                             }
                         }
 
                         // Append the last result we collected (it wasn't added to the list)
                         if (lastResult != null)
                         {
-                            result.Append(lastResult.ToString());
+                            result.Append(FileUtilities.MaybeAdjustFilePath(lastResult.ToString()));
                         }
 
                         // And if we couldn't find anymore property tags in the expression,

--- a/src/XMakeBuildEngine/Instance/ProjectInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectInstance.cs
@@ -2240,11 +2240,6 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-            if (NativeMethodsShared.IsUnixLike && !_globalProperties.Contains("MSBuildFrameworkToolsRoot"))
-            {
-                _globalProperties.Set(ProjectPropertyInstance.Create("MSBuildFrameworkToolsRoot", NativeMethodsShared.FrameworkBasePath, false));
-            }
-
             if (Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.DebugEvaluation)
             {
                 Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Creating a ProjectInstance from an unevaluated state [{0}]", FullPath));

--- a/src/XMakeBuildEngine/Resources/Constants.cs
+++ b/src/XMakeBuildEngine/Resources/Constants.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Build.Internal
         internal const string localAppData = "LocalAppData";
         internal const string assemblyVersion = "MSBuildAssemblyVersion";
         internal const string osName = "OS";
+        internal const string frameworkToolsRoot = "MSBuildFrameworkToolsRoot";
 
         /// <summary>
         /// Lookup for reserved property names

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -38,11 +38,5 @@
       <toolset toolsVersion="14.1">
         <property name="MSBuildToolsPath" value="." />
       </toolset>
-      <toolset toolsVersion="12.0">
-        <property name="MSBuildToolsPath" value="." />
-      </toolset>
-      <toolset toolsVersion="4.0">
-        <property name="MSBuildToolsPath" value="." />
-      </toolset>
     </msbuildToolsets>
   </configuration>


### PR DESCRIPTION
Fix slashes on Unix & Mac in properties that look like paths. If the
path points at the Mono framework directory, fix it up based on the
framework version.

Add some of the standard properties associated with toolsets. These
are normally found in the registry, but for Mono they are easy to
deduce.