### PR TITLE
Copy Task: implement hardlink support for non-Windows OS

### DIFF
--- a/src/XMakeTasks/Copy.cs
+++ b/src/XMakeTasks/Copy.cs
@@ -319,21 +319,13 @@ namespace Microsoft.Build.Tasks
                     FileUtilities.DeleteNoThrow(destinationFileState.Name);
                 }
 
-                if (NativeMethodsShared.IsWindows)
-                {
-                    hardLinkCreated = NativeMethods.CreateHardLink(destinationFileState.Name, sourceFileState.Name, IntPtr.Zero /* reserved, must be NULL */);
-                }
-                else
-                {
-                    hardLinkCreated = NativeMethods.link(sourceFileState.Name, destinationFileState.Name) == 0;
-                }
+                string errorMessage;
+                hardLinkCreated = NativeMethods.MakeHardLink(destinationFileState.Name, sourceFileState.Name, out errorMessage);
 
                 if (!hardLinkCreated)
                 {
-                    int errorCode = NativeMethodsShared.IsWindows ? Marshal.GetHRForLastWin32Error() : Marshal.GetLastWin32Error();
-                    Exception hardLinkException = NativeMethodsShared.IsWindows ? Marshal.GetExceptionForHR(errorCode) : new Exception("The link() library call failed with the following error code: " + errorCode);
                     // This is only a message since we don't want warnings when copying to network shares etc.
-                    Log.LogMessageFromResources(MessageImportance.Low, "Copy.RetryingAsFileCopy", sourceFileState.Name, destinationFileState.Name, hardLinkException.Message);
+                    Log.LogMessageFromResources(MessageImportance.Low, "Copy.RetryingAsFileCopy", sourceFileState.Name, destinationFileState.Name, errorMessage);
                 }
             }
 

--- a/src/XMakeTasks/NativeMethods.cs
+++ b/src/XMakeTasks/NativeMethods.cs
@@ -777,6 +777,23 @@ namespace Microsoft.Build.Tasks
         [DllImport("libc", SetLastError = true)] 
         internal static extern int link(string oldpath, string newpath);
 
+        internal static bool MakeHardLink(string newFileName, string exitingFileName, out string errorMessage)
+        {
+            bool hardLinkCreated;
+            if (NativeMethodsShared.IsWindows)
+            {
+                hardLinkCreated = CreateHardLink(newFileName, exitingFileName, IntPtr.Zero /* reserved, must be NULL */);
+                errorMessage = hardLinkCreated ? null : Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()).Message;
+            }
+            else
+            {
+                hardLinkCreated = link(exitingFileName, newFileName) == 0;
+                errorMessage = hardLinkCreated ? null : "The link() library call failed with the following error code: " + Marshal.GetLastWin32Error();
+            }
+
+            return hardLinkCreated;
+        }
+
         //------------------------------------------------------------------------------
         // MoveFileEx
         //------------------------------------------------------------------------------

--- a/src/XMakeTasks/NativeMethods.cs
+++ b/src/XMakeTasks/NativeMethods.cs
@@ -774,6 +774,9 @@ namespace Microsoft.Build.Tasks
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern bool CreateHardLink(string newFileName, string exitingFileName, IntPtr securityAttributes);
 
+        [DllImport("libc", SetLastError = true)] 
+        internal static extern int link(string oldpath, string newpath);
+
         //------------------------------------------------------------------------------
         // MoveFileEx
         //------------------------------------------------------------------------------


### PR DESCRIPTION
Use the link() library function for the xplat MSBuild so creating hardlinks works on other platforms too.

See dotnet/buildtools#197