### PR TITLE
Metaprojects should relay outputs

### DIFF
--- a/src/XMakeBuildEngine/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/XMakeBuildEngine/Construction/Solution/SolutionProjectGenerator.cs
@@ -1136,7 +1136,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private void AddMetaprojectTargetForManagedProject(ProjectInstance traversalProject, ProjectInstance metaprojectInstance, ProjectInSolution project, ProjectConfigurationInSolution projectConfiguration, string targetName, string outputItem)
         {
-            ProjectTargetInstance target = metaprojectInstance.AddTarget(targetName ?? "Build", String.Empty, String.Empty, String.Empty, null, String.Empty, String.Empty, false /* legacy target returns behaviour */);
+            string outputItemAsItem = null;
+            if (!String.IsNullOrEmpty(outputItem))
+            {
+                outputItemAsItem = "@(" + outputItem + ")";
+            }
+
+            ProjectTargetInstance target = metaprojectInstance.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, false /* legacy target returns behaviour */);
 
             AddReferencesBuildTask(metaprojectInstance, target, targetName, outputItem);
 


### PR DESCRIPTION
As identified in issue #69, there's a somewhat-rare corner case where the `TargetOutputs` of an `MSBuild` invocation does not contain the expected output.  Most of the juicy details are there.

The `SolutionConfigurationWithDependenciesRelaysItsOutputs` test was added based on the original repro case of the associated [Connect report](https://connect.microsoft.com/VisualStudio/feedback/details/1176406/msbuild-targetoutputs-does-not-include-projects-with-explicit-project-dependencies-listed) and then fixed.

It would be fabulous if this fix could also be back-ported to MSBuild 12.0 (or even 4.0), as that's where the issue was originally discovered.