### PR TITLE
Reenable switches that start with a slash on Mono

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -472,22 +472,36 @@ namespace Microsoft.Build.Shared
                 }
             }
 
-            var firstSlash = checkValue.IndexOf('/');
-            // The first slash will either be at the beginning of the string or after the first directory name
-            if (firstSlash == 0)
-            {
-                firstSlash = checkValue.Substring(1).IndexOf('/') + 1;
-            }
-
-            if (firstSlash > 0 && Directory.Exists(checkValue.Substring(0, firstSlash)))
-            {
-                return newValue;
-            }
-
-            return value;
+            return LooksLikeUnixFilePath(checkValue) ? newValue : value;
         }
 
+        /// <summary>
+        /// If on Unix, check if the string looks like a file path.
+        /// The heuristic is if something resembles paths (contains slashes) check if the
+        /// first segment exists and is a directory.
+        /// </summary>
+        internal static bool LooksLikeUnixFilePath(string value)
+        {
+            if (!NativeMethodsShared.IsUnix)
+            {
+                return false;
+            }
 
+            var firstSlash = value.IndexOf('/');
+
+            // The first slash will either be at the beginning of the string or after the first directory name 
+            if (firstSlash == 0)
+            {
+                firstSlash = value.Substring(1).IndexOf('/') + 1;
+            }
+
+            if (firstSlash > 0 && Directory.Exists(value.Substring(0, firstSlash)))
+            {
+                return true;
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Extracts the directory from the given file-spec.

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1291,13 +1291,7 @@ namespace Microsoft.Build.CommandLine
                         string switchParameters;
 
                         // all switches should start with - or / unless a project is being specified
-                        if (!unquotedCommandLineArg.StartsWith("-", StringComparison.Ordinal)
-#if MONO
-                            )
-#else
-                            && !unquotedCommandLineArg.StartsWith("/", StringComparison.Ordinal)
-                        )
-#endif
+                        if (!unquotedCommandLineArg.StartsWith("-", StringComparison.Ordinal) && (!unquotedCommandLineArg.StartsWith("/", StringComparison.Ordinal) || LooksLikeUnixFilePath(unquotedCommandLineArg)))
                         {
                             switchName = null;
                             // add a (fake) parameter indicator for later parsing
@@ -1360,6 +1354,30 @@ namespace Microsoft.Build.CommandLine
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// If on Unix, check if the string looks like a file path.
+        /// The heuristic is if something resembles paths (contains slashes) check if the
+        /// first segment exists and is a directory.
+        /// </summary>
+        private static bool LooksLikeUnixFilePath(string value)
+        {
+#if MONO
+            var firstSlash = value.IndexOf('/');
+
+            // The first slash will either be at the beginning of the string or after the first directory name 
+            if (firstSlash == 0)
+            {
+                firstSlash = value.Substring(1).IndexOf('/') + 1;
+            }
+
+            if (firstSlash > 0 && System.IO.Directory.Exists(value.Substring(0, firstSlash)))
+            {
+                return true;
+            }
+#endif
+            return false;
         }
 
         /// <summary>

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1291,7 +1291,7 @@ namespace Microsoft.Build.CommandLine
                         string switchParameters;
 
                         // all switches should start with - or / unless a project is being specified
-                        if (!unquotedCommandLineArg.StartsWith("-", StringComparison.Ordinal) && (!unquotedCommandLineArg.StartsWith("/", StringComparison.Ordinal) || LooksLikeUnixFilePath(unquotedCommandLineArg)))
+                        if (!unquotedCommandLineArg.StartsWith("-", StringComparison.Ordinal) && (!unquotedCommandLineArg.StartsWith("/", StringComparison.Ordinal) || FileUtilities.LooksLikeUnixFilePath(unquotedCommandLineArg)))
                         {
                             switchName = null;
                             // add a (fake) parameter indicator for later parsing
@@ -1354,30 +1354,6 @@ namespace Microsoft.Build.CommandLine
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// If on Unix, check if the string looks like a file path.
-        /// The heuristic is if something resembles paths (contains slashes) check if the
-        /// first segment exists and is a directory.
-        /// </summary>
-        private static bool LooksLikeUnixFilePath(string value)
-        {
-#if MONO
-            var firstSlash = value.IndexOf('/');
-
-            // The first slash will either be at the beginning of the string or after the first directory name 
-            if (firstSlash == 0)
-            {
-                firstSlash = value.Substring(1).IndexOf('/') + 1;
-            }
-
-            if (firstSlash > 0 && System.IO.Directory.Exists(value.Substring(0, firstSlash)))
-            {
-                return true;
-            }
-#endif
-            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Until now, switches on Mono only supported the '-' prefix instead of '/'.
This was done for simplicity to be able to determine if the parameter is a path or MSBuild switch.

By using a similar heuristic as introduced in https://github.com/Microsoft/msbuild/pull/67, we can now use slashes as well. The heuristic checks if the first segment of a string with slashes is a directory on disk, if yes it's very likely a path. Otherwise it's a switch.

Fixes #48

Note: I built MSBuild itself with these changes and using / for the switches which worked fine. I don't know where it makes sense to add unit tests since those would only work on Unix filesystems.