### PR TITLE
[tests] GenerateResource: Use NUL as the invalid char on unix

### DIFF
--- a/src/XMakeTasks/UnitTests/GenerateResourceOutOfProc_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResourceOutOfProc_Tests.cs
@@ -2263,7 +2263,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                 resourcesFile = Utilities.WriteTestResX(false, null, null);
 
                 t.Sources = new ITaskItem[] { new TaskItem(resourcesFile) };
-                t.OutputResources = new ITaskItem[] { new TaskItem("||") };
+                t.OutputResources = new ITaskItem[] { new TaskItem(NativeMethodsShared.IsWindows ? "||" : "\0") };
 
                 bool success = t.Execute();
 

--- a/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
@@ -2137,7 +2137,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 t.Sources = new ITaskItem[] { new TaskItem(txtFile) };
                 t.StronglyTypedLanguage = "CSharp";
                 t.StronglyTypedClassName = "cc";
-                t.StronglyTypedFileName = "||";
+                t.StronglyTypedFileName = NativeMethodsShared.IsWindows ? "||" : "\0";
                 t.OutputResources = new ITaskItem[] { new TaskItem("somefile.resources") };
 
                 bool success = t.Execute();
@@ -2314,7 +2314,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 resourcesFile = Utilities.WriteTestResX(false, null, null);
 
                 t.Sources = new ITaskItem[] { new TaskItem(resourcesFile) };
-                t.OutputResources = new ITaskItem[] { new TaskItem("||") };
+                t.OutputResources = new ITaskItem[] { new TaskItem(NativeMethodsShared.IsWindows ? "||" : "\0") };
 
                 bool success = t.Execute();
 


### PR DESCRIPTION
"||" is an invalid filename on Windows but not on Unix. Some tests
depend on GenerateResource task failing because of invalid characters
in the filename. So, use "\0" as the filename for such tests,
which is invalid on Unix.