### PR TITLE
Fix getting FrameworkName from TargetFrameworkAttribute on Mono

### DIFF
--- a/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
@@ -275,15 +275,12 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 
-                object name = null;
+                string name = null;
                 if (attr != null)
                 {
-                    name =
-                        attr.NamedArguments.FirstOrDefault(
-                            t =>
-                            t.MemberName.Equals("FrameworkDisplayName", StringComparison.InvariantCultureIgnoreCase));
+                    name = (string)attr.ConstructorArguments[0].Value;
                 }
-                return name == null ? null : name as FrameworkName;
+                return name == null ? null : new FrameworkName(name);
             }
 
             FrameworkName frameworkAttribute = null;


### PR DESCRIPTION
The Mono implementation looked at FrameworkDisplayName which is something like `.NET Portable Subset`, but the Windows/COM implementation got the framework identifier as `.NETPortable,Version=v4.5,Profile=Profile259`.

Changed the Mono implementation to get the first constructor argument of the attribute, which contains what we want.

/cc @JeremyKuhne now that the Mono bug is fixed, I noticed this while testing.