### PR TITLE
[tests] Fix XamlTaskFactory tests on case sensitive filesystems ..

### DIFF
--- a/src/XMakeTasks/UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/XMakeTasks/UnitTests/XamlTaskFactory_Tests.cs
@@ -434,10 +434,10 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
 
                 // Add an assembly reference.
                 cp.ReferencedAssemblies.Add("System.dll");
-                cp.ReferencedAssemblies.Add("System.XML.dll");
-                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "microsoft.build.utilities.core.dll"));
-                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "microsoft.build.tasks.core.dll"));
-                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "microsoft.build.framework.dll"));
+                cp.ReferencedAssemblies.Add("System.Xml.dll");
+                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "Microsoft.Build.Utilities.Core.dll"));
+                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "Microsoft.Build.Tasks.Core.dll"));
+                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "Microsoft.Build.Framework.dll"));
                 cp.ReferencedAssemblies.Add("System.Data.dll");
 
                 // Generate an executable instead of 
@@ -490,10 +490,10 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
 
                 // Add an assembly reference.
                 cp.ReferencedAssemblies.Add("System.dll");
-                cp.ReferencedAssemblies.Add("System.XML.dll");
-                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "microsoft.build.utilities.core.dll"));
-                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "microsoft.build.tasks.core.dll"));
-                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "microsoft.build.framework.dll"));
+                cp.ReferencedAssemblies.Add("System.Xml.dll");
+                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "Microsoft.Build.Utilities.Core.dll"));
+                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "Microsoft.Build.Tasks.Core.dll"));
+                cp.ReferencedAssemblies.Add(Path.Combine(XamlTestHelpers.PathToMSBuildBinaries, "Microsoft.Build.Framework.dll"));
                 cp.ReferencedAssemblies.Add("System.Data.dll");
 
                 // Generate an executable instead of 

--- a/src/XMakeTasks/UnitTests/XamlTestHelpers.cs
+++ b/src/XMakeTasks/UnitTests/XamlTestHelpers.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests
                 // Add an assembly reference.
                 cp.ReferencedAssemblies.Add("System.dll");
                 cp.ReferencedAssemblies.Add("System.Data.dll");
-                cp.ReferencedAssemblies.Add("System.XML.dll");
+                cp.ReferencedAssemblies.Add("System.Xml.dll");
                 cp.ReferencedAssemblies.Add(Path.Combine(PathToMSBuildBinaries, "Microsoft.Build.Framework.dll"));
                 cp.ReferencedAssemblies.Add(Path.Combine(PathToMSBuildBinaries, "Microsoft.Build.Utilities.Core.dll"));
                 cp.ReferencedAssemblies.Add(Path.Combine(PathToMSBuildBinaries, "Microsoft.Build.Tasks.Core.dll"));


### PR DESCRIPTION
.. by using the correct case for assembly file names like:

`microsoft.build.tasks.core.dll` => `Microsoft.Build.Tasks.Core.dll`

The incorrect case causes compilation errors in the XamlTaskFactory
tests on case sensitive filesystems, for example on xfs/Linux.