### PR TITLE
Fix shebang in build.pl and set execute flag

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -1,4 +1,4 @@
-# !/usr/bin/perl
+#!/usr/bin/perl
 
 use strict;
 use Getopt::Long;


### PR DESCRIPTION
There was a space in the shebang of build.pl, making it fail when invoked with ./build.pl
Also set the execute permission on the file in git so it works automatically after cloning.