### PR TITLE
[tests] NoTempFileLeaks - Remove unnecessary single quote ..

### DIFF
--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.UnitTests
             int originalTempFileCount = tempFiles.Length;
 
             // Now run the Exec task on a simple command.
-            Exec exec = PrepareExec("echo Four days 'till ZBB!");
+            Exec exec = PrepareExec("echo Four days till ZBB!");
             bool result = exec.Execute();
 
             // Get the new count of temp files.


### PR DESCRIPTION
.. that broke the test on Unix.