### PR TITLE
Allow building with Roslyn compilers

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,6 +2,12 @@
    <PropertyGroup>
      <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
    </PropertyGroup>
+
+   <!-- Compiler config -->
+   <PropertyGroup>
+     <UseRoslynCompilers>true</UseRoslynCompilers>
+     <DebugSymbols Condition="'$(UseRoslynCompilers)' == 'true'">false</DebugSymbols>
+  </PropertyGroup>
    
    <!-- Common repo directories -->
   <PropertyGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -47,6 +47,20 @@
     <Message Importance="High" Text="Build binary target directory: '$(BaseOutputPathWithConfig)'" />
   </Target>
 
+  <Target Name="_CopyCompilers" AfterTargets="_RestoreBuildTools" Condition="'$(UseRoslynCompilers)' == 'true'">
+    <ItemGroup>
+      <BuildFiles Include="$(PackagesDir)Microsoft.Net.ToolsetCompilers*\build\*" />
+      <ToolsFiles Include="$(PackagesDir)Microsoft.Net.ToolsetCompilers*\tools\*" />
+    </ItemGroup>
+    
+    <Copy
+      SourceFiles="@(BuildFiles);@(ToolsFiles)"
+      DestinationFolder="$(OutputPath)tools"
+      SkipUnchangedFiles="true"
+    />
+    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="find '$(OutputPath)tools' -name &quot;*.exe&quot; -exec chmod &quot;+x&quot; '{}' ';'" />
+  </Target>
+
   <Target Name="_RestoreBuildTools"
           Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
           Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc2-20150415-05" targetFramework="net451" userInstalled="true" />
 </packages>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -5490,5 +5490,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportByWildcardAfterMicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter')"/>
   <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\*" Condition="'$(ImportUserLocationsByWildcardAfterMicrosoftCommonTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter')"/>
+  <Import Project="$(MSBuildToolsPath)\tools\*.props" />
 
 </Project>


### PR DESCRIPTION
Add a dependency on the Roslyn compilers NuGet. Copy binaries to the output
directory and load props file that overrides the compiler tasks parameter so
that they use the new compilers (controled by a property).