### PR TITLE
#71 Improved exception handling in SecurityUtilities.SignFile

### DIFF
--- a/src/XMakeTasks/ManifestUtil/SecurityUtil.cs
+++ b/src/XMakeTasks/ManifestUtil/SecurityUtil.cs
@@ -654,6 +654,9 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
             else
             {
+                if (cert.PrivateKey == null)
+                    throw new InvalidOperationException(resources.GetString("SignFile.CertMissingPrivateKey"));
+
                 if (cert.PrivateKey.GetType() != typeof(RSACryptoServiceProvider))
                     throw new ApplicationException(resources.GetString("SecurityUtil.OnlyRSACertsAreAllowed"));
                 try

--- a/src/XMakeTasks/Strings.resx
+++ b/src/XMakeTasks/Strings.resx
@@ -1938,6 +1938,10 @@
     <value>MSB3484: Signing target '{0}' could not be found.</value>
     <comment>{StrBegin="MSB3484: "}</comment>
   </data>
+  <data name="SignFile.CertMissingPrivateKey">
+    <value>MSB3487: The signing certificate does not include private key information.</value>
+    <comment>{StrBegin="MSB3487: "}</comment>
+  </data>
   <!--
         The StrongNameUtils message bucket is: MSB3351 - MSB3360
 


### PR DESCRIPTION
#71 Improved exception handling in _SecurityUtilities.SignFile_.
A specific check is now performed for a _null_ value in the _PrivateKey_ property.
The message prefix chosen here, `MSB3487`, may appear to have skipped two at first glance - this is intentional, based on the following comment in _Strings.resx_:
`// MSB3485 MSB3486 not used but already shipped, do not reuse`