### PR TITLE
Add override for reference folder base path.

### DIFF
--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -801,9 +801,19 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string GenerateProgramFilesReferenceAssemblyRoot()
         {
-            string combinedPath = NativeMethodsShared.IsWindows
-                                      ? Path.Combine(programFiles32, "Reference Assemblies\\Microsoft\\Framework")
-                                      : Path.Combine(NativeMethodsShared.FrameworkBasePath, "xbuild-frameworks");
+            string combinedPath = Environment.GetEnvironmentVariable("ReferenceAssemblyRoot");
+            if (!String.IsNullOrEmpty(combinedPath))
+            {
+                combinedPath = Path.GetFullPath(combinedPath);
+                if (Directory.Exists(combinedPath))
+                {
+                    return combinedPath;
+                }
+            }
+
+            combinedPath = NativeMethodsShared.IsWindows
+                               ? Path.Combine(programFiles32, "Reference Assemblies\\Microsoft\\Framework")
+                               : Path.Combine(NativeMethodsShared.FrameworkBasePath, "xbuild-frameworks");
 
             return Path.GetFullPath(combinedPath);
         }


### PR DESCRIPTION
Allow explicitly overriding the root reference assembly folder via "ReferenceAssemblyRoot" env var.

@ValMenn @AndyGerlicher 