### PR TITLE
Fixes ResolveAssemblyReference tests on mac

### DIFF
--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -194,6 +194,24 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         protected static readonly string s_frameworksPath = Path.Combine(s_rootPathPrefix, "Frameworks");
 
+        protected static readonly string s_myComponentsRootPath = Path.Combine(s_rootPathPrefix, "MyComponents");
+        protected static readonly string s_myComponents10Path = Path.Combine(s_myComponentsRootPath, "1.0");
+        protected static readonly string s_myComponents20Path = Path.Combine(s_myComponentsRootPath, "2.0");
+        protected static readonly string s_myComponentsMiscPath = Path.Combine(s_myComponentsRootPath, "misc");
+
+        protected static readonly string s_myComponentsV05Path = Path.Combine(s_myComponentsRootPath, "v0.5");
+        protected static readonly string s_myComponentsV10Path = Path.Combine(s_myComponentsRootPath, "v1.0");
+        protected static readonly string s_myComponentsV20Path = Path.Combine(s_myComponentsRootPath, "v2.0");
+        protected static readonly string s_myComponentsV30Path = Path.Combine(s_myComponentsRootPath, "v3.0");
+
+        protected static readonly string s_unifyMeDll_V05Path = Path.Combine(s_myComponentsV05Path, "UnifyMe.dll");
+        protected static readonly string s_unifyMeDll_V10Path = Path.Combine(s_myComponentsV10Path, "UnifyMe.dll");
+        protected static readonly string s_unifyMeDll_V20Path = Path.Combine(s_myComponentsV20Path, "UnifyMe.dll");
+        protected static readonly string s_unifyMeDll_V30Path = Path.Combine(s_myComponentsV30Path, "UnifyMe.dll");
+
+        protected static readonly string s_myComponents40ComponentPath = Path.Combine(s_myComponentsRootPath, "4.0Component");
+        protected static readonly string s_40ComponentDependsOnOnlyv4AssembliesDllPath = Path.Combine(s_myComponents40ComponentPath, "DependsOnOnlyv4Assemblies.dll");
+
         /// <summary>
         /// Search paths to use.
         /// </summary>
@@ -202,9 +220,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             "{RawFileName}",
             "{CandidateAssemblyFiles}",
             s_myProjectPath,
-            @"c:\MyComponents\misc\",
-            @"c:\MyComponents\1.0",
-            @"c:\MyComponents\2.0",
+            s_myComponentsMiscPath,
+            s_myComponents10Path,
+            s_myComponents20Path,
             s_myVersion20Path,
             @"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}",
             "{AssemblyFolders}",
@@ -323,7 +341,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"C:\myassemblies\My.Assembly.dll",
                 Path.Combine(s_myProjectPath, "mscorlib.dll"),                           // This is an mscorlib.dll that has no metadata (i.e. GetAssemblyName returns null)
                 Path.Combine(s_myProjectPath, "System.Data.dll"),                        // This is a System.Data.dll that has the wrong pkt, it shouldn't be matched.
-                @"C:\MyComponents\MyGrid.dll",                                           // A vendor component that we should find in the registry.
+                Path.Combine(s_myComponentsRootPath, "MyGrid.dll"),                      // A vendor component that we should find in the registry.
                 @"C:\MyComponentsA\CustomComponent.dll",                                           // A vendor component that we should find in the registry.
                 @"C:\MyComponentsB\CustomComponent.dll",                                           // A vendor component that we should find in the registry.
                 @"C:\MyWinMDComponents7\MyGridWinMD.winmd",
@@ -341,11 +359,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"C:\MyWinMDComponents\HKLM Components\MyHKLMControlWinMD.winmd",                    // A vendor component that is installed under HKLM but not HKCU.
                 @"C:\MyWinMDComponents\HKCU Components\MyHKLMandHKCUControlWinMD.winmd",             // A vendor component that is installed under HKLM and HKCU.
                 @"C:\MyWinMDComponents\HKLM Components\MyHKLMandHKCUControlWinMD.winmd",             // A vendor component that is installed under HKLM and HKCU.
-                @"C:\MyComponents\v3.0\MyControlWithFutureTargetNDPVersion.dll",         // The future version of a component.
-                @"C:\MyComponents\v2.0\MyControlWithFutureTargetNDPVersion.dll",         // The current version of a component.
-                @"C:\MyComponents\v1.0\MyNDP1Control.dll",                               // A control that only has an NDP 1.0 version
-                @"C:\MyComponents\v2.0\MyControlWithPastTargetNDPVersion.dll",           // The current version of a component.
-                @"C:\MyComponents\v1.0\MyControlWithPastTargetNDPVersion.dll",           // The past version of a component.
+                Path.Combine(s_myComponentsV30Path, "MyControlWithFutureTargetNDPVersion.dll"),         // The future version of a component.
+                Path.Combine(s_myComponentsV20Path, "MyControlWithFutureTargetNDPVersion.dll"),         // The current version of a component.
+                Path.Combine(s_myComponentsV10Path, "MyNDP1Control.dll"),                               // A control that only has an NDP 1.0 version
+                Path.Combine(s_myComponentsV20Path, "MyControlWithPastTargetNDPVersion.dll"),           // The current version of a component.
+                Path.Combine(s_myComponentsV10Path, "MyControlWithPastTargetNDPVersion.dll"),           // The past version of a component.
                 @"C:\MyComponentServicePack\MyControlWithServicePack.dll",               // The service pack 1 version of the control
                 @"C:\MyComponentBase\MyControlWithServicePack.dll",                      // The non-service pack version of the control.
                 @"C:\MyComponentServicePack2\MyControlWithServicePack.dll",              // The service pack 1 version of the control
@@ -421,9 +439,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             // ==[Unification Testing]============================================================================================================
             //@"C:\MyComponents\v0.5\UnifyMe.dll",                                 // For unification testing, a version that doesn't exist.
-            @"C:\MyComponents\v1.0\UnifyMe.dll",
-                @"C:\MyComponents\v2.0\UnifyMe.dll",
-                @"C:\MyComponents\v3.0\UnifyMe.dll",
+            s_unifyMeDll_V10Path,
+                s_unifyMeDll_V20Path,
+                s_unifyMeDll_V30Path,
             //@"C:\MyComponents\v4.0\UnifyMe.dll",
             @"C:\MyApp\v0.5\DependsOnUnified.dll",
                 @"C:\MyApp\v1.0\DependsOnUnified.dll",
@@ -436,18 +454,18 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // ==[Unification Testing]============================================================================================================
 
             // ==[Test assemblies reference higher versions than the current target framework=====================================================
-            @"c:\MyComponents\misc\DependsOnOnlyv4Assemblies.dll",  // Only depends on 4.0.0 assemblies
-                @"c:\MyComponents\misc\ReferenceVersion9.dll", //Is in redist list and is a 9.0 assembly
-                @"c:\MyComponents\misc\DependsOn9.dll", //Depends on 9.0 assemblies
-                @"c:\MyComponents\misc\DependsOn9Also.dll", // Depends on 9.0 assemblies
-                @"c:\MyComponents\1.0\DependsOn9.dll", // Depends on 9.0 assemblies
-                @"c:\MyComponents\2.0\DependsOn9.dll", // Depends on 9.0 assemblies
+            Path.Combine(s_myComponentsMiscPath, "DependsOnOnlyv4Assemblies.dll"),  // Only depends on 4.0.0 assemblies
+                Path.Combine(s_myComponentsMiscPath, "ReferenceVersion9.dll"), //Is in redist list and is a 9.0 assembly
+                Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll"), //Depends on 9.0 assemblies
+                Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"), // Depends on 9.0 assemblies
+                Path.Combine(s_myComponents10Path, "DependsOn9.dll"), // Depends on 9.0 assemblies
+                Path.Combine(s_myComponents20Path, "DependsOn9.dll"), // Depends on 9.0 assemblies
                 @"c:\Regress444809\A.dll",
                 @"c:\Regress444809\v2\A.dll",
                 @"c:\Regress444809\B.dll",
                 @"c:\Regress444809\C.dll",
                 @"c:\Regress444809\D.dll",
-                @"c:\MyComponents\4.0Component\DependsOnOnlyv4Assemblies.dll",
+                s_40ComponentDependsOnOnlyv4AssembliesDllPath,
                 @"C:\Regress714052\MSIL\a.dll",
                 @"C:\Regress714052\X86\a.dll",
                 @"C:\Regress714052\NONE\a.dll",
@@ -459,12 +477,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"C:\Regress714052\Mix\b.dll",
                 @"C:\Regress714052\Mix\b.winmd",
 
-                @"C:\MyComponents\X.dll",
-                @"C:\MyComponents\Y.dll",
-                @"C:\MyComponents\Z.dll",
+                Path.Combine(s_myComponentsRootPath, "X.dll"),
+                Path.Combine(s_myComponentsRootPath, "Y.dll"),
+                Path.Combine(s_myComponentsRootPath, "Z.dll"),
 
-                @"C:\MyComponents\Microsoft.Build.dll",
-                @"C:\MyComponents\DependsOnMSBuild12.dll",
+                Path.Combine(s_myComponentsRootPath, "Microsoft.Build.dll"),
+                Path.Combine(s_myComponentsRootPath, "DependsOnMSBuild12.dll"),
 
             // WinMD sample files
             @"C:\WinMD\v4\mscorlib.dll",  // Fake 4.0 mscorlib so we can actually resolve it for one of the tests. With a version of 4
@@ -1184,12 +1202,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
 
-            if (String.Compare(path, @"C:\MyComponents\v0.5\UnifyMe.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_unifyMeDll_V05Path, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 throw new FileNotFoundException();
             }
 
-            if (String.Compare(path, @"C:\MyComponents\v1.0\UnifyMe.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_unifyMeDll_V10Path, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("UnifyMe, Version=1.0.0.0, Culture=nEUtral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL");
             }
@@ -1240,12 +1258,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension("DependsOnUnified, Version=3.0.0.0, Culture=neutral, PublicKEYToken=b77a5c561934e089");
             }
 
-            if (String.Compare(path, @"C:\MyComponents\v2.0\UnifyMe.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_unifyMeDll_V20Path, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyTOKEn=b77a5c561934e089");
             }
 
-            if (String.Compare(path, @"C:\MyComponents\v3.0\UnifyMe.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_unifyMeDll_V30Path, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("UnifyMe, Version=3.0.0.0, Culture=neutral, PublICkeyToken=b77a5c561934e089");
             }
@@ -1270,35 +1288,35 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             // Set up assembly names for testing target framework version checks
             // Is version 4 and will only depends on 4.0 assemblies
-            if (String.Compare(path, @"c:\MyComponents\4.0Component\DependsOnOnlyv4Assemblies.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_40ComponentDependsOnOnlyv4AssembliesDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnOnlyv4Assemblies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
 
             // Is version 9 and will not have any dependencies, will be in the redist list
-            if (String.Compare(path, @"c:\MyComponents\misc\ReferenceVersion9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsMiscPath, "ReferenceVersion9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("ReferenceVersion9, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
 
             // Is a third party assembly which depends on a version 9 assembly
-            if (String.Compare(path, @"c:\MyComponents\misc\DependsOn9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOn9, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
 
             //A second assembly which depends on version 9 framework assemblies.
-            if (String.Compare(path, @"c:\MyComponents\misc\DependsOn9Also.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOn9Also, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
 
-            if (String.Compare(path, @"c:\MyComponents\1.0\DependsOn9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponents10Path, "DependsOn9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOn9, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
 
-            if (String.Compare(path, @"c:\MyComponents\2.0\DependsOn9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponents20Path, "DependsOn9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOn9, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
@@ -1375,27 +1393,27 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 return new AssemblyNameExtension("B, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
-            if (String.Compare(path, @"c:\MyComponents\X.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "X.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("X, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\MyComponents\Z.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "Z.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("Z, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\MyComponents\Y.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "Y.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("Y, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\MyComponents\Microsoft.Build.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "Microsoft.Build.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("Microsoft.Build, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             }
 
-            if (String.Compare(path, @"c:\MyComponents\DependsOnMSBuild12.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "DependsOnMSBuild12.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnMSBuild12, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
@@ -2017,7 +2035,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyComponents\MyGrid.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "MyGrid.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2136,7 +2154,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             // Set up assembly names for testing target framework version checks
             // Is version 4 and will only depends on 4.0 assemblies
-            if (String.Compare(path, @"c:\MyComponents\4.0Component\DependsOnOnlyv4Assemblies.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_40ComponentDependsOnOnlyv4AssembliesDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2145,7 +2163,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
             // Is version 9 and will not have any dependencies, will be in the redist list
-            if (String.Compare(path, @"c:\MyComponents\misc\ReferenceVersion9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsMiscPath, "ReferenceVersion9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2155,7 +2173,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
             // Is a third party assembly which depends on a version 9 assembly
-            if (String.Compare(path, @"c:\MyComponents\misc\DependsOn9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2165,7 +2183,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
             //A second assembly which depends on version 9 framework assemblies.
-            if (String.Compare(path, @"c:\MyComponents\misc\DependsOn9Also.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2173,7 +2191,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\1.0\DependsOn9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponents10Path, "DependsOn9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2181,7 +2199,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\2.0\DependsOn9.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponents20Path, "DependsOn9.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2214,7 +2232,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\X.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "X.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2222,12 +2240,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\Z.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "Z.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[] { };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\Y.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "Y.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2235,12 +2253,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\Microsoft.Build.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "Microsoft.Build.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[] { };
             }
 
-            if (String.Compare(path, @"c:\MyComponents\DependsOnMSBuild12.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myComponentsRootPath, "DependsOnMSBuild12.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2641,7 +2659,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 if (String.Compare(subKey, @"Software\Microsoft\.NetFramework\v3.0\AssemblyFoldersEx\Infragistics.MyControlWithFutureTargetNDPVersion.1.0", StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    return @"C:\MyComponents\v3.0";
+                    return s_myComponentsV30Path;
                 }
 
                 if
@@ -2651,7 +2669,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     || String.Compare(subKey, @"Software\Microsoft\.NetFramework\v2.0.50727\AssemblyFoldersEx\Infragistics.MyControlWithServicePack.1.0", StringComparison.OrdinalIgnoreCase) == 0
                 )
                 {
-                    return @"C:\MyComponents\v2.0";
+                    return s_myComponentsV20Path;
                 }
 
                 if
@@ -2684,7 +2702,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     || String.Compare(subKey, @"Software\Microsoft\.NetFramework\v1.0\AssemblyFoldersEx\Infragistics.MyControlWithPastTargetNDPVersion.1.0", StringComparison.OrdinalIgnoreCase) == 0
                 )
                 {
-                    return @"C:\MyComponents\v1.0";
+                    return s_myComponentsV10Path;
                 }
 
                 if (String.Compare(subKey, @"SOFTWARE\Microsoft\.NETCompactFramework\v2.0.3600\PocketPC\AssemblyFoldersEx\AFETestDeviceControl", StringComparison.OrdinalIgnoreCase) == 0)
@@ -3199,7 +3217,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
                 // Construct the app.config.
@@ -3241,7 +3259,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
 
@@ -3294,7 +3312,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
 
@@ -3439,7 +3457,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
                 // Construct the app.config.
@@ -3492,7 +3510,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
                 // Construct the app.config.
@@ -3545,7 +3563,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
                 // Construct the app.config.
@@ -3596,7 +3614,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v0.5\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V05Path)
                     };
 
                 // Construct the app.config.
@@ -3918,7 +3936,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             /// <value></value>
             new internal string[] DefaultPaths
             {
-                get { return new string[] { @"C:\MyComponents\v0.5", @"C:\MyComponents\v1.0", @"C:\MyComponents\v2.0", @"C:\MyComponents\v3.0" }; }
+                get { return new string[] { s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
             }
 
 
@@ -4204,7 +4222,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             /// <value></value>
             new internal string[] DefaultPaths
             {
-                get { return new string[] { @"C:\MyApp\v0.5", @"C:\MyApp\v1.0", @"C:\MyComponents\v0.5", @"C:\MyComponents\v1.0", @"C:\MyComponents\v2.0", @"C:\MyComponents\v3.0" }; }
+                get { return new string[] { @"C:\MyApp\v0.5", @"C:\MyApp\v1.0", s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
             }
 
 
@@ -4863,7 +4881,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             /// <value></value>
             new internal string[] DefaultPaths
             {
-                get { return new string[] { @"C:\MyApp\v0.5", @"C:\MyApp\v1.0", @"C:\MyApp\v2.0", @"C:\MyApp\v3.0", @"C:\MyComponents\v0.5", @"C:\MyComponents\v1.0", @"C:\MyComponents\v2.0", @"C:\MyComponents\v3.0" }; }
+                get { return new string[] { @"C:\MyApp\v0.5", @"C:\MyApp\v1.0", @"C:\MyApp\v2.0", @"C:\MyApp\v3.0", s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
             }
 
 
@@ -4910,7 +4928,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 Assert.IsTrue(succeeded);
                 AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                AssertNoCase(@"C:\MyComponents\v2.0\UnifyMe.dll", t.ResolvedDependencyFiles[0].ItemSpec);
+                AssertNoCase(s_unifyMeDll_V20Path, t.ResolvedDependencyFiles[0].ItemSpec);
 
                 engine.AssertLogContains
                 (
@@ -4985,7 +5003,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     Assert.IsTrue(t.ResolvedFiles[0].ItemSpec.Contains(@"C:\MyApp\v1.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
                     Assert.IsTrue(t.ResolvedDependencyFiles.Length == 1, "Expected there to be two resolved dependencies");
                     AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                    AssertNoCase(@"C:\MyComponents\v1.0\UnifyMe.dll", t.ResolvedDependencyFiles[0].ItemSpec);
+                    AssertNoCase(s_unifyMeDll_V10Path, t.ResolvedDependencyFiles[0].ItemSpec);
 
                     engine.AssertLogDoesntContain
                     (
@@ -5224,7 +5242,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"C:\MyApp\v1.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
                 Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"C:\MyApp\v2.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to be the item spec of the 2.0.0.0 assembly");
                 AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                AssertNoCase(@"C:\MyComponents\v2.0\UnifyMe.dll", t.ResolvedDependencyFiles[0].ItemSpec);
+                AssertNoCase(s_unifyMeDll_V20Path, t.ResolvedDependencyFiles[0].ItemSpec);
 
                 engine.AssertLogContains
                 (
@@ -5284,7 +5302,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 Assert.IsTrue(succeeded);
                 AssertNoCase("UnifyMe, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                AssertNoCase(@"C:\MyComponents\v3.0\UnifyMe.dll", t.ResolvedDependencyFiles[0].ItemSpec);
+                AssertNoCase(s_unifyMeDll_V30Path, t.ResolvedDependencyFiles[0].ItemSpec);
 
                 engine.AssertLogContains
                 (
@@ -5898,7 +5916,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOnOnlyv4Assemblies.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOnOnlyv4Assemblies.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5944,7 +5962,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.IsTrue(t.ResolvedFiles[0].GetMetadata("OriginalItemSpec").Equals("AnotherOne", StringComparison.OrdinalIgnoreCase));
 
-            Assert.IsTrue(t.ResolvedFiles[0].ItemSpec.Equals(@"c:\MyComponents\misc\ReferenceVersion9.dll", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(t.ResolvedFiles[0].ItemSpec.Equals(Path.Combine(s_myComponentsMiscPath, "ReferenceVersion9.dll"), StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -6075,7 +6093,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             e.AssertLogDoesntContain("MSB3257");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\ReferenceVersion9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "ReferenceVersion9.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -6184,7 +6202,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             e.AssertLogDoesntContain("MSB3257");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -6217,8 +6235,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             e.AssertLogContains(t.Log.FormatResourceString("ResolveAssemblyReference.DependencyReferenceOutsideOfFramework", "DependsOn9Also", "System, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "9.0.0.0", "4.0.0.0"));
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to not find assembly, but did.");
-            Assert.IsFalse(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9Also.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to not find assembly, but did.");
+            Assert.IsFalse(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -6251,8 +6269,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             e.AssertLogDoesntContain("MSB3258");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(2, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9Also.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -6309,7 +6327,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                                   "</FileList >";
 
             List<string> additionalPaths = new List<string>();
-            additionalPaths.Add(@"c:\MyComponents\4.0Component\");
+            additionalPaths.Add(s_myComponents40ComponentPath);
             additionalPaths.Add(s_myVersion40Path);
             additionalPaths.Add(s_myVersion90Path + Path.DirectorySeparatorChar);
 
@@ -6321,8 +6339,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(2, t.ResolvedFiles.Length);
             Assert.AreEqual(2, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\4.0Component\DependsOnOnlyv4Assemblies.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_40ComponentDependsOnOnlyv4AssembliesDllPath), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -6350,7 +6368,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                                   "</FileList >";
 
             List<string> additionalPaths = new List<string>();
-            additionalPaths.Add(@"c:\MyComponents\4.0Component\");
+            additionalPaths.Add(s_myComponents40ComponentPath);
             additionalPaths.Add(s_myVersion40Path);
             additionalPaths.Add(s_myVersion90Path + Path.DirectorySeparatorChar);
 
@@ -6362,8 +6380,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\4.0Component\DependsOnOnlyv4Assemblies.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsFalse(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_40ComponentDependsOnOnlyv4AssembliesDllPath), "Expected to find assembly, but didn't.");
+            Assert.IsFalse(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
         }
     }
 
@@ -6402,7 +6420,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
 
             // Do the resolution without the metadata, expect it to not work since we should not be able to find Dependson9 version 10.0.0.0
             e = new MockEngine();
@@ -6455,7 +6473,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
 
             // Do the resolution without the metadata, expect it to not work since we should not be able to find Dependson9 version 10.0.0.0
             e = new MockEngine();
@@ -6508,7 +6526,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyComponents\misc\DependsOn9.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -6521,7 +6539,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             TaskItem item = new TaskItem("DependsOn9, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             item.SetMetadata("IgnoreVersionForFrameworkReference", "True");
-            item.SetMetadata("HintPath", @"c:\MyComponents\misc\DependsOn9.dll");
+            item.SetMetadata("HintPath", Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll"));
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -7445,7 +7463,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.BuildEngine = engine;
             t.Assemblies = assemblyNames;
-            t.SearchPaths = new string[] { @"c:\MyComponents" };
+            t.SearchPaths = new string[] { s_myComponentsRootPath };
             t.CopyLocalDependenciesWhenParentReferenceInGac = false;
             bool succeeded = Execute(t);
 
@@ -7476,7 +7494,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.BuildEngine = engine;
             t.Assemblies = assemblyNames;
-            t.SearchPaths = new string[] { @"c:\MyComponents" };
+            t.SearchPaths = new string[] { s_myComponentsRootPath };
             t.TargetFrameworkMoniker = "I am a random frameworkName";
             bool succeeded = Execute(t);
 
@@ -7514,7 +7532,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.BuildEngine = engine;
             t.Assemblies = assemblyNames;
-            t.SearchPaths = new string[] { @"c:\MyComponents" };
+            t.SearchPaths = new string[] { s_myComponentsRootPath };
             t.CopyLocalDependenciesWhenParentReferenceInGac = false;
             bool succeeded = Execute(t);
 
@@ -7566,7 +7584,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.BuildEngine = engine;
             t.Assemblies = assemblyNames;
-            t.SearchPaths = new string[] { @"c:\MyComponents" };
+            t.SearchPaths = new string[] { s_myComponentsRootPath };
             t.CopyLocalDependenciesWhenParentReferenceInGac = true;
             bool succeeded = Execute(t);
 
@@ -7606,7 +7624,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.BuildEngine = engine;
             t.Assemblies = assemblyNames;
-            t.SearchPaths = new string[] { @"c:\MyComponents" };
+            t.SearchPaths = new string[] { s_myComponentsRootPath };
             t.CopyLocalDependenciesWhenParentReferenceInGac = true;
             bool succeeded = Execute(t);
 
@@ -8993,7 +9011,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.AreEqual(@"C:\MyComponents\v2.0\MyControlWithFutureTargetNDPVersion.dll", t.ResolvedFiles[0].ItemSpec);
+            Assert.AreEqual(Path.Combine(s_myComponentsV20Path, "MyControlWithFutureTargetNDPVersion.dll"), t.ResolvedFiles[0].ItemSpec);
         }
 
         /// <summary>
@@ -9012,7 +9030,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.AreEqual(@"C:\MyComponents\v1.0\MyNDP1Control.dll", t.ResolvedFiles[0].ItemSpec);
+            Assert.AreEqual(Path.Combine(s_myComponentsV10Path, "MyNDP1Control.dll"), t.ResolvedFiles[0].ItemSpec);
         }
 
         /// <summary>
@@ -9031,7 +9049,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.AreEqual(@"C:\MyComponents\v2.0\MyControlWithPastTargetNDPVersion.dll", t.ResolvedFiles[0].ItemSpec);
+            Assert.AreEqual(Path.Combine(s_myComponentsV20Path, "MyControlWithPastTargetNDPVersion.dll"), t.ResolvedFiles[0].ItemSpec);
         }
 
         /// <summary>
@@ -11904,7 +11922,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll"),
+                        new TaskItem(s_unifyMeDll_V10Path),
                         new TaskItem(Path.GetTempPath())
                     };
 
@@ -12323,7 +12341,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ITaskItem[] assemblyFiles = new TaskItem[]
                     {
-                        new TaskItem(@"C:\MyComponents\v1.0\UnifyMe.dll")
+                        new TaskItem(s_unifyMeDll_V10Path)
                     };
 
             // Construct the app.config.
@@ -15751,7 +15769,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
                 MockEngine e = new MockEngine();
                 t.BuildEngine = e;
-                t.AssemblyFiles = new ITaskItem[] { new TaskItem(@"c:\MyComponents\misc\DependsOn9Also.dll") };
+                t.AssemblyFiles = new ITaskItem[] { new TaskItem(Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll")) };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}", fullFrameworkDirectory };
                 t.TargetFrameworkDirectories = new string[] { targetFrameworkDirectory };
                 t.InstalledAssemblyTables = new ITaskItem[] { new TaskItem(profileRedistList) };
@@ -15763,7 +15781,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 bool success = Execute(t, false);
                 Assert.IsTrue(success, "Expected no errors.");
                 Assert.AreEqual(0, t.ResolvedFiles.Length, "Expected no resolved assemblies.");
-                string warningMessage = t.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", @"c:\MyComponents\misc\DependsOn9Also.dll", "System, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.TargetFrameworkMoniker);
+                string warningMessage = t.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"), "System, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.TargetFrameworkMoniker);
                 e.AssertLogContains(warningMessage);
             }
             finally
@@ -15799,7 +15817,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
                 MockEngine e = new MockEngine();
                 t.BuildEngine = e;
-                TaskItem item = new TaskItem(@"c:\MyComponents\misc\DependsOn9Also.dll");
+                TaskItem item = new TaskItem(Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"));
                 item.SetMetadata("SpecificVersion", "true");
                 t.AssemblyFiles = new ITaskItem[] { item };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}", fullFrameworkDirectory };
@@ -15812,7 +15830,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 bool success = Execute(t);
                 Assert.IsTrue(success, "Expected no errors.");
                 Assert.AreEqual(1, t.ResolvedFiles.Length, "Expected no resolved assemblies.");
-                string warningMessage = t.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", @"c:\MyComponents\misc\DependsOn9Also.dll", "System, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "Client");
+                string warningMessage = t.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"), "System, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "Client");
                 e.AssertLogDoesntContain(warningMessage);
             }
             finally
@@ -15946,7 +15964,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 t.BuildEngine = e;
                 TaskItem item = new TaskItem(@"DependsOnOnlyv4Assemblies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
                 t.Assemblies = new ITaskItem[] { item };
-                t.SearchPaths = new string[] { @"c:\MyComponents\4.0Component\", "{GAC}" };
+                t.SearchPaths = new string[] { s_myComponents40ComponentPath, "{GAC}" };
                 t.TargetFrameworkDirectories = new string[] { targetFrameworkDirectory };
                 t.InstalledAssemblyTables = new ITaskItem[] { new TaskItem(profileRedistList) };
                 t.IgnoreDefaultInstalledAssemblyTables = true;

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -212,6 +212,20 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_myComponents40ComponentPath = Path.Combine(s_myComponentsRootPath, "4.0Component");
         protected static readonly string s_40ComponentDependsOnOnlyv4AssembliesDllPath = Path.Combine(s_myComponents40ComponentPath, "DependsOnOnlyv4Assemblies.dll");
 
+        protected static readonly string s_myLibrariesRootPath = Path.Combine(s_rootPathPrefix, "MyLibraries");
+        protected static readonly string s_myLibraries_V1Path = Path.Combine(s_myLibrariesRootPath, "v1");
+        protected static readonly string s_myLibraries_V2Path = Path.Combine(s_myLibrariesRootPath, "v2");
+        protected static readonly string s_myLibraries_V1_EPath = Path.Combine(s_myLibraries_V1Path, "E");
+
+        protected static readonly string s_myLibraries_ADllPath = Path.Combine(s_myLibrariesRootPath, "A.dll");
+        protected static readonly string s_myLibraries_BDllPath = Path.Combine(s_myLibrariesRootPath, "B.dll");
+        protected static readonly string s_myLibraries_CDllPath = Path.Combine(s_myLibrariesRootPath, "C.dll");
+        protected static readonly string s_myLibraries_TDllPath = Path.Combine(s_myLibrariesRootPath, "T.dll");
+
+        protected static readonly string s_myLibraries_V1_DDllPath = Path.Combine(s_myLibraries_V1Path, "D.dll");
+        protected static readonly string s_myLibraries_V1_E_EDllPath = Path.Combine(s_myLibraries_V1_EPath, "E.dll");
+        protected static readonly string s_myLibraries_V2_DDllPath = Path.Combine(s_myLibraries_V2Path, "D.dll");
+
         /// <summary>
         /// Search paths to use.
         /// </summary>
@@ -368,14 +382,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"C:\MyComponentBase\MyControlWithServicePack.dll",                      // The non-service pack version of the control.
                 @"C:\MyComponentServicePack2\MyControlWithServicePack.dll",              // The service pack 1 version of the control
                 Path.Combine(s_myVersionPocket20Path, "mscorlib.dll"),  // A devices mscorlib.
-                @"c:\MyLibraries\A.dll",
+                s_myLibraries_ADllPath,
                 @"c:\MyExecutableLibraries\A.exe",
-                @"c:\MyLibraries\B.dll",
-                @"c:\MyLibraries\C.dll",
-                @"c:\MyLibraries\v1\D.dll",
-                @"c:\MyLibraries\v1\E\E.dll",
+                s_myLibraries_BDllPath,
+                s_myLibraries_CDllPath,
+                s_myLibraries_V1_DDllPath,
+                s_myLibraries_V1_E_EDllPath,
                 @"c:\RogueLibraries\v1\D.dll",
-                @"c:\MyLibraries\v2\D.dll",
+                s_myLibraries_V2_DDllPath,
                 @"c:\MyStronglyNamed\A.dll",
                 @"c:\MyWeaklyNamed\A.dll",
                 @"c:\MyInaccessible\A.dll",
@@ -1184,7 +1198,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension(AssemblyRef.SystemData);
             }
 
-            if (path.EndsWith(@"c:\MyLibraries\v1\D.dll"))
+            if (path.EndsWith(s_myLibraries_V1_DDllPath))
             {
                 // Version 1 of D
                 return new AssemblyNameExtension("D, Version=1.0.0.0, CulTUre=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa");
@@ -1196,7 +1210,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension("D, VERsion=1.0.0.0, Culture=neutral, PublicKeyToken=bbbbbbbbbbbbbbbb");
             }
 
-            if (path.EndsWith(@"c:\MyLibraries\v1\E\E.dll"))
+            if (path.EndsWith(s_myLibraries_V1_E_EDllPath))
             {
                 return new AssemblyNameExtension("E, Version=0.0.0.0, Culture=neutral, PUBlicKeyToken=null");
             }
@@ -1268,7 +1282,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension("UnifyMe, Version=3.0.0.0, Culture=neutral, PublICkeyToken=b77a5c561934e089");
             }
 
-            if (path.EndsWith(@"c:\MyLibraries\v2\D.dll"))
+            if (path.EndsWith(s_myLibraries_V2_DDllPath))
             {
                 return new AssemblyNameExtension("D, VErsion=2.0.0.0, CulturE=neutral, PublicKEyToken=aaaaaaaaaaaaaaaa");
             }
@@ -2052,7 +2066,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
 
-            if (String.Compare(path, @"c:\MyLibraries\a.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_myLibraries_ADllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2060,7 +2074,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyLibraries\t.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_myLibraries_TDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2068,7 +2082,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyLibraries\b.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_myLibraries_BDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2076,7 +2090,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyLibraries\v1\d.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_myLibraries_V1_DDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2084,7 +2098,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyLibraries\v2\d.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_myLibraries_V2_DDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2092,7 +2106,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyLibraries\v1\E\E.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_myLibraries_V1_E_EDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -10694,16 +10708,16 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries",
-                @"c:\MyLibraries\v1",
-                @"c:\MyLibraries\v2"
+                s_myLibrariesRootPath,
+                s_myLibraries_V1Path,
+                s_myLibraries_V2Path
             };
 
             Execute(t);
 
             Assert.AreEqual(2, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\MyLibraries\v2\D.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V2_DDllPath), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
             Assert.AreEqual(1, t.SuggestedRedirects.Length);
             Assert.IsTrue(ContainsItem(t.SuggestedRedirects, @"D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa"), "Expected to find suggested redirect, but didn't");
             Assert.IsTrue(e.Warnings == 1, "Should only be one warning for suggested redirects.");
@@ -10734,7 +10748,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.SearchPaths = new string[] {
-                @"c:\MyLibraries", @"c:\MyLibraries\v1", @"c:\MyLibraries\v2"
+                s_myLibrariesRootPath, s_myLibraries_V1Path, s_myLibraries_V2Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -10757,9 +10771,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                         ),
                         "D, Culture=neutral, PublicKeyToken=aaaaaaaaaaaaaaaa",
                         "1.0.0.0",
-                        "c:\\MyLibraries\\v1\\D.dll",
+                        s_myLibraries_V1_DDllPath,
                         "2.0.0.0",
-                        "c:\\MyLibraries\\v2\\D.dll"
+                        s_myLibraries_V2_DDllPath
                     )
                 )
             );
@@ -10883,7 +10897,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.SearchPaths = new string[] {
-                @"c:\MyLibraries", @"c:\MyLibraries\v1", @"c:\MyLibraries\v2"
+                s_myLibrariesRootPath, s_myLibraries_V1Path, s_myLibraries_V2Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -10926,7 +10940,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V2Path, s_myLibraries_V1Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -10937,7 +10951,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.AreEqual(0, t.SuggestedRedirects.Length);
             Assert.AreEqual(3, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -10964,7 +10978,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V2Path, s_myLibraries_V1Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -10975,7 +10989,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.AreEqual(0, t.SuggestedRedirects.Length);
             Assert.AreEqual(3, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -11007,7 +11021,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.SearchPaths = new string[] {
-                @"c:\MyLibraries", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V2Path, s_myLibraries_V1Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -11016,7 +11030,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.IsTrue(result, @"Expected a success because this conflict is solvable.");
             Assert.AreEqual(3, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v2\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V2_DDllPath), "Expected to find assembly, but didn't.");
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
         }
 
@@ -11047,7 +11061,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V2Path, s_myLibraries_V1Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -11056,8 +11070,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.IsTrue(e.Warnings == 2, @"Expected a warning because this is an unresolvable conflict.");
             Assert.AreEqual(2, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v2\D.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V2_DDllPath), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -11084,15 +11098,15 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.SearchPaths = new string[] {
-                @"c:\MyLibraries", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V2Path, s_myLibraries_V1Path
             };
 
             bool result = Execute(t);
 
             Assert.IsTrue(result, @"Expected success because this conflict is solvable.");
             Assert.AreEqual(2, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v2\D.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V2_DDllPath), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -11121,7 +11135,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v1", @"c:\RogueLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V1Path, @"c:\RogueLibraries\v1"
             };
 
             bool result = Execute(t);
@@ -11157,13 +11171,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v1", @"c:\RogueLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V1Path, @"c:\RogueLibraries\v1"
             };
 
             Execute(t);
 
             Assert.AreEqual(3, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -11290,7 +11304,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries",
+                s_myLibrariesRootPath,
                 @"c:\MyExecutableLibraries"
             };
 
@@ -11330,7 +11344,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.SearchPaths = new string[]
             {
                 @"c:\MyExecutableLibraries",
-                @"c:\MyLibraries"
+                s_myLibrariesRootPath
             };
 
             Execute(t);
@@ -11338,7 +11352,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\a.DlL"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_ADllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -11367,7 +11381,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries",
+                s_myLibrariesRootPath,
                 @"c:\MyExecutableLibraries"
             };
 
@@ -11376,7 +11390,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\a.DlL"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_ADllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -11406,7 +11420,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.SearchPaths = new string[]
             {
                 @"c:\MyExecutableLibraries",
-                @"c:\MyLibraries"
+                s_myLibrariesRootPath
             };
 
             Execute(t);
@@ -11448,7 +11462,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.SearchPaths = new string[]
             {
                 @"c:\MyStronglyNamed",
-                @"c:\MyLibraries"
+                s_myLibrariesRootPath
             };
 
             Execute(t);
@@ -11486,7 +11500,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.SearchPaths = new string[]
             {
                 @"c:\MyStronglyNamed",
-                @"c:\MyLibraries"
+                s_myLibrariesRootPath
             };
 
             Execute(t);
@@ -11522,7 +11536,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1"
+                s_myLibrariesRootPath, s_myLibraries_V2Path, s_myLibraries_V1Path
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -11530,7 +11544,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             bool result = Execute(t);
 
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
         }
 
 
@@ -11575,7 +11589,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v1", @"c:\MyLibraries\v1\E"
+                s_myLibrariesRootPath, s_myLibraries_V1Path, s_myLibraries_V1_EPath
             };
             t.TargetFrameworkDirectories = new string[] { @"c:\myfx" };
 
@@ -11583,13 +11597,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.AreEqual(2, t.ResolvedFiles.Length);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length); // Not 2 because D is treated as a primary reference.
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\MyLibraries\v1\E\E.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_E_EDllPath), "Expected to find assembly, but didn't.");
             Assert.AreEqual(0, engine.Warnings);
             Assert.AreEqual(0, engine.Errors);
 
             foreach (ITaskItem item in t.ResolvedDependencyFiles)
             {
-                if (0 == String.Compare(item.ItemSpec, @"c:\MyLibraries\v1\E\E.dll", StringComparison.OrdinalIgnoreCase))
+                if (0 == String.Compare(item.ItemSpec, s_myLibraries_V1_E_EDllPath, StringComparison.OrdinalIgnoreCase))
                 {
                     Assert.AreEqual("false", item.GetMetadata("CopyLocal"));
                 }
@@ -11636,7 +11650,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries", @"c:\MyLibraries\v1", @"c:\MyLibraries\v2", @"c:\MyLibraries\v1\E"
+                s_myLibrariesRootPath, s_myLibraries_V1Path, s_myLibraries_V2Path, s_myLibraries_V1_EPath
             };
             t.TargetFrameworkDirectories = new string[] { @"c:\myfx" };
 
@@ -11644,17 +11658,17 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.AreEqual(2, t.ResolvedFiles.Length);
             Assert.AreEqual(3, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\MyLibraries\v1\D.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\MyLibraries\v1\E\E.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_DDllPath), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, s_myLibraries_V1_E_EDllPath), "Expected to find assembly, but didn't.");
 
             foreach (ITaskItem item in t.ResolvedDependencyFiles)
             {
-                if (0 == String.Compare(item.ItemSpec, @"c:\MyLibraries\v1\D.dll", StringComparison.OrdinalIgnoreCase))
+                if (0 == String.Compare(item.ItemSpec, s_myLibraries_V1_DDllPath, StringComparison.OrdinalIgnoreCase))
                 {
                     Assert.AreEqual("false", item.GetMetadata("CopyLocal"));
                 }
 
-                if (0 == String.Compare(item.ItemSpec, @"c:\MyLibraries\v1\E\E.dll", StringComparison.OrdinalIgnoreCase))
+                if (0 == String.Compare(item.ItemSpec, s_myLibraries_V1_E_EDllPath, StringComparison.OrdinalIgnoreCase))
                 {
                     Assert.AreEqual("true", item.GetMetadata("CopyLocal"));
                 }
@@ -12288,7 +12302,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries"
+                s_myLibrariesRootPath
             };
 
             Execute(t);
@@ -12296,7 +12310,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\a.DlL"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_ADllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -12315,7 +12329,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 new TaskItem("A")
             };
 
-            t.TargetFrameworkDirectories = new string[] { @"c:\boguslocation", @"c:\MyLibraries" };
+            t.TargetFrameworkDirectories = new string[] { @"c:\boguslocation", s_myLibrariesRootPath };
             t.SearchPaths = new string[]
             {
                 @"{TargetFrameworkDirectory}",
@@ -12326,7 +12340,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\MyLibraries\a.DlL"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_myLibraries_ADllPath), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -15388,7 +15402,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             t.SearchPaths = new string[]
             {
-                @"c:\MyLibraries"
+                s_myLibrariesRootPath
             };
 
             t.Assemblies[1].SetMetadata("RequiredTargetFramework", "3.0");

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -192,6 +192,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_myMissingAssemblyRelPath = Path.Combine("MyProject", "MyMissingAssembly.dll");
         protected static readonly string s_myPrivateAssemblyRelPath = Path.Combine("MyProject", "MyPrivateAssembly.exe");
 
+        protected static readonly string s_frameworksPath = Path.Combine(s_rootPathPrefix, "Frameworks");
+
         /// <summary>
         /// Search paths to use.
         /// </summary>
@@ -286,12 +288,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         private static List<string> s_existentFiles = new List<string>
             {
-                @"c:\Frameworks\DependsOnFoo4Framework.dll",
-                @"c:\Frameworks\DependsOnFoo45Framework.dll",
-                @"c:\Frameworks\DependsOnFoo35Framework.dll",
-                @"c:\Frameworks\IndirectDependsOnFoo45Framework.dll",
-                @"c:\Frameworks\IndirectDependsOnFoo4Framework.dll",
-                @"c:\Frameworks\IndirectDependsOnFoo35Framework.dll",
+                Path.Combine(s_frameworksPath, "DependsOnFoo4Framework.dll"),
+                Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll"),
+                Path.Combine(s_frameworksPath, "DependsOnFoo35Framework.dll"),
+                Path.Combine(s_frameworksPath, "IndirectDependsOnFoo45Framework.dll"),
+                Path.Combine(s_frameworksPath, "IndirectDependsOnFoo4Framework.dll"),
+                Path.Combine(s_frameworksPath, "IndirectDependsOnFoo35Framework.dll"),
                 Path.Combine(Path.GetTempPath(), @"RawFileNameRelative\System.Xml.dll"),
                 Path.Combine(Path.GetTempPath(), @"RelativeAssemblyFiles\System.Xml.dll"),
                 Path.Combine(s_myVersion20Path, "System.Data.dll"),
@@ -997,17 +999,17 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 throw new FileNotFoundException(path);
             }
 
-            if (String.Compare(path, @"c:\Frameworks\DependsOnFoo45Framework.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnFoo45Framework, Version=4.5.0.0, PublicKeyToken=null, Culture=Neutral");
             }
 
-            if (String.Compare(path, @"c:\Frameworks\DependsOnFoo4Framework.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_frameworksPath, "DependsOnFoo4Framework.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnFoo4Framework, Version=4.0.0.0, PublicKeyToken=null, Culture=Neutral");
             }
 
-            if (String.Compare(path, @"c:\Frameworks\DependsOnFoo35Framework.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_frameworksPath, "DependsOnFoo35Framework.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnFoo35Framework, Version=3.5.0.0, PublicKeyToken=null, Culture=Neutral");
             }
@@ -1674,27 +1676,27 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             FrameworkNameVersioning frameworkName = null;
 
-            if (String.Equals(path, @"c:\Frameworks\DependsOnFoo4Framework.dll", StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(path, Path.Combine(s_frameworksPath, "DependsOnFoo4Framework.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 frameworkName = new FrameworkNameVersioning("FoO, Version=v4.0");
             }
-            else if (String.Equals(path, @"c:\Frameworks\DependsOnFoo45Framework.dll", StringComparison.OrdinalIgnoreCase))
+            else if (String.Equals(path, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 frameworkName = new FrameworkNameVersioning("FoO, Version=v4.5");
             }
-            else if (String.Equals(path, @"c:\Frameworks\DependsOnFoo35Framework.dll", StringComparison.OrdinalIgnoreCase))
+            else if (String.Equals(path, Path.Combine(s_frameworksPath, "DependsOnFoo35Framework.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 frameworkName = new FrameworkNameVersioning("FoO, Version=v3.5");
             }
-            else if (String.Equals(path, @"c:\Frameworks\IndirectDependsOnFoo4Framework.dll", StringComparison.OrdinalIgnoreCase))
+            else if (String.Equals(path, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo4Framework.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 frameworkName = new FrameworkNameVersioning("FoO, Version=v4.0");
             }
-            else if (String.Equals(path, @"c:\Frameworks\IndirectDependsOnFoo45Framework.dll", StringComparison.OrdinalIgnoreCase))
+            else if (String.Equals(path, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo45Framework.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 frameworkName = new FrameworkNameVersioning("FoO, Version=v4.0");
             }
-            else if (String.Equals(path, @"c:\Frameworks\IndirectDependsOnFoo35Framework.dll", StringComparison.OrdinalIgnoreCase))
+            else if (String.Equals(path, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo35Framework.dll"), StringComparison.OrdinalIgnoreCase))
             {
                 frameworkName = new FrameworkNameVersioning("FoO, Version=v4.0");
             }
@@ -1709,7 +1711,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <returns>The array of dependent assembly names.</returns>
         internal static AssemblyNameExtension[] GetDependencies(string path)
         {
-            if (String.Compare(path, @"c:\Frameworks\IndirectDependsOnFoo4Framework.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo4Framework.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -1717,7 +1719,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\Frameworks\IndirectDependsOnFoo45Framework.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo45Framework.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -1725,7 +1727,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\Frameworks\IndirectDependsOnFoo35Framework.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo35Framework.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -5524,13 +5526,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "BAR, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "BAR";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\DependsOnFoo4Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "DependsOnFoo4Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5551,13 +5553,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=v4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\DependsOnFoo35Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "DependsOnFoo35Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5578,13 +5580,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\DependsOnFoo4Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "DependsOnFoo4Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5608,13 +5610,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\DependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5635,15 +5637,15 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=v4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\IndirectDependsOnFoo35Framework.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\Frameworks\DependsOnFoo35Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo35Framework.dll")), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, Path.Combine(s_frameworksPath, "DependsOnFoo35Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5664,15 +5666,15 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\IndirectDependsOnFoo4Framework.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\Frameworks\DependsOnFoo4Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo4Framework.dll")), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, Path.Combine(s_frameworksPath, "DependsOnFoo4Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5696,15 +5698,15 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t);
 
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\IndirectDependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\Frameworks\DependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5727,7 +5729,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t, false);
 
             Assert.IsTrue(e.Warnings == 1, "One warning expected in this scenario.");
@@ -5757,7 +5759,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             t.IgnoreTargetFrameworkAttributeVersionMismatch = true;
             Execute(t);
 
@@ -5765,8 +5767,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\IndirectDependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
-            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, @"c:\Frameworks\DependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "IndirectDependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedDependencyFiles, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
         /// <summary>
@@ -5789,7 +5791,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             t.IgnoreTargetFrameworkAttributeVersionMismatch = true;
 
             Execute(t);
@@ -5797,7 +5799,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Warnings == 0, "No warnings expected in this scenario.");
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\DependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
         }
 
 
@@ -5821,7 +5823,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.Assemblies = items;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Execute(t, false);
 
             Assert.IsTrue(e.Warnings == 1, "One warning expected in this scenario.");
@@ -5854,7 +5856,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             t.FindDependencies = false;
             t.TargetFrameworkMoniker = "Foo, Version=4.0";
             t.TargetFrameworkMonikerDisplayName = "Foo";
-            t.SearchPaths = new string[] { @"c:\Frameworks\" };
+            t.SearchPaths = new string[] { s_frameworksPath + Path.DirectorySeparatorChar };
             Assert.IsTrue(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
 
 
@@ -5862,7 +5864,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.IsTrue(e.Errors == 0, "No errors expected in this scenario.");
             Assert.AreEqual(1, t.ResolvedFiles.Length);
             Assert.AreEqual(0, t.ResolvedDependencyFiles.Length);
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"c:\Frameworks\DependsOnFoo45Framework.dll"), "Expected to find assembly, but didn't.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_frameworksPath, "DependsOnFoo45Framework.dll")), "Expected to find assembly, but didn't.");
         }
     }
 

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -229,6 +229,15 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_regress454863_ADllPath = Path.Combine(s_rootPathPrefix, "Regress454863", "A.dll");
         protected static readonly string s_regress454863_BDllPath = Path.Combine(s_rootPathPrefix, "Regress454863", "B.dll");
 
+        protected static readonly string s_regress444809RootPath = Path.Combine(s_rootPathPrefix, "Regress444809");
+        protected static readonly string s_regress444809_ADllPath = Path.Combine(s_regress444809RootPath, "A.dll");
+        protected static readonly string s_regress444809_BDllPath = Path.Combine(s_regress444809RootPath, "B.dll");
+        protected static readonly string s_regress444809_CDllPath = Path.Combine(s_regress444809RootPath, "C.dll");
+        protected static readonly string s_regress444809_DDllPath = Path.Combine(s_regress444809RootPath, "D.dll");
+
+        protected static readonly string s_regress444809_V2RootPath = Path.Combine(s_regress444809RootPath, "v2");
+        protected static readonly string s_regress444809_V2_ADllPath = Path.Combine(s_regress444809_V2RootPath, "A.dll");
+
         /// <summary>
         /// Search paths to use.
         /// </summary>
@@ -477,11 +486,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"), // Depends on 9.0 assemblies
                 Path.Combine(s_myComponents10Path, "DependsOn9.dll"), // Depends on 9.0 assemblies
                 Path.Combine(s_myComponents20Path, "DependsOn9.dll"), // Depends on 9.0 assemblies
-                @"c:\Regress444809\A.dll",
-                @"c:\Regress444809\v2\A.dll",
-                @"c:\Regress444809\B.dll",
-                @"c:\Regress444809\C.dll",
-                @"c:\Regress444809\D.dll",
+                s_regress444809_ADllPath,
+                s_regress444809_V2_ADllPath,
+                s_regress444809_BDllPath,
+                s_regress444809_CDllPath,
+                s_regress444809_DDllPath,
                 s_40ComponentDependsOnOnlyv4AssembliesDllPath,
                 @"C:\Regress714052\MSIL\a.dll",
                 @"C:\Regress714052\X86\a.dll",
@@ -1338,31 +1347,31 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension("DependsOn9, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             }
 
-            if (String.Compare(path, @"c:\Regress444809\A.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_ADllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 // Simulate a strongly named assembly.
                 return new AssemblyNameExtension("A, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\Regress444809\v2\A.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_V2_ADllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 // Simulate a strongly named assembly.
                 return new AssemblyNameExtension("A, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\Regress444809\B.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_BDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 // Simulate a strongly named assembly.
                 return new AssemblyNameExtension("B, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\Regress444809\C.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_CDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 // Simulate a strongly named assembly.
                 return new AssemblyNameExtension("C, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"c:\Regress444809\D.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_DDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 // Simulate a strongly named assembly.
                 return new AssemblyNameExtension("D, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null");
@@ -2224,7 +2233,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\Regress444809\C.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_CDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2233,7 +2242,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\Regress444809\B.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_BDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2241,7 +2250,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\Regress444809\D.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress444809_DDllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -10813,7 +10822,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.SearchPaths = new string[] {
-                @"c:\Regress444809", @"c:\Regress444809\v2"
+                s_regress444809RootPath, s_regress444809_V2RootPath
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -10822,11 +10831,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ResourceManager resources = new ResourceManager("Microsoft.Build.Tasks.Strings", Assembly.GetExecutingAssembly());
 
             //Unresolved primary reference with itemspec "A, Version=20.0.0.0, Culture=Neutral, PublicKeyToken=null".
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null", @"c:\Regress444809\A.dll");
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null", @"c:\Regress444809\v2\A.dll");
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", @"c:\Regress444809\C.dll");
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", @"c:\Regress444809\B.dll");
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", @"c:\Regress444809\v2\a.dll");
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=1.0.0.0, Culture=Neutral, PublicKeyToken=null", s_regress444809_ADllPath);
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null", s_regress444809_V2_ADllPath);
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", s_regress444809_CDllPath);
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", s_regress444809_BDllPath);
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", s_regress444809_V2_ADllPath);
         }
 
         /// <summary>
@@ -10860,7 +10869,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.SearchPaths = new string[] {
-                @"c:\Regress444809", @"c:\Regress444809\v2"
+                s_regress444809RootPath, s_regress444809_V2RootPath
             };
 
             t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
@@ -10868,10 +10877,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             bool result = Execute(t);
 
             engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=20.0.0.0, Culture=Neutral, PublicKeyToken=null", String.Empty);
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null", @"c:\Regress444809\v2\A.dll");
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.ReferenceDependsOn", "A, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=null", s_regress444809_V2_ADllPath);
             engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.UnResolvedPrimaryItemSpec", "A, Version=20.0.0.0, Culture=Neutral, PublicKeyToken=null");
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", @"c:\Regress444809\D.dll");
-            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", @"c:\Regress444809\B.dll");
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", s_regress444809_DDllPath);
+            engine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.PrimarySourceItemsForReference", s_regress444809_BDllPath);
         }
 
         /// <summary>

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -238,6 +238,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_regress444809_V2RootPath = Path.Combine(s_regress444809RootPath, "v2");
         protected static readonly string s_regress444809_V2_ADllPath = Path.Combine(s_regress444809_V2RootPath, "A.dll");
 
+        protected static readonly string s_myAppRootPath = Path.Combine(s_rootPathPrefix, "MyApp");
+        protected static readonly string s_myApp_V05Path = Path.Combine(s_myAppRootPath, "v0.5");
+        protected static readonly string s_myApp_V10Path = Path.Combine(s_myAppRootPath, "v1.0");
+        protected static readonly string s_myApp_V20Path = Path.Combine(s_myAppRootPath, "v2.0");
+        protected static readonly string s_myApp_V30Path = Path.Combine(s_myAppRootPath, "v3.0");
+
         /// <summary>
         /// Search paths to use.
         /// </summary>
@@ -408,7 +414,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"c:\MyNameMismatch\Foo.dll",
                 @"c:\MyEscapedName\=A=.dll",
                 @"c:\MyEscapedName\__'ASP'dw0024ry.dll",
-                @"c:\MyApp\DependsOnSimpleA.dll",
+                Path.Combine(s_myAppRootPath, "DependsOnSimpleA.dll"),
                 @"C:\Regress312873\a.dll",
                 @"C:\Regress312873\b.dll",
                 @"C:\Regress312873-2\a.dll",
@@ -469,12 +475,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 s_unifyMeDll_V20Path,
                 s_unifyMeDll_V30Path,
             //@"C:\MyComponents\v4.0\UnifyMe.dll",
-            @"C:\MyApp\v0.5\DependsOnUnified.dll",
-                @"C:\MyApp\v1.0\DependsOnUnified.dll",
-                @"C:\MyApp\v2.0\DependsOnUnified.dll",
-                @"C:\MyApp\v3.0\DependsOnUnified.dll",
-                @"C:\MyApp\DependsOnWeaklyNamedUnified.dll",
-                @"C:\MyApp\v1.0\DependsOnEverettSystem.dll",
+            Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"),
+                Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"),
+                Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"),
+                Path.Combine(s_myApp_V30Path, "DependsOnUnified.dll"),
+                Path.Combine(s_myAppRootPath, "DependsOnWeaklyNamedUnified.dll"),
+                Path.Combine(s_myApp_V10Path, "DependsOnEverettSystem.dll"),
                 @"C:\Framework\Everett\System.dll",
                 @"C:\Framework\Whidbey\System.dll",
             // ==[Unification Testing]============================================================================================================
@@ -1249,12 +1255,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
 
 
-            if (String.Compare(path, @"C:\MyApp\v1.0\DependsOnEverettSystem.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V10Path, "DependsOnEverettSystem.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnEverettSystem, VersION=1.0.5000.0, Culture=neutral, PublicKeyToken=feedbeadbadcadbe");
             }
 
-            if (String.Compare(path, @"C:\MyApp\v0.5\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnUnified, Version=0.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
             }
@@ -1269,17 +1275,17 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 return new AssemblyNameExtension("C, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
             }
 
-            if (String.Compare(path, @"C:\MyApp\v1.0\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnUnified, VERSion=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
             }
 
-            if (String.Compare(path, @"C:\MyApp\v2.0\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnUnified, VeRSIon=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
             }
 
-            if (String.Compare(path, @"C:\MyApp\v3.0\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V30Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension("DependsOnUnified, Version=3.0.0.0, Culture=neutral, PublicKEYToken=b77a5c561934e089");
             }
@@ -2013,7 +2019,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"c:\MyApp\DependsOnSimpleA.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myAppRootPath, "DependsOnSimpleA.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2125,7 +2131,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyApp\v0.5\DependsOnWeaklyNamedUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V05Path, "DependsOnWeaklyNamedUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2133,7 +2139,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyApp\v1.0\DependsOnEverettSystem.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V10Path, "DependsOnEverettSystem.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2141,7 +2147,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyApp\v0.5\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2149,7 +2155,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyApp\v1.0\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2157,7 +2163,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyApp\v2.0\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -2165,7 +2171,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\MyApp\v3.0\DependsOnUnified.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, Path.Combine(s_myApp_V30Path, "DependsOnUnified.dll"), StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -3045,7 +3051,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             /// <value></value>
             new internal string[] DefaultPaths
             {
-                get { return new string[] { @"C:\MyApp\v1.0", @"C:\Framework\Whidbey", @"C:\Framework\Everett" }; }
+                get { return new string[] { s_myApp_V10Path, @"C:\Framework\Whidbey", @"C:\Framework\Everett" }; }
             }
 
             /// <summary>
@@ -3096,7 +3102,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByFrameworkRetarget"), "1.0.5000.0", @"C:\MyApp\v1.0\DependsOnEverettSystem.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByFrameworkRetarget"), "1.0.5000.0", Path.Combine(s_myApp_V10Path, "DependsOnEverettSystem.dll"))
                 );
 
                 engine.AssertLogContains
@@ -3137,7 +3143,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 t.BuildEngine = engine;
                 t.Assemblies = assemblyNames;
-                t.SearchPaths = new string[] { @"C:\MyApp\v1.0", @"C:\Framework\Everett" }; ;
+                t.SearchPaths = new string[] { s_myApp_V10Path, @"C:\Framework\Everett" }; ;
 
                 bool succeeded = Execute(t);
 
@@ -3145,7 +3151,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 Assert.AreEqual(0, t.ResolvedDependencyFiles.Length);
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByFrameworkRetarget"), "1.0.5000.0", @"C:\MyApp\v1.0\DependsOnEverettSystem.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByFrameworkRetarget"), "1.0.5000.0", Path.Combine(s_myApp_V10Path, "DependsOnEverettSystem.dll"))
                 );
             }
 
@@ -3449,7 +3455,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     Assert.AreEqual(0, t.ResolvedDependencyFiles.Length);
                     engine.AssertLogDoesntContain
                     (
-                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                     );
                 }
                 finally
@@ -4248,7 +4254,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             /// <value></value>
             new internal string[] DefaultPaths
             {
-                get { return new string[] { @"C:\MyApp\v0.5", @"C:\MyApp\v1.0", s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
+                get { return new string[] { s_myApp_V05Path, s_myApp_V10Path, s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
             }
 
 
@@ -4299,7 +4305,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                 );
 
                 // Cleanup.
@@ -4375,7 +4381,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     Assert.AreEqual(0, t.ResolvedDependencyFiles.Length);
                     engine.AssertLogDoesntContain
                     (
-                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                     );
                 }
                 finally
@@ -4431,6 +4437,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 t.AppConfigFile = appConfigFile;
 
                 bool succeeded = Execute(t);
+                Console.WriteLine (((MockEngine)(t.BuildEngine)).Log);
 
                 Assert.IsTrue(succeeded);
                 Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
@@ -4489,7 +4496,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                 );
 
                 // Cleanup.
@@ -4559,7 +4566,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                 );
 
                 engine.AssertLogContains
@@ -4621,7 +4628,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "0.5.0.0", appConfigFile, @"C:\MyApp\v0.5\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "0.5.0.0", appConfigFile, Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"))
                 );
 
                 // Cleanup.
@@ -4907,7 +4914,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             /// <value></value>
             new internal string[] DefaultPaths
             {
-                get { return new string[] { @"C:\MyApp\v0.5", @"C:\MyApp\v1.0", @"C:\MyApp\v2.0", @"C:\MyApp\v3.0", s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
+                get { return new string[] { s_myApp_V05Path, s_myApp_V10Path, s_myApp_V20Path, s_myApp_V30Path, s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
             }
 
 
@@ -4963,7 +4970,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                 );
             }
 
@@ -5026,7 +5033,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                     Assert.IsTrue(succeeded);
                     Assert.IsTrue(t.ResolvedFiles.Length == 1, "Expected there to only be one resolved file");
-                    Assert.IsTrue(t.ResolvedFiles[0].ItemSpec.Contains(@"C:\MyApp\v1.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
+                    Assert.IsTrue(t.ResolvedFiles[0].ItemSpec.Contains(Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll")), "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
                     Assert.IsTrue(t.ResolvedDependencyFiles.Length == 1, "Expected there to be two resolved dependencies");
                     AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
                     AssertNoCase(s_unifyMeDll_V10Path, t.ResolvedDependencyFiles[0].ItemSpec);
@@ -5038,7 +5045,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                     engine.AssertLogDoesntContain
                     (
-                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", @"C:\MyApp\v2.0\DependsOnUnified.dll")
+                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"))
                     );
                 }
                 finally
@@ -5120,7 +5127,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     Assert.AreEqual(0, t.ResolvedDependencyFiles.Length);
                     engine.AssertLogDoesntContain
                     (
-                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                        String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                     );
                 }
                 finally
@@ -5192,8 +5199,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     Assert.IsTrue(succeeded);
                     Assert.IsTrue(t.ResolvedFiles.Length == 0, "Expected there to be no resolved files");
 
-                    Assert.IsFalse(ContainsItem(t.ResolvedFiles, @"C:\MyApp\v1.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to not be the item spec of the 1.0.0.0 assembly");
-                    Assert.IsFalse(ContainsItem(t.ResolvedFiles, @"C:\MyApp\v2.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to not be the item spec of the 2.0.0.0 assembly");
+                    Assert.IsFalse(ContainsItem(t.ResolvedFiles, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll")), "Expected the ItemSpec of the resolved file to not be the item spec of the 1.0.0.0 assembly");
+                    Assert.IsFalse(ContainsItem(t.ResolvedFiles, Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll")), "Expected the ItemSpec of the resolved file to not be the item spec of the 2.0.0.0 assembly");
                     string stringList = ResolveAssemblyReference.GenerateSubSetName(null, new ITaskItem[] { new TaskItem(subsetListPath) });
                     engine.AssertLogContains(t.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", assemblyNames[0].ItemSpec, "UniFYme, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", stringList));
                     engine.AssertLogContains(t.Log.FormatResourceString("ResolveAssemblyReference.DependencyReferenceOutsideOfFramework", assemblyNames[1].ItemSpec, "UniFYme, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "2.0.0.0", "1.0.0.0"));
@@ -5265,8 +5272,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 Assert.IsTrue(succeeded);
                 Assert.IsTrue(t.ResolvedFiles.Length == 2, "Expected to find two resolved assemblies");
-                Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"C:\MyApp\v1.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
-                Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"C:\MyApp\v2.0\DependsOnUnified.dll"), "Expected the ItemSpec of the resolved file to be the item spec of the 2.0.0.0 assembly");
+                Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll")), "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
+                Assert.IsTrue(ContainsItem(t.ResolvedFiles, Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll")), "Expected the ItemSpec of the resolved file to be the item spec of the 2.0.0.0 assembly");
                 AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
                 AssertNoCase(s_unifyMeDll_V20Path, t.ResolvedDependencyFiles[0].ItemSpec);
 
@@ -5277,12 +5284,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                 );
 
                 engine.AssertLogDoesntContain
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "2.0.0.0", @"C:\MyApp\v2.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "2.0.0.0", Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"))
                 );
             }
 
@@ -5337,12 +5344,12 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", @"C:\MyApp\v1.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "1.0.0.0", Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
                 );
 
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "2.0.0.0", @"C:\MyApp\v2.0\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "2.0.0.0", Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"))
                 );
             }
 
@@ -5388,7 +5395,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
                 engine.AssertLogContains
                 (
-                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "0.5.0.0", @"C:\MyApp\v0.5\DependsOnUnified.dll")
+                    String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "0.5.0.0", Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"))
                 );
             }
         }
@@ -8410,7 +8417,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 new TaskItem("DependsOnSimpleA")
             };
 
-            t.SearchPaths = new string[] { @"c:\MyApp", @"c:\MyStronglyNamed", @"c:\MyWeaklyNamed" };
+            t.SearchPaths = new string[] { s_myAppRootPath, @"c:\MyStronglyNamed", @"c:\MyWeaklyNamed" };
             Execute(t);
             Assert.AreEqual(1, t.ResolvedDependencyFiles.Length);
             Assert.AreEqual(@"c:\MyWeaklyNamed\A.dll", t.ResolvedDependencyFiles[0].ItemSpec);

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -16049,7 +16049,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// </summary>
         private static void GenerateRedistAndProfileXmlLocations(string fullRedistContents, string profileListContents, out string profileRedistList, out string fullRedistList, string fullFrameworkDirectory, string targetFrameworkDirectory)
         {
-            fullRedistList = Path.Combine(fullFrameworkDirectory, "RedistList\\FrameworkList.xml");
+            fullRedistList = Path.Combine(fullFrameworkDirectory, "RedistList", "FrameworkList.xml");
             string redistDirectory = Path.GetDirectoryName(fullRedistList);
             if (Directory.Exists(redistDirectory))
             {
@@ -16060,7 +16060,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             File.WriteAllText(fullRedistList, fullRedistContents);
 
-            profileRedistList = Path.Combine(targetFrameworkDirectory, "RedistList\\FrameworkList.xml");
+            profileRedistList = Path.Combine(targetFrameworkDirectory, "RedistList", "FrameworkList.xml");
 
             redistDirectory = Path.GetDirectoryName(profileRedistList);
             if (Directory.Exists(redistDirectory))

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -226,6 +226,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         protected static readonly string s_myLibraries_V1_E_EDllPath = Path.Combine(s_myLibraries_V1_EPath, "E.dll");
         protected static readonly string s_myLibraries_V2_DDllPath = Path.Combine(s_myLibraries_V2Path, "D.dll");
 
+        protected static readonly string s_regress454863_ADllPath = Path.Combine(s_rootPathPrefix, "Regress454863", "A.dll");
+        protected static readonly string s_regress454863_BDllPath = Path.Combine(s_rootPathPrefix, "Regress454863", "B.dll");
+
         /// <summary>
         /// Search paths to use.
         /// </summary>
@@ -420,8 +423,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 @"C:\Regress313747\MS.Internal.Test.Automation.Office.Excel.dll",
                 @"C:\Regress442570\A.dll",
                 @"C:\Regress442570\B.dll",
-                @"C:\Regress454863\A.dll",
-                @"C:\Regress454863\B.dll",
+                s_regress454863_ADllPath,
+                s_regress454863_BDllPath,
                 @"C:\Regress393931\A.metadata_dll",
                 @"c:\Regress387218\A.dll",
                 @"c:\Regress387218\B.dll",
@@ -1767,7 +1770,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\Regress454863\A.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress454863_ADllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -1831,7 +1834,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 };
             }
 
-            if (String.Compare(path, @"C:\Regress454863\A.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            if (String.Compare(path, s_regress454863_ADllPath, StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return new AssemblyNameExtension[]
                 {
@@ -15088,7 +15091,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 new TaskItem("A"),
                 new TaskItem("B")
             };
-            t.Assemblies[0].SetMetadata("HintPath", @"C:\Regress454863\A.dll");
+            t.Assemblies[0].SetMetadata("HintPath", s_regress454863_ADllPath);
 
             t.SearchPaths = new string[]
             {
@@ -15097,8 +15100,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Execute(t);
 
-            Assert.IsTrue(ContainsItem(t.ResolvedFiles, @"C:\Regress454863\A.dll"), "Expected A.dll to be resolved.");
-            Assert.IsTrue(!ContainsItem(t.ResolvedFiles, @"C:\Regress454863\B.dll"), "Expected B.dll to be *not* be resolved.");
+            Assert.IsTrue(ContainsItem(t.ResolvedFiles, s_regress454863_ADllPath), "Expected A.dll to be resolved.");
+            Assert.IsTrue(!ContainsItem(t.ResolvedFiles, s_regress454863_BDllPath), "Expected B.dll to be *not* be resolved.");
         }
 
         [Test]

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -15755,7 +15755,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string profileRedistList = String.Empty;
             string fullRedistList = String.Empty;
             string fullFrameworkDirectory = Path.Combine(Path.GetTempPath(), "Verifyp2pAndProfile");
-            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles\\Client");
+            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles", "Client");
 
             string fullRedistListContents =
             "<FileList Redist='Microsoft-Windows-CLRCoreComp' >" +
@@ -15803,7 +15803,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string profileRedistList = String.Empty;
             string fullRedistList = String.Empty;
             string fullFrameworkDirectory = Path.Combine(Path.GetTempPath(), "Verifyp2pAndProfile");
-            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles\\Client");
+            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles", "Client");
 
             string fullRedistListContents =
             "<FileList Redist='Microsoft-Windows-CLRCoreComp' >" +
@@ -15853,7 +15853,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string profileRedistList = String.Empty;
             string fullRedistList = String.Empty;
             string fullFrameworkDirectory = Path.Combine(Path.GetTempPath(), "VerifyClientProfileRedistListAndProfileList");
-            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles\\Client");
+            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles", "Client");
             try
             {
                 GenerateRedistAndProfileXmlLocations(_fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
@@ -15900,7 +15900,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string profileRedistList = String.Empty;
             string fullRedistList = String.Empty;
             string fullFrameworkDirectory = Path.Combine(Path.GetTempPath(), "VerifyClientProfileRedistListAndProfileList2");
-            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles\\Client");
+            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles", "Client");
             try
             {
                 GenerateRedistAndProfileXmlLocations(_fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
@@ -15948,7 +15948,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string profileRedistList = String.Empty;
             string fullRedistList = String.Empty;
             string fullFrameworkDirectory = Path.Combine(Path.GetTempPath(), "VerifyAssemblyInGacButNotInProfileIsNotResolved");
-            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles\\Client");
+            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles", "Client");
             useFrameworkFileExists = true;
             string fullRedistListContents =
             "<FileList Redist='Microsoft-Windows-CLRCoreComp' >" +
@@ -16002,7 +16002,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string profileRedistList = String.Empty;
             string fullRedistList = String.Empty;
             string fullFrameworkDirectory = Path.Combine(Path.GetTempPath(), "VerifyProfileErrorsAreLogged");
-            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles\\Client");
+            string targetFrameworkDirectory = Path.Combine(fullFrameworkDirectory, "Profiles", "Client");
             try
             {
                 string fullRedistListContentsErrors =

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -7717,7 +7717,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     AssertNoCase("NOPE", item.GetMetadata(ItemMetadataNames.winMDFile));
                     AssertNoCase("IMPL", item.GetMetadata(ItemMetadataNames.winmdImplmentationFile));
                 }
-                else if (item.ItemSpec.EndsWith(@"v2.0.MyVersion\System.Data.dll"))
+                else if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "System.Data.dll")))
                 {
                     systemDataFound = true;
                     AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
@@ -7725,7 +7725,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     AssertNoCase("false", item.GetMetadata("CopyLocal"));
                     AssertNoCase("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", item.GetMetadata("FusionName"));
                 }
-                else if (item.ItemSpec.EndsWith(@"v2.0.MyVersion\MyGacAssembly.dll"))
+                else if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "MyGacAssembly.dll")))
                 {
                     myGacAssemblyFound = true;
                     AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
@@ -7739,14 +7739,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
                     AssertNoCase("true", item.GetMetadata("CopyLocal"));
                 }
-                else if (item.ItemSpec.EndsWith(@"MyProject\MyCopyLocalAssembly.dll"))
+                else if (item.ItemSpec.EndsWith(Path.Combine("MyProject", "MyCopyLocalAssembly.dll")))
                 {
                     myCopyLocalAssemblyFound = true;
                     AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
                     AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
                     AssertNoCase("true", item.GetMetadata("CopyLocal"));
                 }
-                else if (item.ItemSpec.EndsWith(@"MyProject\MyDontCopyLocalAssembly.dll"))
+                else if (item.ItemSpec.EndsWith(Path.Combine("MyProject", "MyDontCopyLocalAssembly.dll")))
                 {
                     myDontCopyLocalAssemblyFound = true;
                     AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
@@ -7787,7 +7787,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // Process the dependencies.
             foreach (ITaskItem item in t.ResolvedDependencyFiles)
             {
-                if (item.ItemSpec.EndsWith(@"v2.0.MyVersion\SysTem.dll"))
+                if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "SysTem.dll")))
                 {
                     systemFound = true;
                     AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
@@ -7795,7 +7795,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                     AssertNoCase("false", item.GetMetadata("CopyLocal"));
                     AssertNoCase("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", item.GetMetadata("FusionName"));
                 }
-                else if (item.ItemSpec.EndsWith(@"v2.0.MyVersion\mscorlib.dll"))
+                else if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "mscorlib.dll")))
                 {
                     mscorlibFound = true;
                     AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
@@ -7949,8 +7949,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string[] expectedItemSpec =
             {
                 s_myMissingAssemblyRelPath,                 // MyMissingAssembly
-                @"MyProject\MyCopyLocalAssembly.dll",       // MyCopyLocalAssembly
-                @"MyProject\MyDontCopyLocalAssembly.dll",   // MyDontCopyLocalAssembly
+                Path.Combine("MyProject", "MyCopyLocalAssembly.dll"),       // MyCopyLocalAssembly
+                Path.Combine("MyProject", "MyDontCopyLocalAssembly.dll"),   // MyDontCopyLocalAssembly
             };
 
             // matrix of expected CopyLocal value per assembly per framwork


### PR DESCRIPTION
Changes instances of hardcoded paths such as:

`c:\MyComponents\1.0`, `c:\MyLibraries\...` etc

to use readonly fields which are constructed to be valid on both
Windows and Unix. Replace all occurrences of these paths, to use the
new fields.

PR-URL: #124