### PR TITLE
Adding XmlFileLogger project to the Samples folder.

### DIFF
--- a/Samples/RebuildWithXmlLog.cmd
+++ b/Samples/RebuildWithXmlLog.cmd
@@ -1,0 +1,20 @@
+:: Simple script to build the XmlFileLogger project and then build again with the
+:: XML logging enabled. Writes to buildlog.xml.
+@echo off
+setlocal
+set DebugBuildOutputPath=%~dp0..\bin\Samples\Debug\XmlFileLogger
+set TempBinPath=%~dp0..\bin\XmlFileLogger
+set ProjectToBuild=%~dp0\XmlFileLogger\XmlFileLogger.csproj
+
+echo Building source
+MSBuild.exe "%ProjectToBuild%" /v:Minimal /nologo
+echo.
+
+echo ROBOCOPY %DebugBuildOutputPath% -^> %TempBinPath%
+robocopy "%DebugBuildOutputPath%" "%TempBinPath%" *.* /S /NFL /NDL /NJH /NJS /nc /ns /np
+echo.
+
+echo Rebuilding sources with XmlFileLogger enabled (no ouput).
+MSBuild.exe "%ProjectToBuild%" /verbosity:diagnostic /logger:XmlFileLogger,%TempBinPath%\XmlFileLogger.dll;%~dp0buildlog.xml /t:Rebuild>nul
+echo MSBuild.exe returned exit code %errorlevel%
+echo See buildlog.xml for XML log file.

--- a/Samples/XmlFileLogger/ILogNode.cs
+++ b/Samples/XmlFileLogger/ILogNode.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Interface class for an execution MSBuild log node to be represented in XML
+    /// </summary>
+    internal interface ILogNode
+    {
+        /// <summary>
+        /// Writes the node to XML XElement representation.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        void SaveToElement(XElement parentElement);
+    }
+}

--- a/Samples/XmlFileLogger/ItemGroupParser.cs
+++ b/Samples/XmlFileLogger/ItemGroupParser.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    internal static class ItemGroupParser
+    {
+        /// <summary>
+        /// Parses a log output string to a list of Items (e.g. ItemGroup with metadata or property string).
+        /// </summary>
+        /// <param name="message">The message output from the logger.</param>
+        /// <param name="prefix">The prefix parsed out (e.g. 'Output Item(s): '.).</param>
+        /// <param name="name">Out: The name of the list.</param>
+        /// <returns>List of items within the list and all metadata.</returns>
+        public static IList<Item> ParseItemList(string message, string prefix, out string name)
+        {
+            name = null;
+
+            var items = new List<Item>();
+            var lines = message.Split('\n');
+
+            if (lines.Length == 1)
+            {
+                var line = lines[0];
+                line = line.Substring(prefix.Length);
+                var nameValue = ParseNameValue(line);
+                name = nameValue.Key;
+                items.Add(new Item(nameValue.Value));
+                return items;
+            }
+
+            if (lines[0].Length > prefix.Length)
+            {
+                // we have a weird case of multi-line value
+                var nameValue = ParseNameValue(lines[0].Substring(prefix.Length));
+                name = nameValue.Key;
+
+                items.Add(new Item(nameValue.Value.Replace("\r", "")));
+                for (int i = 1; i < lines.Length; i++)
+                {
+                    items.Add(new Item(lines[i].Replace("\r", "")));
+                }
+
+                return items;
+            }
+
+            Item currentItem = null;
+            foreach (var line in lines)
+            {
+                switch (GetNumberOfLeadingSpaces(line))
+                {
+                    case 4:
+                        if (line.EndsWith("=", StringComparison.Ordinal))
+                        {
+                            name = line.Substring(4, line.Length - 5);
+                        }
+                        break;
+                    case 8:
+                        currentItem = new Item(line.Substring(8));
+                        items.Add(currentItem);
+                        break;
+                    case 16:
+                        if (currentItem != null)
+                        {
+                            var nameValue = ParseNameValue(line.Substring(16));
+                            currentItem.AddMetadata(nameValue.Key, nameValue.Value);
+                        }
+                        break;
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// Parse a string for a name value pair (name=value).
+        /// </summary>
+        /// <param name="nameEqualsValue">The (name = value) string to parse.</param>
+        /// <returns>KeyValuePair name and value</returns>
+        private static KeyValuePair<string, string> ParseNameValue(string nameEqualsValue)
+        {
+            var equals = nameEqualsValue.IndexOf('=');
+            var name = nameEqualsValue.Substring(0, equals);
+            var value = nameEqualsValue.Substring(equals + 1);
+            return new KeyValuePair<string, string>(name, value);
+        }
+
+        /// <summary>
+        /// Gets the number of leading spaces from a string
+        /// </summary>
+        /// <param name="line">The string.</param>
+        /// <returns>Number of spaces in the beginning of the string.</returns>
+        private static int GetNumberOfLeadingSpaces(string line)
+        {
+            int result = 0;
+            while (result < line.Length && line[result] == ' ')
+            {
+                result++;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Samples/XmlFileLogger/LogProcessNode.cs
+++ b/Samples/XmlFileLogger/LogProcessNode.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Base class to represent a log node (e.g. Project, or Target) that can contain child node sub nodes 
+    /// and properties defined at that scope. Properties defined will be inherited from the parent if possible.
+    /// </summary>
+    internal abstract class LogProcessNode : ILogNode
+    {
+        /// <summary>
+        /// The child nodes bucketed by their type. This is for performance iterating through the list by
+        /// type as well as to preserve order within the types (List will preserve order).
+        /// </summary>
+        private readonly Dictionary<Type, List<ILogNode>> _childNodes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogProcessNode"/> class.
+        /// </summary>
+        protected LogProcessNode()
+        {
+            Properties = new PropertyBag();
+            _childNodes = new Dictionary<Type, List<ILogNode>>();
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the node (e.g. name of the project).
+        /// </summary>
+        /// <value>
+        /// The name of the node.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the node.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
+        public int Id { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the time at which MSBuild indicated the node started execution.
+        /// </summary>
+        /// <value>
+        /// The start time.
+        /// </value>
+        public DateTime StartTime { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the time at which MSBuild indicated the node completed execution.
+        /// </summary>
+        /// <value>
+        /// The end time.
+        /// </value>
+        public DateTime EndTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the properties collection for this node.
+        /// </summary>
+        /// <value>
+        /// The properties.
+        /// </value>
+        public PropertyBag Properties { get; protected set; }
+
+        /// <summary>
+        /// Writes the node to XML XElement representation.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        public abstract void SaveToElement(XElement parentElement);
+
+        /// <summary>
+        /// Adds a generic message type child to the node.
+        /// </summary>
+        /// <param name="message">The message node to add.</param>
+        public void AddMessage(Message message)
+        {
+            AddChildNode(message);
+        }
+
+        /// <summary>
+        /// Adds the child node.
+        /// </summary>
+        /// <typeparam name="T">Generic ILogNode type to add</typeparam>
+        /// <param name="childNode">The child node.</param>
+        protected void AddChildNode<T>(T childNode) where T : ILogNode
+        {
+            var type = childNode.GetType();
+
+            if (_childNodes.ContainsKey(type))
+            {
+                _childNodes[type].Add(childNode);
+            }
+            else
+            {
+                _childNodes[type] = new List<ILogNode> { childNode };
+            }
+        }
+
+        /// <summary>
+        /// Gets the child nodes that are of type T.
+        /// </summary>
+        /// <remarks>Must be exactly of type T, not inherited</remarks>
+        /// <typeparam name="T">Generic ILogNode type</typeparam>
+        /// <returns></returns>
+        protected IEnumerable<T> GetChildrenOfType<T>() where T : ILogNode
+        {
+            var t = typeof(T);
+            return _childNodes.ContainsKey(t) ? _childNodes[t].Cast<T>() : new List<T>();
+        }
+
+        /// <summary>
+        /// Writes the properties associated with this node to the XML element.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        protected void WriteProperties(XElement parentElement)
+        {
+            if (Properties.Properties.Count > 0)
+            {
+                var propElement = new XElement("Properties");
+                foreach (var p in Properties.Properties)
+                {
+                    propElement.Add(new XElement("Property", new XAttribute("Name", p.Key)) { Value = p.Value });
+                }
+
+                parentElement.Add(propElement);
+            }
+        }
+
+        /// <summary>
+        /// Writes the children of type T to the XML element.
+        /// </summary>
+        /// <typeparam name="T">Generic ILogNode type</typeparam>
+        /// <param name="parentElement">The root.</param>
+        protected void WriteChildren<T>(XElement parentElement) where T : ILogNode
+        {
+            foreach (var child in GetChildrenOfType<T>())
+            {
+                child.SaveToElement(parentElement);
+            }
+        }
+
+        /// <summary>
+        /// Writes the children of type T to the XML element and creates a root node if necessary.
+        /// </summary>
+        /// <typeparam name="T">Generic ILogNode type</typeparam>
+        /// <param name="parentElement">The parent element.</param>
+        /// <param name="subNodeFactory">Delegate to create a new element to contain children. Will not be called if 
+        /// there are no children of the specified type.</param>
+        protected void WriteChildren<T>(XElement parentElement, Func<XElement> subNodeFactory) where T : ILogNode
+        {
+            if (GetChildrenOfType<T>().Any())
+            {
+                var node = subNodeFactory();
+                WriteChildren<T>(node);
+                parentElement.Add(node);
+            }
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/Build.cs
+++ b/Samples/XmlFileLogger/ObjectModel/Build.cs
@@ -1,0 +1,282 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of an MSBuild overall build execution.
+    /// </summary>
+    internal class Build : LogProcessNode
+    {
+        /// <summary>
+        /// A lookup table mapping of project identifiers to project nodes (which can be nested multiple layers). 
+        /// </summary>
+        private readonly ConcurrentDictionary<int, Project> _projectIdToProjectMap = new ConcurrentDictionary<int, Project>();
+
+        /// <summary>
+        /// A mapping of task names to assembly locations.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, string> _taskToAssemblyMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Build"/> class.
+        /// </summary>
+        /// <param name="buildStartedEventArgs">The <see cref="BuildStartedEventArgs"/> instance containing the event data.</param>
+        public Build(BuildStartedEventArgs buildStartedEventArgs)
+        {
+            StartTime = buildStartedEventArgs.Timestamp;
+            Properties = new PropertyBag(buildStartedEventArgs.BuildEnvironment);
+        }
+
+        /// <summary>
+        /// Completes the build and writes to the XML log file.
+        /// </summary>
+        /// <param name="buildFinishedEventArgs">The <see cref="BuildFinishedEventArgs"/> instance containing the event data.</param>
+        /// <param name="logFile">The XML log file.</param>
+        public void CompleteBuild(BuildFinishedEventArgs buildFinishedEventArgs, string logFile, int errorCount, int warningCount)
+        {
+            EndTime = buildFinishedEventArgs.Timestamp;
+            var document = new XDocument();
+            var root = new XElement("Build",
+                new XAttribute("BuildSucceeded", buildFinishedEventArgs.Succeeded),
+                new XAttribute("StartTime", StartTime),
+                new XAttribute("EndTime", EndTime),
+                new XAttribute("Errors", errorCount),
+                new XAttribute("Warnings", warningCount));
+
+            document.Add(root);
+            SaveToElement(root);
+
+            document.Save(logFile);
+        }
+
+        /// <summary>
+        /// Writes the build and its children to XML XElement representation.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        public override void SaveToElement(XElement parentElement)
+        {
+            WriteChildren<Message>(parentElement, () => new XElement("BuildMessageEvents"));
+            WriteProperties(parentElement);
+            WriteChildren<Project>(parentElement);
+        }
+
+        /// <summary>
+        /// Handler for a TargetStarted log event. Adds the target to the object structure.
+        /// </summary>
+        /// <param name="targetStartedEventArgs">The <see cref="TargetStartedEventArgs"/> instance containing the event data.</param>
+        public void AddTarget(TargetStartedEventArgs targetStartedEventArgs)
+        {
+            var project = GetOrAddProject(targetStartedEventArgs.BuildEventContext.ProjectContextId);
+            project.AddTarget(targetStartedEventArgs);
+        }
+
+        /// <summary>
+        /// Handler for a BuildMessage log event. Adds the node to the appropriate target.
+        /// </summary>
+        /// <param name="buildMessageEventArgs">The <see cref="BuildMessageEventArgs"/> instance containing the event data.</param>
+        /// <param name="messagePrefix">The message prefix.</param>
+        public void AddTaskParameter(BuildMessageEventArgs buildMessageEventArgs, string messagePrefix)
+        {
+            var project = GetOrAddProject(buildMessageEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(buildMessageEventArgs.BuildEventContext.TargetId);
+            var task = target.GetTaskById(buildMessageEventArgs.BuildEventContext.TaskId);
+
+            task.AddParameter(TaskParameter.Create(buildMessageEventArgs.Message, messagePrefix));
+        }
+
+        /// <summary>
+        /// Handler for a TaskCommandLine log event. Sets the command line arguments on the appropriate task. 
+        /// </summary>
+        /// <param name="taskCommandLineEventArgs">The <see cref="TaskCommandLineEventArgs"/> instance containing the event data.</param>
+        public void AddCommandLine(TaskCommandLineEventArgs taskCommandLineEventArgs)
+        {
+            var project = GetOrAddProject(taskCommandLineEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(taskCommandLineEventArgs.BuildEventContext.TargetId);
+            var task = target.GetTaskById(taskCommandLineEventArgs.BuildEventContext.TaskId);
+
+            task.CommandLineArguments = taskCommandLineEventArgs.CommandLine;
+        }
+
+        /// <summary>
+        /// Handles BuildMessage event when a property discovery/evaluation is logged.
+        /// </summary>
+        /// <param name="buildMessageEventArgs">The <see cref="BuildMessageEventArgs"/> instance containing the event data.</param>
+        /// <param name="prefix">The prefix string.</param>
+        public void AddPropertyGroup(BuildMessageEventArgs buildMessageEventArgs, string prefix)
+        {
+            string message = buildMessageEventArgs.Message.Substring(prefix.Length);
+
+            var project = GetOrAddProject(buildMessageEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(buildMessageEventArgs.BuildEventContext.TargetId);
+
+            var equals = message.IndexOf('=');
+            var name = message.Substring(0, equals);
+            var value = message.Substring(equals + 1);
+
+            target.AddProperty(name, value);
+        }
+
+        /// <summary>
+        /// Handles BuildMessage event when an ItemGroup discovery/evaluation is logged.
+        /// </summary>
+        /// <param name="buildMessageEventArgs">The <see cref="BuildMessageEventArgs"/> instance containing the event data.</param>
+        /// <param name="prefix">The prefix string.</param>
+        public void AddItemGroup(BuildMessageEventArgs buildMessageEventArgs, string prefix)
+        {
+            var project = GetOrAddProject(buildMessageEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(buildMessageEventArgs.BuildEventContext.TargetId);
+
+            target.AddItemGroup((ItemGroup)TaskParameter.Create(buildMessageEventArgs.Message, prefix));
+        }
+
+        /// <summary>
+        /// Handles a generic BuildMessage event and assigns it to the appropriate logging node.
+        /// </summary>
+        /// <param name="buildMessageEventArgs">The <see cref="BuildMessageEventArgs"/> instance containing the event data.</param>
+        public void AddMessage(LazyFormattedBuildEventArgs buildMessageEventArgs, string message)
+        {
+            LogProcessNode node = this;
+
+            if (buildMessageEventArgs.BuildEventContext.TaskId > 0)
+            {
+                node = GetOrAddProject(buildMessageEventArgs.BuildEventContext.ProjectContextId)
+                    .GetTargetById(buildMessageEventArgs.BuildEventContext.TargetId)
+                    .GetTaskById(buildMessageEventArgs.BuildEventContext.TaskId);
+            }
+            else if (buildMessageEventArgs.BuildEventContext.TargetId > 0)
+            {
+                node = GetOrAddProject(buildMessageEventArgs.BuildEventContext.ProjectContextId)
+                    .GetTargetById(buildMessageEventArgs.BuildEventContext.TargetId);
+            }
+            else if (buildMessageEventArgs.BuildEventContext.ProjectContextId > 0)
+            {
+                node = GetOrAddProject(buildMessageEventArgs.BuildEventContext.ProjectContextId);
+            }
+
+            node.AddMessage(new Message(message, buildMessageEventArgs.Timestamp));
+        }
+
+        /// <summary>
+        /// Handles a TaskStarted event from the log. Creates the task and assigns to the appropriate target.
+        /// </summary>
+        /// <param name="taskStartedEventArgs">The <see cref="TaskStartedEventArgs"/> instance containing the event data.</param>
+        public void AddTask(TaskStartedEventArgs taskStartedEventArgs)
+        {
+            var project = GetOrAddProject(taskStartedEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(taskStartedEventArgs.BuildEventContext.TargetId);
+
+            target.AddChildTask(new Task(taskStartedEventArgs.TaskName, taskStartedEventArgs, GetTaskAssembly((taskStartedEventArgs.TaskName))));
+        }
+
+        /// <summary>
+        /// Handles a ProjectStarted event from the log. Creates the project and assigns it to the correct parent project (if any).
+        /// </summary>
+        /// <param name="projectStartedEventArgs">The <see cref="ProjectStartedEventArgs"/> instance containing the event data.</param>
+        public void AddProject(ProjectStartedEventArgs projectStartedEventArgs)
+        {
+            Project parent = null;
+
+            if (projectStartedEventArgs.ParentProjectBuildEventContext != null && projectStartedEventArgs.ParentProjectBuildEventContext.ProjectContextId >= 0)
+            {
+                parent = GetOrAddProject(projectStartedEventArgs.ParentProjectBuildEventContext.ProjectContextId);
+            }
+
+            var project = GetOrAddProject(projectStartedEventArgs.BuildEventContext.ProjectContextId, projectStartedEventArgs, parent);
+
+            if (parent != null)
+            {
+                parent.AddChildProject(project);
+            }
+            else
+            {
+                // This is a "Root" project (no parent project).
+                AddChildNode(project);
+            }
+        }
+
+        /// <summary>
+        /// Gets a project instance for the given identifier. Will create if it doesn't exist.
+        /// </summary>
+        /// <remarks>If the ProjectStartedEventArgs is not known at this time (null), a stub project is created.</remarks>
+        /// <param name="projectId">The project identifier.</param>
+        /// <param name="projectStartedEventArgs">The <see cref="ProjectStartedEventArgs"/> instance containing the event data.</param>
+        /// <param name="parentProject">The parent project, if any.</param>
+        /// <returns>Project object</returns>
+        public Project GetOrAddProject(int projectId, ProjectStartedEventArgs projectStartedEventArgs = null, Project parentProject = null)
+        {
+            Project result = _projectIdToProjectMap.GetOrAdd(projectId,
+                id =>
+                    new Project(id, projectStartedEventArgs,
+                        parentProject == null ? Properties : parentProject.Properties));
+
+            if (projectStartedEventArgs != null)
+            {
+                result.TryUpdate(projectStartedEventArgs);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Completes the target.
+        /// </summary>
+        /// <param name="targetFinishedEventArgs">The <see cref="TargetFinishedEventArgs" /> instance containing the event data.</param>
+        public void CompleteTarget(TargetFinishedEventArgs targetFinishedEventArgs)
+        {
+            var project = GetOrAddProject(targetFinishedEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(targetFinishedEventArgs.BuildEventContext.TargetId);
+
+            target.EndTime = targetFinishedEventArgs.Timestamp;
+        }
+
+        /// <summary>
+        /// Completes the project.
+        /// </summary>
+        /// <param name="projectFinishedEventArgs">The <see cref="ProjectFinishedEventArgs"/> instance containing the event data.</param>
+        public void CompleteProject(ProjectFinishedEventArgs projectFinishedEventArgs)
+        {
+            var project = GetOrAddProject(projectFinishedEventArgs.BuildEventContext.ProjectContextId);
+            project.EndTime = projectFinishedEventArgs.Timestamp;
+        }
+
+        /// <summary>
+        /// Completes the task.
+        /// </summary>
+        /// <param name="taskFinishedEventArgs">The <see cref="TaskFinishedEventArgs"/> instance containing the event data.</param>
+        public void CompleteTask(TaskFinishedEventArgs taskFinishedEventArgs)
+        {
+            var project = GetOrAddProject(taskFinishedEventArgs.BuildEventContext.ProjectContextId);
+            var target = project.GetTargetById(taskFinishedEventArgs.BuildEventContext.TargetId);
+            var task = target.GetTaskById(taskFinishedEventArgs.BuildEventContext.TaskId);
+
+            task.EndTime = taskFinishedEventArgs.Timestamp;
+        }
+
+        /// <summary>
+        /// Sets the assembly location for a given task.
+        /// </summary>
+        /// <param name="taskName">Name of the task.</param>
+        /// <param name="assembly">The assembly location.</param>
+        public void SetTaskAssembly(string taskName, string assembly)
+        {
+            _taskToAssemblyMap.GetOrAdd(taskName, t => assembly);
+        }
+
+        /// <summary>
+        /// Gets the task assembly.
+        /// </summary>
+        /// <param name="taskName">Name of the task.</param>
+        /// <returns>The assembly location for the task.</returns>
+        public string GetTaskAssembly(string taskName)
+        {
+            string assembly;
+            return _taskToAssemblyMap.TryGetValue(taskName, out assembly) ? assembly : string.Empty;
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/InputParameter.cs
+++ b/Samples/XmlFileLogger/ObjectModel/InputParameter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of a task input parameter.
+    /// </summary>
+    internal class InputParameter : TaskParameter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InputParameter"/> class.
+        /// </summary>
+        /// <param name="message">The message from the logger.</param>
+        /// <param name="prefix">The prefix string (e.g. 'Output Property: ').</param>
+        public InputParameter(string message, string prefix)
+            : base(message, prefix)
+        {
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/Item.cs
+++ b/Samples/XmlFileLogger/ObjectModel/Item.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of an item/property with associated metadata (if any).
+    /// </summary>
+    internal class Item
+    {
+        /// <summary>
+        /// The metadata associated with this Item
+        /// </summary>
+        private readonly List<KeyValuePair<string, string>> _metadata = new List<KeyValuePair<string, string>>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Item"/> class.
+        /// </summary>
+        /// <param name="text">The text value of the item (e.g. file name).</param>
+        public Item(string text)
+        {
+            Text = text;
+        }
+
+        /// <summary>
+        /// Gets the text value of the item.
+        /// </summary>
+        /// <value>
+        /// The text.
+        /// </value>
+        public string Text { get; private set; }
+
+        /// <summary>
+        /// Gets the (non null/empty) metadata.
+        /// </summary>
+        /// <value>
+        /// The metadata.
+        /// </value>
+        public IEnumerable<KeyValuePair<string, string>> Metadata
+        {
+            get { return _metadata; }
+        }
+
+        /// <summary>
+        /// Adds the metadata to the item.
+        /// </summary>
+        /// <param name="key">The metadata key.</param>
+        /// <param name="value">The metadata value.</param>
+        public void AddMetadata(string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                _metadata.Add(new KeyValuePair<string, string>(key, value));
+            }
+        }
+
+        /// <summary>
+        /// Writes the item to XML XElement representation.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        /// <param name="xmlAttributeName">Name of the item 'Include' attribute.</param>
+        /// <param name="collapseSingleItem">If set to <c>true</c>, will collapse the node to a single item when possible.</param>
+        public void SaveToElement(XElement parentElement, string xmlAttributeName, bool collapseSingleItem)
+        {
+            var element = new XElement("Item");
+            parentElement.Add(element);
+
+            if (Metadata.Any() || !collapseSingleItem)
+            {
+                element.Add(new XAttribute(xmlAttributeName, Text));
+                foreach (var metadataItem in Metadata)
+                {
+                    var metadataElement = new XElement(metadataItem.Key);
+                    metadataElement.Add(metadataItem.Value);
+                    element.Add(metadataElement);
+                }
+            }
+            else
+            {
+                element.Add(new XText(Text));
+            }
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/ItemGroup.cs
+++ b/Samples/XmlFileLogger/ObjectModel/ItemGroup.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of a logged item group entry.
+    /// </summary>
+    internal class ItemGroup : TaskParameter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemGroup"/> class.
+        /// </summary>
+        /// <param name="message">The message from the logger.</param>
+        /// <param name="prefix">The prefix string (e.g. 'Added item(s): ').</param>
+        /// <param name="itemAttributeName">Name of the item attribute ('Include' or 'Remove').</param>
+        public ItemGroup(string message, string prefix, string itemAttributeName) :
+            base(message, prefix, false, itemAttributeName)
+        {
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/Message.cs
+++ b/Samples/XmlFileLogger/ObjectModel/Message.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Xml.Linq;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of a logged generic string output message.
+    /// </summary>
+    internal class Message : ILogNode
+    {
+        private readonly string _message;
+        private readonly DateTime _timestamp;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Message"/> class.
+        /// </summary>
+        /// <param name="message">The message string.</param>
+        /// <param name="timestamp">The time stamp of the logged event.</param>
+        public Message(string message, DateTime timestamp)
+        {
+            _message = message;
+            _timestamp = timestamp;
+        }
+
+        /// <summary>
+        /// Writes the message to XML XElement representation.
+        /// </summary>
+        /// <param name="element">The parent element.</param>
+        public void SaveToElement(XElement element)
+        {
+            element.Add(new XElement("Message", new XAttribute("Timestamp", _timestamp), new XText(_message)));
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/OutputItem.cs
+++ b/Samples/XmlFileLogger/ObjectModel/OutputItem.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of a task output item group.
+    /// </summary>
+    internal class OutputItem : TaskParameter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputItem"/> class.
+        /// </summary>
+        /// <param name="message">The message from the logger..</param>
+        /// <param name="prefix">The prefix string (e.g. 'Output Item(s): ').</param>
+        public OutputItem(string message, string prefix)
+            : base(message, prefix)
+        {
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/OutputProperty.cs
+++ b/Samples/XmlFileLogger/ObjectModel/OutputProperty.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of a task output property.
+    /// </summary>
+    internal class OutputProperty : TaskParameter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputProperty"/> class.
+        /// </summary>
+        /// <param name="message">The message from the logger..</param>
+        /// <param name="prefix">The prefix string (e.g. 'Output Item(s): ').</param>
+        public OutputProperty(string message, string prefix)
+            : base(message, prefix)
+        {
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/Project.cs
+++ b/Samples/XmlFileLogger/ObjectModel/Project.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of an MSBuild project execution.
+    /// </summary>
+    internal class Project : LogProcessNode
+    {
+        /// <summary>
+        /// The full path to the MSBuild project file for this project.
+        /// </summary>
+        private string _projectFile;
+
+        /// <summary>
+        /// A lookup table mapping of target names to targets. 
+        /// Target names are unique to a project and the id is not always specified in the log.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, Target> _targetNameToTargetMap = new ConcurrentDictionary<string, Target>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Project"/> class.
+        /// </summary>
+        /// <param name="projectId">The project identifier.</param>
+        /// <param name="e">The <see cref="ProjectStartedEventArgs"/> instance containing the event data.</param>
+        /// <param name="parentPropertyBag">The parent property bag (to check for inherited properties).</param>
+        public Project(int projectId, ProjectStartedEventArgs e, PropertyBag parentPropertyBag)
+        {
+            Properties = new PropertyBag(parentPropertyBag);
+            Id = projectId;
+
+            TryUpdate(e);
+        }
+
+        /// <summary>
+        /// Add the given project as a child to this node.
+        /// </summary>
+        /// <param name="childProject">The child project to add.</param>
+        public void AddChildProject(Project childProject)
+        {
+            AddChildNode(childProject);
+        }
+
+        /// <summary>
+        /// Adds a new target node to the project.
+        /// </summary>
+        /// <param name="targetStartedEventArgs">The <see cref="TargetStartedEventArgs"/> instance containing the event data.</param>
+        public void AddTarget(TargetStartedEventArgs targetStartedEventArgs)
+        {
+            var target = GetOrAddTargetByName(targetStartedEventArgs.TargetName, targetStartedEventArgs);
+
+            if (!string.IsNullOrEmpty(targetStartedEventArgs.ParentTarget))
+            {
+                var parentTarget = GetOrAddTargetByName(targetStartedEventArgs.ParentTarget);
+                parentTarget.AddChildTarget(target);
+            }
+            else
+            {
+                AddChildNode(target);
+            }
+        }
+
+        /// <summary>
+        /// Gets the child target by identifier.
+        /// </summary>
+        /// <remarks>Throws if the child target does not exist</remarks>
+        /// <param name="id">The target identifier.</param>
+        /// <returns>Target with the given ID</returns>
+        public Target GetTargetById(int id)
+        {
+            return _targetNameToTargetMap.Values.First(t => t.Id == id);
+        }
+
+        /// <summary>
+        /// Writes the project and its children to XML XElement representation.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        public override void SaveToElement(XElement parentElement)
+        {
+            // We could be in a situation where we never saw a "Parent" Target. So it's now
+            // in our scope but not rooted. This can happen when targets fail to run.
+            // Let's just add them back.
+            foreach (var orphan in _targetNameToTargetMap.Values.Where(t => t.Id < 0))
+            {
+                AddChildNode(orphan);
+            }
+
+            var element = new XElement("Project",
+                new XAttribute("Name", Name.Replace("\"", string.Empty)),
+                new XAttribute("StartTime", StartTime),
+                new XAttribute("EndTime", EndTime),
+                new XAttribute("ProjectFile", _projectFile));
+
+            parentElement.Add(element);
+
+            WriteProperties(element);
+            WriteChildren<Message>(element, () => new XElement("ProjectMessageEvents"));
+            WriteChildren<Project>(element);
+            WriteChildren<Target>(element);
+        }
+
+        /// <summary>
+        /// Try to update the project data given a project started event. This is useful if the project
+        /// was created (e.g. as a parent) before we saw the started event.
+        /// <remarks>Does nothing if the data has already been set or the new data is null.</remarks>
+        /// </summary>
+        /// <param name="projectStartedEventArgs">The <see cref="ProjectStartedEventArgs"/> instance containing the event data.</param>
+        public void TryUpdate(ProjectStartedEventArgs projectStartedEventArgs)
+        {
+            if (Name == null && projectStartedEventArgs != null)
+            {
+                StartTime = projectStartedEventArgs.Timestamp;
+                Name = projectStartedEventArgs.Message;
+                _projectFile = projectStartedEventArgs.ProjectFile;
+
+                if (projectStartedEventArgs.GlobalProperties != null)
+                {
+                    Properties.AddProperties(projectStartedEventArgs.GlobalProperties);
+                }
+                if (projectStartedEventArgs.Properties != null)
+                {
+                    Properties.AddProperties(projectStartedEventArgs.Properties.Cast<DictionaryEntry>());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format("{0} - {1}", Id, Name);
+        }
+
+        /// <summary>
+        /// Gets a child target by name. If the target doesn't exist a stub will be created.
+        /// </summary>
+        /// <param name="targetName">Name of the target.</param>
+        /// <param name="e">The <see cref="TargetStartedEventArgs"/> instance containing the event data, if any.</param>
+        /// <returns>Target node</returns>
+        private Target GetOrAddTargetByName(string targetName, TargetStartedEventArgs e = null)
+        {
+            Target result = _targetNameToTargetMap.GetOrAdd(targetName, key=> new Target(key, e));
+
+            if (e != null)
+            {
+                result.TryUpdate(e);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/Target.cs
+++ b/Samples/XmlFileLogger/ObjectModel/Target.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of an MSBuild target execution.
+    /// </summary>
+    internal class Target : LogProcessNode
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Target"/> class.
+        /// </summary>
+        /// <param name="targetName">Name of the target.</param>
+        /// <param name="targetStartedEvent">The <see cref="TargetStartedEventArgs"/> instance containing the target started event data.</param>
+        public Target(string targetName, TargetStartedEventArgs targetStartedEvent)
+        {
+            Id = -1;
+            Name = targetName;
+            TryUpdate(targetStartedEvent);
+        }
+
+        /// <summary>
+        /// Writes the project and its children to XML XElement representation.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        public override void SaveToElement(XElement parentElement)
+        {
+            var element = new XElement("Target",
+                new XAttribute("Name", Name),
+                new XAttribute("StartTime", StartTime),
+                new XAttribute("EndTime", EndTime));
+
+            parentElement.Add(element);
+
+            WriteProperties(element);
+            WriteChildren<Message>(element, () => new XElement("TargetMessages"));
+            WriteChildren<ItemGroup>(element, () => new XElement("ItemGroups"));
+            WriteChildren<Target>(element);
+            WriteChildren<Task>(element);
+        }
+
+        /// <summary>
+        /// Adds the given target as a child node.
+        /// </summary>
+        /// <param name="target">The target to add.</param>
+        public void AddChildTarget(Target target)
+        {
+            AddChildNode(target);
+        }
+
+        /// <summary>
+        /// Adds the given task as a child node.
+        /// </summary>
+        /// <param name="task">The task to add.</param>
+        public void AddChildTask(Task task)
+        {
+            AddChildNode(task);
+        }
+
+        /// <summary>
+        /// Gets a child task by identifier.
+        /// </summary>
+        /// /// <remarks>Throws if the child target does not exist</remarks>
+        /// <param name="taskId">The task identifier.</param>
+        /// <returns>Task object with the given id.</returns>
+        public Task GetTaskById(int taskId)
+        {
+            return GetChildrenOfType<Task>().First(t => t.Id == taskId);
+        }
+
+        /// <summary>
+        /// Adds a property key/value pair to the target context.
+        /// </summary>
+        /// <param name="key">The property key.</param>
+        /// <param name="value">The property value.</param>
+        public void AddProperty(string key, string value)
+        {
+            Properties.AddProperty(key, value);
+        }
+
+        /// <summary>
+        /// Add a discovered ItemGroup list to the node.
+        /// </summary>
+        /// <param name="itemGroup">The item group to add.</param>
+        public void AddItemGroup(ItemGroup itemGroup)
+        {
+            AddChildNode(itemGroup);
+        }
+
+        /// <summary>
+        /// Try to update the target data given a target started event. This is useful if the project
+        /// was created (e.g. as a parent) before we saw the started event.
+        /// </summary>
+        /// <remarks>Does nothing if the data has already been set or the new data is null.</remarks>
+        /// <param name="e">The <see cref="TargetStartedEventArgs"/> instance containing the event data.</param>
+        public void TryUpdate(TargetStartedEventArgs e)
+        {
+            if (Id < 0 && e != null)
+            {
+                // = e.Timestamp;
+                Id = e.BuildEventContext.TargetId;
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format("{0} - {1}", Id, Name);
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/Task.cs
+++ b/Samples/XmlFileLogger/ObjectModel/Task.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Class representation of an MSBuild task execution.
+    /// </summary>
+    internal class Task : LogProcessNode
+    {
+        /// <summary>
+        /// The assembly from which the task originated.
+        /// </summary>
+        private readonly string _fromAssembly;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Task"/> class.
+        /// </summary>
+        /// <param name="name">The name of the task.</param>
+        /// <param name="taskStartedEvent">The <see cref="TaskStartedEventArgs"/> instance containing the event data.</param>
+        /// <param name="assembly">The assembly from which the task originated.</param>
+        public Task(string name, TaskStartedEventArgs taskStartedEvent, string assembly)
+        {
+            Name = name;
+            Id = taskStartedEvent.BuildEventContext.TaskId;
+            StartTime = taskStartedEvent.Timestamp;
+            _fromAssembly = assembly;
+        }
+
+        /// <summary>
+        /// Gets or sets the command line arguments.
+        /// </summary>
+        /// <value>
+        /// The command line arguments (if any) for the task).
+        /// </value>
+        public string CommandLineArguments { get; set; }
+
+        /// <summary>
+        /// Saves to task representation to XML XElement.
+        /// </summary>
+        /// <param name="element">The element to write the task Node to.</param>
+        public override void SaveToElement(XElement element)
+        {
+            var task = new XElement("Task",
+                new XAttribute("Name", Name),
+                new XAttribute("FromAssembly", _fromAssembly),
+                new XAttribute("StartTime", StartTime),
+                new XAttribute("EndTime", EndTime));
+            element.Add(task);
+
+            WriteChildren<Message>(task, () => new XElement("TaskMessages"));
+            WriteChildren<InputParameter>(task, () => new XElement("Parameters"));
+            WriteChildren<OutputItem>(task, () => new XElement("OutputItems"));
+            WriteChildren<OutputProperty>(task, () => new XElement("OutputProperties"));
+
+            if (!string.IsNullOrEmpty(CommandLineArguments))
+            {
+                task.Add(new XElement("CommandLineArguments") { Value = CommandLineArguments });
+            }
+        }
+
+        /// <summary>
+        /// Adds a task level parameter (input/output).
+        /// </summary>
+        /// <param name="parameter">The parameter to add</param>
+        public void AddParameter(TaskParameter parameter)
+        {
+            AddChildNode(parameter);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Format("{0} - {1}", Id, Name);
+        }
+    }
+}

--- a/Samples/XmlFileLogger/ObjectModel/TaskParameter.cs
+++ b/Samples/XmlFileLogger/ObjectModel/TaskParameter.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// Abstract base class for task input / output parameters (can be ItemGroups)
+    /// </summary>
+    internal abstract class TaskParameter : ILogNode
+    {
+        protected bool collapseSingleItem;
+        protected string itemAttributeName;
+        protected readonly List<Item> items = new List<Item>();
+        protected readonly string name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskParameter"/> class.
+        /// </summary>
+        /// <param name="message">The message from the logging system.</param>
+        /// <param name="prefix">The prefix parsed out (e.g. 'Output Item(s): ').</param>
+        /// <param name="collapseSingleItem">If set to <c>true</c>, will collapse the node to a single item when possible.</param>
+        /// <param name="itemAttributeName">Name of the item 'Include' attribute.</param>
+        protected TaskParameter(string message, string prefix, bool collapseSingleItem = true, string itemAttributeName = "Include")
+        {
+            this.collapseSingleItem = collapseSingleItem;
+            this.itemAttributeName = itemAttributeName;
+
+            foreach (var item in ItemGroupParser.ParseItemList(message, prefix, out name))
+            {
+                items.Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Saves the task parameter node to XML XElement.
+        /// </summary>
+        /// <param name="parentElement">The parent element.</param>
+        public void SaveToElement(XElement parentElement)
+        {
+            XElement element = new XElement(name);
+            parentElement.Add(element);
+
+            if (collapseSingleItem && items.Count == 1 && !items[0].Metadata.Any())
+            {
+                element.Add(items[0].Text);
+            }
+            else
+            {
+                foreach (var item in items)
+                {
+                    item.SaveToElement(element, itemAttributeName, collapseSingleItem);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a concrete Task Parameter type based on the message logging message.
+        /// </summary>
+        /// <param name="message">The message string from the logger.</param>
+        /// <param name="prefix">The prefix to the message string.</param>
+        /// <returns>Concrete task parameter node.</returns>
+        public static TaskParameter Create(string message, string prefix)
+        {
+            switch (prefix)
+            {
+                case XmlFileLogger.OutputItemsMessagePrefix:
+                    return new OutputItem(message, prefix);
+                case XmlFileLogger.TaskParameterMessagePrefix:
+                    return new InputParameter(message, prefix);
+                case XmlFileLogger.OutputPropertyMessagePrefix:
+                    return new OutputProperty(message, prefix);
+                case XmlFileLogger.ItemGroupIncludeMessagePrefix:
+                    return new ItemGroup(message, prefix, "Include");
+                case XmlFileLogger.ItemGroupRemoveMessagePrefix:
+                    return new ItemGroup(message, prefix, "Remove");
+                default:
+                    throw new UnknownTaskParameterPrefixException(prefix);
+            }
+        }
+    }
+}

--- a/Samples/XmlFileLogger/Properties/AssemblyInfo.cs
+++ b/Samples/XmlFileLogger/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("XmlFileLogger")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft Corp.")]
+[assembly: AssemblyProduct("XmlFileLogger")]
+[assembly: AssemblyCopyright("Copyright \u00A9 Microsoft Corp. 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bd519bcb-f7d7-41ea-8c71-7f980a3ab694")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Samples/XmlFileLogger/PropertyBag.cs
+++ b/Samples/XmlFileLogger/PropertyBag.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// This class encapsulates functionality for a collection of properties (name value pairs) in a
+    /// hierarchical way. (e.g. if the parameter is defined and identical in the parent, it is not
+    /// stored in this instance). 
+    /// </summary>
+    internal class PropertyBag
+    {
+        /// <summary>
+        /// The parent instance.
+        /// </summary>
+        private readonly PropertyBag _parent;
+
+        /// <summary>
+        /// The properties defined at this level.
+        /// </summary>
+        private readonly Dictionary<string, string> _properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
+        /// </summary>
+        /// <param name="properties">The initial properties to set.</param>
+        /// <param name="parent">The parent <see cref="PropertyBag"/> instance.</param>
+        public PropertyBag(IEnumerable<KeyValuePair<string, string>> properties, PropertyBag parent = null)
+            : this(parent)
+        {
+            AddProperties(properties);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="PropertyBag"/>.</param>
+        public PropertyBag(PropertyBag parent = null)
+        {
+            _parent = parent;
+        }
+
+        /// <summary>
+        /// Gets the properties associated with this instance (without parent properties).
+        /// </summary>
+        /// <value>
+        /// The properties.
+        /// </value>
+        public IDictionary<string, string> Properties { get { return _properties; } }
+
+        /// <summary>
+        /// Adds properties to the collection.
+        /// </summary>
+        /// <param name="newProperties">The new properties.</param>
+        public void AddProperties(IEnumerable<KeyValuePair<string, string>> newProperties)
+        {
+            if (newProperties == null)
+            {
+                throw new ArgumentNullException("newProperties");
+            }
+
+            foreach (var property in newProperties)
+            {
+                AddProperty(property.Key, property.Value);
+            }
+        }
+
+        /// <summary>
+        /// Adds properties to the collection.
+        /// </summary>
+        /// <remarks>If the property is defined and identical in the parent, no action is taken.</remarks>
+        /// <param name="newProperties">The new properties.</param>
+        /// <exception cref="System.ArgumentException">newProperties</exception>
+        public void AddProperties(IEnumerable<DictionaryEntry> newProperties)
+        {
+            if (newProperties == null)
+            {
+                throw new ArgumentNullException("newProperties");
+            }
+
+            foreach (var property in newProperties)
+            {
+                AddProperty(property.Key.ToString(), property.Value.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Add a single property to the collection.
+        /// </summary>
+        /// <remarks>If the property is defined and identical in the parent, no action is taken.</remarks>
+        /// <param name="key">The property key.</param>
+        /// <param name="value">The property value.</param>
+        public void AddProperty(string key, string value)
+        {
+            string currentValue;
+
+            if (_properties.TryGetValue(key, out currentValue))
+            {
+                // We've already seen the property here, update value if different
+                if (currentValue != value)
+                {
+                    _properties[key] = value;
+                }
+            }
+            else if (_parent != null && _parent.TryGetValue(key, out currentValue))
+            {
+                // The parent has the property, only add if different
+                if (currentValue != value)
+                {
+                    _properties.Add(key, value);
+                }
+            }
+            else
+            {
+                // No one has the property, just add it.
+                _properties.Add(key, value);
+            }
+        }
+
+        /// <summary>
+        /// Tries the get the value for the property in this scope.
+        /// </summary>
+        /// <param name="key">The property key.</param>
+        /// <param name="value">Out: The property value.</param>
+        /// <returns>True if the property was found and set, else false.</returns>
+        public bool TryGetValue(string key, out string value)
+        {
+            if (_properties.TryGetValue(key, out value))
+            {
+                return true;
+            }
+
+            return _parent != null && _parent.TryGetValue(key, out value);
+        }
+    }
+}

--- a/Samples/XmlFileLogger/UnknownTaskParameterPrefixException.cs
+++ b/Samples/XmlFileLogger/UnknownTaskParameterPrefixException.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    internal class UnknownTaskParameterPrefixException : Exception
+    {
+        public UnknownTaskParameterPrefixException(string prefix)
+            : base(string.Format("Unknown task parameter type: {0}", prefix))
+        {
+        }
+    }
+}

--- a/Samples/XmlFileLogger/XmlFileLogger.cs
+++ b/Samples/XmlFileLogger/XmlFileLogger.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Build.Logging.StructuredLogger
+{
+    /// <summary>
+    /// XML File Logger class to handle, parse, and route messages form the MSBuild logging system.
+    /// </summary>
+    public class XmlFileLogger : Logger
+    {
+        public const string OutputItemsMessagePrefix = @"Output Item(s): ";
+        public const string OutputPropertyMessagePrefix = @"Output Property: ";
+        public const string TaskParameterMessagePrefix = @"Task Parameter:";
+        public const string PropertyGroupMessagePrefix = @"Set Property: ";
+        public const string ItemGroupIncludeMessagePrefix = @"Added Item(s): ";
+        public const string ItemGroupRemoveMessagePrefix = @"Removed Item(s): ";
+
+        /// <summary>
+        /// The path to the log file specified by the user
+        /// </summary>
+        private string _logFile;
+
+        /// <summary>
+        /// The build instance set when the build starts.
+        /// </summary>
+        private Build _build;
+
+        private int _errors;
+        private int _warings;
+
+        /// <summary>
+        /// Initializes the logger and subscribes to the relevant events.
+        /// </summary>
+        /// <param name="eventSource">The available events that processEvent logger can subscribe to.</param>
+        public override void Initialize(IEventSource eventSource)
+        {
+            ProcessParameters();
+            
+            eventSource.BuildStarted    += (s, args) => _build = new Build(args);
+            eventSource.BuildFinished   += (o, args) => _build.CompleteBuild(args, _logFile, _errors, _warings);
+
+            eventSource.ProjectStarted  += (o, args) => TryProcessEvent(() => _build.AddProject(args));
+            eventSource.ProjectFinished += (o, args) => TryProcessEvent(() => _build.CompleteProject(args));
+            eventSource.TargetStarted   += (o, args) => TryProcessEvent(() => _build.AddTarget(args));
+            eventSource.TargetFinished  += (o, args) => TryProcessEvent(() => _build.CompleteTarget(args));
+            eventSource.TaskStarted     += (o, args) => TryProcessEvent(() => _build.AddTask(args));
+            eventSource.TaskFinished    += (o, args) => TryProcessEvent(() => _build.CompleteTask(args));
+
+            eventSource.TaskFinished += (o, args) => TryProcessEvent(() => _build.CompleteTask(args));
+
+            eventSource.MessageRaised += HandleMessageRaised;
+
+            eventSource.ErrorRaised += (o, args) =>
+            {
+                _errors++;
+                _build.AddMessage(args, string.Format("Error {0}: {1}", args.Code, args.Message));
+            };
+            eventSource.WarningRaised += (o, args) =>
+            {
+
+                _warings++;
+                _build.AddMessage(args, string.Format("Warning {0}: {1}", args.Code, args.Message));
+            };
+        }
+
+        /// <summary>
+        /// Tries to process an event (action). On exception, log as a build message so we don't crash.
+        /// </summary>
+        /// <param name="processEvent">Action/event to process.</param>
+        private void TryProcessEvent(Action processEvent)
+        {
+            try
+            {
+                processEvent();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                _build.AddMessage(new Message(string.Format("XmlFileLogger Error: {0}", e), DateTime.Now));
+            }
+        }
+
+        /// <summary>
+        /// Handles the generic message raised event.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="messageArgs">The <see cref="BuildMessageEventArgs"/> instance containing the event data.</param>
+        private void HandleMessageRaised(object sender, BuildMessageEventArgs messageArgs)
+        {
+            const string taskAssemblyPattern = "Using \"(?<task>.+)\" task from (assembly|the task factory) \"(?<assembly>.+)\"\\.";
+
+            // Task Input / Outputs
+            if (messageArgs.Message.StartsWith(TaskParameterMessagePrefix))
+            {
+                _build.AddTaskParameter(messageArgs, TaskParameterMessagePrefix);
+            }
+            else if (messageArgs.Message.StartsWith(OutputItemsMessagePrefix))
+            {
+                _build.AddTaskParameter(messageArgs, OutputItemsMessagePrefix);
+            }
+            else if (messageArgs.Message.StartsWith(OutputPropertyMessagePrefix))
+            {
+                _build.AddTaskParameter(messageArgs, OutputPropertyMessagePrefix);
+            }
+
+            // Item / Property groups
+            else if (messageArgs.Message.StartsWith(PropertyGroupMessagePrefix))
+            {
+                _build.AddPropertyGroup(messageArgs, PropertyGroupMessagePrefix);
+            }
+            else if (messageArgs.Message.StartsWith(ItemGroupIncludeMessagePrefix))
+            {
+                _build.AddItemGroup(messageArgs, ItemGroupIncludeMessagePrefix);
+            }
+            else if (messageArgs.Message.StartsWith(ItemGroupRemoveMessagePrefix))
+            {
+                _build.AddItemGroup(messageArgs, ItemGroupRemoveMessagePrefix);
+            }
+            else
+            {
+                // This was command line arguments for processEvent task
+                var args = messageArgs as TaskCommandLineEventArgs;
+                if (args != null)
+                {
+                    _build.AddCommandLine(args);
+                    return;
+                }
+
+                // A task from assembly message (parses out the task name and assembly path).
+                var match = Regex.Match(messageArgs.Message, taskAssemblyPattern);
+                if (match.Success)
+                {
+                    _build.SetTaskAssembly(match.Groups["task"].Value, match.Groups["assembly"].Value);
+                }
+                else
+                {
+                    // Just processEvent generic log message or something we currently don't handle in the object model.
+                    _build.AddMessage(messageArgs, messageArgs.Message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Processes the parameters given to the logger from MSBuild.
+        /// </summary>
+        /// <exception cref="LoggerException">
+        /// </exception>
+        private void ProcessParameters()
+        {
+            const string invalidParamSpecificationMessage = @"Need processEvent log file.  Specify using the following pattern: '/logger:XmlFileLogger,XmlFileLogger.dll;buildlog.xml";
+
+            if (Parameters == null)
+            {
+                throw new LoggerException(invalidParamSpecificationMessage);
+            }
+
+            string[] parameters = Parameters.Split(';');
+
+            if (parameters.Length != 1)
+            {
+                throw new LoggerException(invalidParamSpecificationMessage);
+            }
+
+            _logFile = parameters[0];
+        }
+    }
+}

--- a/Samples/XmlFileLogger/XmlFileLogger.csproj
+++ b/Samples/XmlFileLogger/XmlFileLogger.csproj
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2A0E81B1-9E7A-4F9F-81B2-AB180833F754}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Build.Logging.StructuredLogger</RootNamespace>
+    <AssemblyName>XmlFileLogger</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ILogNode.cs" />
+    <Compile Include="ItemGroupParser.cs" />
+    <Compile Include="ObjectModel\Build.cs" />
+    <Compile Include="ObjectModel\InputParameter.cs" />
+    <Compile Include="ObjectModel\ItemGroup.cs" />
+    <Compile Include="LogProcessNode.cs" />
+    <Compile Include="ObjectModel\Item.cs" />
+    <Compile Include="ObjectModel\Message.cs" />
+    <Compile Include="ObjectModel\OutputItem.cs" />
+    <Compile Include="ObjectModel\OutputProperty.cs" />
+    <Compile Include="ObjectModel\Project.cs" />
+    <Compile Include="ObjectModel\Target.cs" />
+    <Compile Include="ObjectModel\Task.cs" />
+    <Compile Include="ObjectModel\TaskParameter.cs" />
+    <Compile Include="PropertyBag.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnknownTaskParameterPrefixException.cs" />
+    <Compile Include="XmlFileLogger.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/Samples/dir.props
+++ b/Samples/dir.props
@@ -1,3 +1,9 @@
 ﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
+
+  <PropertyGroup>
+    <!-- Explicitly set the OutDir as it is used by the packaging targets -->
+    <OutDir>$(BaseOutputPath)Samples\$(Configuration)\$(MSBuildProjectName)</OutDir>
+  </PropertyGroup>
+  
 </Project>

--- a/Samples/dirs.proj
+++ b/Samples/dirs.proj
@@ -3,13 +3,9 @@
 
   <ItemGroup>
     <Project Include="TaskUsageLogger\TaskUsageLogger.csproj" />
+    <Project Include="XmlFileLogger\XmlFileLogger.csproj" />
   </ItemGroup>
 
   <Import Project="..\dir.traversal.targets" />
-  
-  <PropertyGroup>
-    <!-- Explicitly set the OutDir as it is used by the packaging targets -->
-    <OutDir>$(BaseOutputPathWithConfig)</OutDir>
-  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Adding a structured XML file logger to the samples folder.

##### Background
In Visual Studio 2015, one of the changes we made to MSBuild was to enable some additional logging in diagnostics mode, specifically around task inputs and outputs. This XmlFileLogger project is a sample of how you might use that information. The output XML file is not as much of a trace log but a structure of how the project was built with inputs and outputs. I've found this especially useful when you know what parameter is used, but not where it came from and what else uses it.

##### Some caveats
* It will hold onto everything in memory in order to output the contents at the end. Probably not a good idea to use it on a really huge project. If there's demand, this could be fixed.
* Events aren't in order, especially with a multi-core build. They appear in the file based on their build hierarchy.

##### Example structure (very simplified)
```
<Build>
  <Project Name=”Project1”>
    <Target>
      <Task Name=”Task”
        <Parameters>
          <P1>value in</P1>
        </Parameters>
        <OutputParameters>
          <P2>value out</P2>
        <OutputParameters>
      </Task>
  </Project>
  <Project Name=”Project2”>
    <Target>
      <Task Name=”Csc” … />
    </Target>
  </Project>
</Build>
```

##### Usage
`MSBuild.exe /logger:XmlFileLogger,XmlFileLogger.dll;buildlog.xml ...`
See `RebuildWithXmlLog.cmd` file in the Samples folder. This will build the project and build it again with the XML logger enabled.