### PR TITLE
[tests] Disable tests on Unix that depend on Windows only features

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -259,12 +259,16 @@ sub runtests {
 
     # Build the command to run the test
     my $command = '';
+    my $excludeCategories = '';
+    if ($^O ne 'MSWin32') {
+        $excludeCategories = "WindowsOnly";
+    }
     if ($testName) {
         $command = "\"$nunitConsole\" -run:$testName -xml:$xmlResultFile " . join (' ', @files);
     } elsif ($fixture) {
-        $command = "\"$nunitConsole\" -fixture:$fixture -xml:$xmlResultFile " . join (' ', @files);
+        $command = "\"$nunitConsole\" -fixture:$fixture -exclude:$excludeCategories -xml:$xmlResultFile " . join (' ', @files);
     } else {
-        $command = "\"$nunitConsole\" -xml:$xmlResultFile " . join (' ', @files);
+        $command = "\"$nunitConsole\" -exclude:$excludeCategories -xml:$xmlResultFile " . join (' ', @files);
     }
     print $command . "\n" unless $silent;
 

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Test]
+        [Category("WindowsOnly")]
         public void GetApiContractReferencesFindsWinMDs()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -6629,6 +6629,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// Unit tests for the ResolveAssemblyReference task.
     /// </summary>
     [TestFixture]
+    [Category("WindowsOnly")]
     sealed public class WinMDTests : ResolveAssemblyReferenceTestFixture
     {
         #region AssemblyInformationIsWinMDFile Tests

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -3645,6 +3645,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ///     perf hit when loading large solutions.
             /// </summary>
             [Test]
+            [Category("WindowsOnly")]
             public void Exists()
             {
                 // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -8431,6 +8432,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Do the most basic AssemblyFoldersEx resolve.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExBasic()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8451,6 +8453,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify that higher alphabetical values for a component are chosen over lower alphabetic values of a component.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExVerifyComponentFolderSorting()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8472,6 +8475,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// with the letter "v", we should tolerate it and treat it as if it does.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExTargetFrameworkVersionDoesNotBeginWithV()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8496,6 +8500,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchDoesNotMatch()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8521,6 +8526,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchMSILX86()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8543,6 +8549,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify if there is a mismatch between what the project targets and the architecture of the resolved primary reference log a warning.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void VerifyProcessArchitectureMismatchWarning()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8567,6 +8574,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify if there is a mismatch between what the project targets and the architecture of the resolved primary reference log a warning.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void VerifyProcessArchitectureMismatchWarningDefault()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8590,6 +8598,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify if there is a mismatch between what the project targets and the architecture of the resolved primary reference log a error.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void VerifyProcessArchitectureMismatchError()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8617,6 +8626,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchNoneX86()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8637,6 +8647,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// has a MSIL architecture or a NONE architecture. NONE means you do not care what architecure is picked.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchNoneMix()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8665,6 +8676,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchMSILLastFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8690,6 +8702,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchNoneLastFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8714,6 +8727,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchX86FirstFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8737,6 +8751,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchX86MSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8759,6 +8774,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchX86None()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8781,6 +8797,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchNoneNone()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8802,6 +8819,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArcMSILNone()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8823,6 +8841,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchNoneMSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8845,6 +8864,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchMSILMSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8867,6 +8887,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExProcessorArchMatches()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8891,6 +8912,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// carry on and inspect those.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExTargetFrameworkVersionBogusValue()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8916,6 +8938,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Tolerate keys like v2.0.x86chk.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void Regress357227_AssemblyFoldersExAgainstRawDrop()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8936,6 +8959,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Matches that exist only in the HKLM hive.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExHKLM()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8955,6 +8979,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Matches that exist in both HKLM and HKCU should favor HKCU
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExHKCUTrumpsHKLM()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -8979,6 +9004,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// When matches that have v3.0 (future) and v2.0 (current) versions, the 2.0 version wins.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExFutureTargetNDPVersionsDontMatch()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8998,6 +9024,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// If there is no v2.0 (current target NDP) match, then v1.0 should match.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExMatchBackVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9017,6 +9044,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// If there is a 2.0 and a 1.0 then match 2.0.
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExCurrentTargetVersionTrumpsPastTargetVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9036,6 +9064,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// If a control has a service pack then that wins over the control itself
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExServicePackTrumpsBaseVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9056,6 +9085,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Test MaxOSVersion condition
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExConditionFilterMaxOS()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -9099,6 +9129,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Test MinOSVersion condition
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExConditionFilterMinOS()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9385,6 +9416,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Test Platform condition
         /// </summary>
         [Test]
+        [Category("WindowsOnly")]
         public void AssemblyFoldersExConditionFilterPlatform()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();


### PR DESCRIPTION
Exclude tests marked with category WindowsOnly on !Windows, when
running nunit from build.pl .
This is useful for disabling tests that make sense only on Windows,
eg, those that depend on presence of Registry or WinMD.

PR-URL: #125