### PR TITLE
Allow build.pl to find xbuild in current PATH

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,7 +52,7 @@
 *.bat	wintext
 *.rsp	wintext
 *.sample wintext
-
+*.pl	text eol=auto
 
 # Sources (Binary)
 *.doc  binary

--- a/build.pl
+++ b/build.pl
@@ -48,8 +48,10 @@ USAGE
 
 # Quick check if we are in the right place and that mono is installed
 # (just checking for solution and xbuild presence)
+my $xbuild = ($^O eq 'MSWin32') ? `where xbuild` : `which xbuild`;
+chomp $xbuild;
 die ("Solution $solutionToBuild does not exist\n") unless -e $solutionToBuild;
-die ("xbuild was not found") unless $^O eq "MSWin32" || -e "/usr/bin/xbuild";
+die ("xbuild was not found") unless $^O eq "MSWin32" || -e $xbuild;
 
 my $buildRoot;
 my $runTests;
@@ -115,7 +117,7 @@ if ($^O eq "MSWin32") {
     $slash = '\\';
 }
 else {
-    $installedBuild = '/usr/bin/xbuild';
+    $installedBuild = $xbuild;
     $slash = '/';
 }
 


### PR DESCRIPTION
Before, build.pl would always take xbuild from /usr/bin which causes problems when another xbuild is in the PATH.
Also fix line endings for *.pl to be the platforms default so it works out of the box on Linux.