### PR TITLE
Fixes #62 allows blank lines in solution configuration

### DIFF
--- a/src/XMakeBuildEngine/Construction/Solution/SolutionFile.cs
+++ b/src/XMakeBuildEngine/Construction/Solution/SolutionFile.cs
@@ -1318,6 +1318,11 @@ namespace Microsoft.Build.Construction
                     break;
                 }
 
+                if (String.IsNullOrWhiteSpace(str))
+                {
+                    continue;
+                }
+
                 Match match = s_crackPropertyLine.Match(str);
                 ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile(match.Success, "SubCategoryForSolutionParsingErrors",
                     new BuildEventFileInfo(FullPath, _currentLineNumber, 0), "SolutionParseNestedProjectError");
@@ -1360,6 +1365,11 @@ namespace Microsoft.Build.Construction
                 if ((str == null) || (str == "EndGlobalSection"))
                 {
                     break;
+                }
+
+                if (String.IsNullOrWhiteSpace(str))
+                {
+                    continue;
                 }
 
                 string[] configurationNames = str.Split(nameValueSeparators);
@@ -1419,6 +1429,11 @@ namespace Microsoft.Build.Construction
                 if ((str == null) || (str == "EndGlobalSection"))
                 {
                     break;
+                }
+
+                if (String.IsNullOrWhiteSpace(str))
+                {
+                    continue;
                 }
 
                 string[] nameValue = str.Split(new char[] { '=' });

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
@@ -945,6 +945,79 @@ namespace Microsoft.Build.UnitTests.Construction
         }
 
         /// <summary>
+        /// Parses solution configuration file that contains empty or whitespace lines
+        /// to simulate a possible source control merge scenario.
+        /// </summary>
+        [TestMethod]
+        public void ParseSolutionConfigurationWithEmptyLines()
+        {
+            string solutionFileContents =
+                @"
+                Microsoft Visual Studio Solution File, Format Version 9.00
+                # Visual Studio 2005
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'ClassLibrary1\ClassLibrary1.csproj', '{34E0D07D-CF8F-459D-9449-C4188D8C5564}'
+                EndProject
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'MySlnFolder', 'MySlnFolder', '{E0F97730-25D2-418A-A7BD-02CAFDC6E470}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary1', 'MyPhysicalFolder\ClassLibrary1\ClassLibrary1.csproj', '{A5EE8128-B08E-4533-86C5-E46714981680}'
+                EndProject
+                Project('{2150E333-8FDC-42A3-9474-1A3956D46DE8}') = 'MySubSlnFolder', 'MySubSlnFolder', '{2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}'
+                EndProject
+                Project('{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}') = 'ClassLibrary2', 'ClassLibrary2\ClassLibrary2.csproj', '{6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}'
+                EndProject
+                Global
+                    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+
+                        Debug|Any CPU = Debug|Any CPU
+                        
+                        Release|Any CPU = Release|Any CPU
+ 
+    
+                    EndGlobalSection
+                    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {34E0D07D-CF8F-459D-9449-C4188D8C5564}.Release|Any CPU.Build.0 = Release|Any CPU
+ 
+  
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {A5EE8128-B08E-4533-86C5-E46714981680}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4}.Release|Any CPU.Build.0 = Release|Any CPU
+    
+                    EndGlobalSection
+                    GlobalSection(SolutionProperties) = preSolution
+                        HideSolutionNode = FALSE
+                    EndGlobalSection
+                    GlobalSection(NestedProjects) = preSolution
+                        
+                        {A5EE8128-B08E-4533-86C5-E46714981680} = {E0F97730-25D2-418A-A7BD-02CAFDC6E470}
+                        {2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B} = {E0F97730-25D2-418A-A7BD-02CAFDC6E470}
+                        {6DB98C35-FDCC-4818-B5D4-1F0A385FDFD4} = {2AE8D6C4-FB43-430C-8AEB-15E5EEDAAE4B}
+                        
+
+                    EndGlobalSection
+                EndGlobal
+                ";
+
+            try
+            {
+                SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+            }
+            catch (InvalidProjectFileException ex)
+            {
+                Assert.Fail();
+            }
+        }
+
+        /// <summary>
         /// Tests situation where there's a nonexistent project listed in the solution folders.  We should 
         /// error with a useful message. 
         /// </summary>


### PR DESCRIPTION
Fixes #62 allows empty lines in solution configuration to simulate a
scenario of source control merges that end up creating empty lines in
the following sections:
- SolutionConfigurationPlatforms
- SolutionProperties
- NestedProjects

Visual Studio can open solutions like these, and so should MSBuild.