### PR TITLE
[xaml] TaskParser.Parse: Handle detection of content or file on Unix.

### DIFF
--- a/src/XMakeTasks/UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/XMakeTasks/UnitTests/XamlTaskFactory_Tests.cs
@@ -314,6 +314,34 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
             Assert.AreEqual("/target:\"[value]\"", properties.First.Value.SwitchName);
         }
 
+        [Test]
+        public void TestLoadAndParseFromAbsoluteFilePath()
+        {
+            string xmlContents = @"<ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
+                                     <Rule Name=`CL`>
+                                       <StringProperty Name=`TargetAssembly` Switch=`/target:&quot;[value]&quot;` />
+                                     </Rule>
+                                   </ProjectSchemaDefinitions>";
+            string tmpXamlFile = FileUtilities.GetTemporaryFile();
+            try {
+                File.WriteAllText(tmpXamlFile, xmlContents.Replace("`", "\""));
+                TaskParser tp = new TaskParser();
+                tp.Parse(tmpXamlFile, "CL");
+
+                LinkedList<Property> properties = tp.Properties;
+
+                Assert.AreEqual(1, properties.Count, "Expected one property but there were " + properties.Count);
+                Assert.IsNotNull(properties.First.Value, "TargetAssembly switch should exist");
+                Assert.AreEqual("TargetAssembly", properties.First.Value.Name);
+                Assert.AreEqual(PropertyType.String, properties.First.Value.Type);
+                Assert.AreEqual("/target:\"[value]\"", properties.First.Value.SwitchName);
+            } finally {
+                // This throws because the file is still in use!
+                //if (File.Exists(tmpXamlFile))
+                //    File.Delete(tmpXamlFile);
+            }
+        }
+
         /// <summary>
         /// Tests a simple string array property. 
         /// </summary>


### PR DESCRIPTION
TaskParser.Parse(string contentOrFile, string)
.. first argument can either be a filename or xaml string. Existing
code depended on Path.GetFullPath returning null for xml string, for
this detection. But on Unix, xml string could be a valid file path.

So, instead we utilize the knowledge that:

On Windows:
- xml string will be an invalid file path, so, Path.GetFullPath will
  return null
- xml string cannot be a rooted path ("C:\\<abc />")

On Unix:
- xml string is a valid path, this is not useful as Path.GetFullPath
  will return !null in most cases
- xml string cannot be a rooted path ("/foo/<abc />")

We have an additional check for rooted paths, just to be able to throw
the correct error in case of:
- Unix, @contentOrFile being a non-existant file path
An additional test is added for this code path.

This fixes all the XamlTaskFactory tests on Unix.