### PR TITLE
Do not convert switches like `/foo` to `-foo` on Unix

### DIFF
--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Build.Utilities
             ErrorUtilities.VerifyThrowArgumentNull(switchName, "switchName");
 
             AppendSpaceIfNotEmpty();
-            AppendTextUnquoted(FixCommandLineSwitch(switchName));
+            AppendTextUnquoted(switchName);
         }
 
         /// <summary>

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -503,13 +503,6 @@ namespace Microsoft.Build.Utilities
 
         #region Appending switches with quoted parameters
 
-        internal static string FixCommandLineSwitch(string switchName)
-        {
-            return !NativeMethodsShared.IsWindows && !string.IsNullOrEmpty(switchName) && switchName.StartsWith("/")
-                       ? "-" + switchName.Substring(1)
-                       : switchName;
-        }
-
         /// <summary>
         /// Appends a command-line switch that has no separate value, without any quoting.
         /// This method appends a space to the command line (if it's not currently empty) before the switch.

--- a/src/Utilities/UnitTests/CommandLineBuilder_Tests.cs
+++ b/src/Utilities/UnitTests/CommandLineBuilder_Tests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.UnitTests
             c.AppendSwitch("/a");
             c.AppendSwitch("-b");
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/a ") + CommandLineBuilder.FixCommandLineSwitch("-b"),
+                "/a " + "-b",
                 c.ToString());
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/animal:", "dog");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch("/animal:dog"), c.ToString());
+            Assert.Equal("/animal:dog", c.ToString());
         }
 
         /*
@@ -53,7 +53,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/animal:", "dog and pony");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch("/animal:\"dog and pony\""), c.ToString());
+            Assert.Equal("/animal:\"dog and pony\"", c.ToString());
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/animal:", (ITaskItem)new TaskItem("dog and pony"));
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch("/animal:\"dog and pony\""), c.ToString());
+            Assert.Equal("/animal:\"dog and pony\"", c.ToString());
         }
 
         /*
@@ -77,7 +77,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchUnquotedIfNotNull("/animal:", "dog and pony");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch("/animal:dog and pony"), c.ToString());
+            Assert.Equal("/animal:dog and pony", c.ToString());
         }
 
         /*
@@ -183,8 +183,8 @@ namespace Microsoft.Build.UnitTests
 
             // Managed compilers use this function to append sources files.
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/something ")
-                + CommandLineBuilder.FixCommandLineSwitch("/switch:\"Mer cury.cs\",\"Ve nus.cs\",\"Ear th.cs\""),
+                "/something "
+                + "/switch:\"Mer cury.cs\",\"Ve nus.cs\",\"Ear th.cs\"",
                 c.ToString());
         }
 
@@ -200,8 +200,8 @@ namespace Microsoft.Build.UnitTests
 
             // Managed compilers use this function to append sources files.
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/something ")
-                + CommandLineBuilder.FixCommandLineSwitch("/switch:\"Mer cury.cs\",,\"Ve nus.cs\",\"Ear th.cs\""),
+                "/something "
+                + "/switch:\"Mer cury.cs\",,\"Ve nus.cs\",\"Ear th.cs\"",
                 c.ToString());
         }
 
@@ -217,8 +217,8 @@ namespace Microsoft.Build.UnitTests
 
             // Managed compilers use this function to append sources files.
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/something ")
-                + CommandLineBuilder.FixCommandLineSwitch("/switch:Mer cury.cs,Ve nus.cs,Ear th.cs"),
+                "/something "
+                + "/switch:Mer cury.cs,Ve nus.cs,Ear th.cs",
                 c.ToString());
         }
 
@@ -234,8 +234,8 @@ namespace Microsoft.Build.UnitTests
 
             // Managed compilers use this function to append sources files.
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/something ")
-                + CommandLineBuilder.FixCommandLineSwitch("/switch:Mer cury.cs,,Ve nus.cs,Ear th.cs"),
+                "/something "
+                + "/switch:Mer cury.cs,,Ve nus.cs,Ear th.cs",
                 c.ToString());
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.Build.UnitTests
 
             // Managed compilers use this function to append sources files.
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/something ." + Path.DirectorySeparatorChar + "-Mercury.cs Mercury.cs \"Mer cury.cs\""),
+                "/something ." + Path.DirectorySeparatorChar + "-Mercury.cs Mercury.cs \"Mer cury.cs\"",
                 c.ToString());
         }
 
@@ -271,7 +271,7 @@ namespace Microsoft.Build.UnitTests
 
             // Managed compilers use this function to append sources files.
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch("/something ." + Path.DirectorySeparatorChar + "-Mercury.cs Mercury.cs \"Mer cury.cs\""),
+                "/something ." + Path.DirectorySeparatorChar + "-Mercury.cs Mercury.cs \"Mer cury.cs\"",
                 c.ToString());
         }
 
@@ -300,8 +300,7 @@ namespace Microsoft.Build.UnitTests
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", "LSYSTEM_COMPATIBLE_ASSEMBLY_NAME=L\"Microsoft.Windows.SystemCompatible\"");
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch(
-                    "/D\"LSYSTEM_COMPATIBLE_ASSEMBLY_NAME=L\\\"Microsoft.Windows.SystemCompatible\\\"\""),
+                    "/D\"LSYSTEM_COMPATIBLE_ASSEMBLY_NAME=L\\\"Microsoft.Windows.SystemCompatible\\\"\"",
                 c.ToString());
         }
 
@@ -314,7 +313,7 @@ namespace Microsoft.Build.UnitTests
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", @"ASSEMBLY_KEY_FILE=""c:\\foo\\FinalKeyFile.snk""");
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch(@"/D""ASSEMBLY_KEY_FILE=\""c:\\foo\\FinalKeyFile.snk\"""""),
+                @"/D""ASSEMBLY_KEY_FILE=\""c:\\foo\\FinalKeyFile.snk\""""",
                 c.ToString());
         }
 
@@ -326,7 +325,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", @"""A B"" and ""C""");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/D""\""A B\"" and \""C\"""""), c.ToString());
+            Assert.Equal(@"/D""\""A B\"" and \""C\""""", c.ToString());
         }
 
         /// <summary>
@@ -337,7 +336,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", @"A \B");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/D""A \B"""), c.ToString());
+            Assert.Equal(@"/D""A \B""", c.ToString());
         }
 
         /// <summary>
@@ -348,7 +347,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", @"A"" \""B");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/D""A\"" \\\""B"""), c.ToString());
+            Assert.Equal(@"/D""A\"" \\\""B""", c.ToString());
         }
 
         /// <summary>
@@ -359,7 +358,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchUnquotedIfNotNull("/D", @"A"" \""B");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/DA"" \""B"), c.ToString());
+            Assert.Equal(@"/DA"" \""B", c.ToString());
         }
 
         /// <summary>
@@ -371,7 +370,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", @"A B\");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/D""A B\\"""), c.ToString());
+            Assert.Equal(@"/D""A B\\""", c.ToString());
         }
 
         /// <summary>
@@ -382,7 +381,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder();
             c.AppendSwitchIfNotNull("/D", @"AB\");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/DAB\"), c.ToString());
+            Assert.Equal(@"/DAB\", c.ToString());
         }
 
         /// <summary>
@@ -393,7 +392,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder(/* do not quote hyphens*/);
             c.AppendSwitchIfNotNull("/D", @"foo-bar");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/Dfoo-bar"), c.ToString());
+            Assert.Equal(@"/Dfoo-bar", c.ToString());
         }
 
         /// <summary>
@@ -404,7 +403,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder(true /* quote hyphens*/);
             c.AppendSwitchIfNotNull("/D", @"foo-bar");
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/D""foo-bar"""), c.ToString());
+            Assert.Equal(@"/D""foo-bar""", c.ToString());
         }
 
         /// <summary>
@@ -415,7 +414,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder(true);
             c.AppendSwitchIfNotNull("/D", new TaskItem(@"foo-bar"));
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/D""foo-bar"""), c.ToString());
+            Assert.Equal(@"/D""foo-bar""", c.ToString());
         }
 
         /// <summary>
@@ -426,7 +425,7 @@ namespace Microsoft.Build.UnitTests
         {
             CommandLineBuilder c = new CommandLineBuilder(true);
             c.AppendSwitchUnquotedIfNotNull("/D", new TaskItem(@"foo-bar"));
-            Assert.Equal(CommandLineBuilder.FixCommandLineSwitch(@"/Dfoo-bar"), c.ToString());
+            Assert.Equal(@"/Dfoo-bar", c.ToString());
         }
 
         /// <summary>

--- a/src/XMakeTasks/UnitTests/Al_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Al_Tests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("whatisthis", t.AlgorithmId); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/algid:whatisthis"));
+            CommandLine.ValidateHasParameter(t, @"/algid:whatisthis");
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("12345678", t.BaseAddress); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/baseaddress:12345678"));
+            CommandLine.ValidateHasParameter(t, @"/baseaddress:12345678");
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("Google", t.CompanyName); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/company:Google"));
+            CommandLine.ValidateHasParameter(t, @"/company:Google");
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("debug", t.Configuration); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/configuration:debug"));
+            CommandLine.ValidateHasParameter(t, @"/configuration:debug");
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("(C) 2005", t.Copyright); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/copyright:(C) 2005"));
+            CommandLine.ValidateHasParameter(t, @"/copyright:(C) 2005");
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("aussie", t.Culture); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/culture:aussie"));
+            CommandLine.ValidateHasParameter(t, @"/culture:aussie");
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.Build.UnitTests
             Assert.True(t.DelaySign); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/delaysign+"));
+            CommandLine.ValidateHasParameter(t, "/delaysign+");
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("whatever", t.Description); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/description:whatever"));
+            CommandLine.ValidateHasParameter(t, @"/description:whatever");
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Microsoft.Build.UnitTests
             // Check the parameters.
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch("/embed:MyResource.bmp,Kenny,Private"));
+                "/embed:MyResource.bmp,Kenny,Private");
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("MyEvidenceFile", t.EvidenceFile); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/evidence:MyEvidenceFile"));
+            CommandLine.ValidateHasParameter(t, @"/evidence:MyEvidenceFile");
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("1.2.3.4", t.FileVersion); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/fileversion:1.2.3.4"));
+            CommandLine.ValidateHasParameter(t, @"/fileversion:1.2.3.4");
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("0x8421", t.Flags); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/flags:0x8421"));
+            CommandLine.ValidateHasParameter(t, @"/flags:0x8421");
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace Microsoft.Build.UnitTests
             Assert.True(t.GenerateFullPaths); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/fullpaths"));
+            CommandLine.ValidateHasParameter(t, "/fullpaths");
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("mykey.snk", t.KeyFile); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/keyfile:mykey.snk"));
+            CommandLine.ValidateHasParameter(t, @"/keyfile:mykey.snk");
         }
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("MyKeyContainer", t.KeyContainer); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/keyname:MyKeyContainer"));
+            CommandLine.ValidateHasParameter(t, @"/keyname:MyKeyContainer");
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Microsoft.Build.UnitTests
             // Check the parameters.
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/link:MyResource.bmp,Kenny,working\MyResource.bmp,Private"));
+                @"/link:MyResource.bmp,Kenny,working\MyResource.bmp,Private");
         }
 
         /// <summary>
@@ -320,10 +320,10 @@ namespace Microsoft.Build.UnitTests
             // Check the parameters.
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/link:MyResource.bmp,Kenny,working\MyResource.bmp,Private"));
+                @"/link:MyResource.bmp,Kenny,working\MyResource.bmp,Private");
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/link:MyResource2.bmp,Chef,working\MyResource2.bmp"));
+                @"/link:MyResource2.bmp,Chef,working\MyResource2.bmp");
         }
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("Class1.Main", t.MainEntryPoint); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/main:Class1.Main"));
+            CommandLine.ValidateHasParameter(t, @"/main:Class1.Main");
         }
 
         /// <summary>
@@ -355,7 +355,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("foo.dll", t.OutputAssembly.ItemSpec); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/out:foo.dll"));
+            CommandLine.ValidateHasParameter(t, @"/out:foo.dll");
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("x86", t.Platform); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/platform:x86"));
+            CommandLine.ValidateHasParameter(t, @"/platform:x86");
         }
 
         // Tests the "Platform" and "Prefer32Bit" parameter combinations on the AL task,
@@ -389,35 +389,35 @@ namespace Microsoft.Build.UnitTests
             t.Prefer32Bit = true;
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/platform:anycpu32bitpreferred"));
+                @"/platform:anycpu32bitpreferred");
 
             // Explicit "anycpu"
             t = new AL();
             t.Platform = "anycpu";
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/platform:anycpu"));
+            CommandLine.ValidateHasParameter(t, @"/platform:anycpu");
             t = new AL();
             t.Platform = "anycpu";
             t.Prefer32Bit = false;
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/platform:anycpu"));
+            CommandLine.ValidateHasParameter(t, @"/platform:anycpu");
             t = new AL();
             t.Platform = "anycpu";
             t.Prefer32Bit = true;
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/platform:anycpu32bitpreferred"));
+                @"/platform:anycpu32bitpreferred");
 
             // Explicit "x86"
             t = new AL();
             t.Platform = "x86";
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/platform:x86"));
+            CommandLine.ValidateHasParameter(t, @"/platform:x86");
             t = new AL();
             t.Platform = "x86";
             t.Prefer32Bit = false;
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/platform:x86"));
+            CommandLine.ValidateHasParameter(t, @"/platform:x86");
             t = new AL();
             t.Platform = "x86";
             t.Prefer32Bit = true;
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/platform:x86"));
+            CommandLine.ValidateHasParameter(t, @"/platform:x86");
         }
 
         /// <summary>
@@ -433,7 +433,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("VisualStudio", t.ProductName); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/product:VisualStudio"));
+            CommandLine.ValidateHasParameter(t, @"/product:VisualStudio");
         }
 
         /// <summary>
@@ -449,7 +449,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("8.0", t.ProductVersion); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/productversion:8.0"));
+            CommandLine.ValidateHasParameter(t, @"/productversion:8.0");
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("winexe", t.TargetType); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/target:winexe"));
+            CommandLine.ValidateHasParameter(t, @"/target:winexe");
         }
 
         /// <summary>
@@ -525,7 +525,7 @@ namespace Microsoft.Build.UnitTests
             // Check the parameters.
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/template:mymainassembly.dll"));
+                @"/template:mymainassembly.dll");
         }
 
         /// <summary>
@@ -541,7 +541,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("WarAndPeace", t.Title); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/title:WarAndPeace"));
+            CommandLine.ValidateHasParameter(t, @"/title:WarAndPeace");
         }
 
         /// <summary>
@@ -557,7 +557,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("MyTrademark", t.Trademark); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/trademark:MyTrademark"));
+            CommandLine.ValidateHasParameter(t, @"/trademark:MyTrademark");
         }
 
         /// <summary>
@@ -575,7 +575,7 @@ namespace Microsoft.Build.UnitTests
             // Check the parameters.
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/version:WowHowManyKindsOfVersionsAreThere"));
+                @"/version:WowHowManyKindsOfVersionsAreThere");
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("foo.ico", t.Win32Icon); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/win32icon:foo.ico"));
+            CommandLine.ValidateHasParameter(t, @"/win32icon:foo.ico");
         }
 
         /// <summary>
@@ -607,7 +607,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("foo.res", t.Win32Resource); // "New value"
 
             // Check the parameters.
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch(@"/win32res:foo.res"));
+            CommandLine.ValidateHasParameter(t, @"/win32res:foo.res");
         }
     }
 }

--- a/src/XMakeTasks/UnitTests/AxImp_Tests.cs
+++ b/src/XMakeTasks/UnitTests/AxImp_Tests.cs
@@ -54,14 +54,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.GenerateSource); // "GenerateSource should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/source"),
+                @"/source",
                 false /* no response file */);
 
             t.GenerateSource = true;
             Assert.True(t.GenerateSource); // "GenerateSource should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/source"),
+                @"/source",
                 false /* no response file */);
         }
 
@@ -98,14 +98,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.OutputAssembly); // "OutputAssembly should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:"),
+                @"/out:",
                 false /* no response file */);
 
             t.OutputAssembly = testParameterValue;
             Assert.Equal(testParameterValue, t.OutputAssembly); // "New OutputAssembly value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:") + testParameterValue,
+                @"/out:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -121,14 +121,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.OutputAssembly); // "OutputAssembly should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:"),
+                @"/out:",
                 false /* no response file */);
 
             t.OutputAssembly = testParameterValue;
             Assert.Equal(testParameterValue, t.OutputAssembly); // "New OutputAssembly value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:") + testParameterValue,
+                @"/out:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -144,14 +144,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.RuntimeCallableWrapperAssembly); // "RuntimeCallableWrapper should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/rcw:"),
+                @"/rcw:",
                 false /* no response file */);
 
             t.RuntimeCallableWrapperAssembly = testParameterValue;
             Assert.Equal(testParameterValue, t.RuntimeCallableWrapperAssembly); // "New RuntimeCallableWrapper value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/rcw:") + testParameterValue,
+                @"/rcw:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -167,14 +167,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.RuntimeCallableWrapperAssembly); // "RuntimeCallableWrapper should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/rcw:"),
+                @"/rcw:",
                 false /* no response file */);
 
             t.RuntimeCallableWrapperAssembly = testParameterValue;
             Assert.Equal(testParameterValue, t.RuntimeCallableWrapperAssembly); // "New RuntimeCallableWrapper value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/rcw:") + testParameterValue,
+                @"/rcw:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -189,14 +189,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.Silent); // "Silent should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/silent"),
+                @"/silent",
                 false /* no response file */);
 
             t.Silent = true;
             Assert.True(t.Silent); // "Silent should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/silent"),
+                @"/silent",
                 false /* no response file */);
         }
 
@@ -211,14 +211,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.Verbose); // "Verbose should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/verbose"),
+                @"/verbose",
                 false /* no response file */);
 
             t.Verbose = true;
             Assert.True(t.Verbose); // "Verbose should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/verbose"),
+                @"/verbose",
                 false /* no response file */);
         }
 

--- a/src/XMakeTasks/UnitTests/AxTlbBaseTask_Tests.cs
+++ b/src/XMakeTasks/UnitTests/AxTlbBaseTask_Tests.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.DelaySign); // "DelaySign should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/delaysign"),
+                @"/delaysign",
                 false /* no response file */);
 
             t.DelaySign = true;
             Assert.True(t.DelaySign); // "DelaySign should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/delaysign"),
+                @"/delaysign",
                 false /* no response file */);
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
                 Assert.Null(t.KeyContainer); // "KeyContainer should be null by default");
                 CommandLine.ValidateNoParameterStartsWith(
                     t,
-                    CommandLineBuilder.FixCommandLineSwitch(@"/keycontainer:"),
+                    @"/keycontainer:",
                     false /* no response file */);
 
                 t.KeyContainer = badParameterValue;
@@ -113,14 +113,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.KeyContainer); // "KeyContainer should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/keycontainer:"),
+                @"/keycontainer:",
                 false /* no response file */);
 
             t.KeyContainer = testParameterValue;
             Assert.Equal(testParameterValue, t.KeyContainer); // "New KeyContainer value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/keycontainer:") + testParameterValue,
+                @"/keycontainer:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -143,14 +143,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
                 Assert.Null(t.KeyFile); // "KeyFile should be null by default"
                 CommandLine.ValidateNoParameterStartsWith(
                     t,
-                    CommandLineBuilder.FixCommandLineSwitch(@"/keyfile:"),
+                    @"/keyfile:",
                     false /* no response file */);
 
                 t.KeyFile = badParameterValue;
                 Assert.Equal(badParameterValue, t.KeyFile); // "New KeyFile value should be set"
                 CommandLine.ValidateHasParameter(
                     t,
-                    CommandLineBuilder.FixCommandLineSwitch(@"/keyfile:") + badParameterValue,
+                    @"/keyfile:" + badParameterValue,
                     false /* no response file */);
                 Utilities.ExecuteTaskAndVerifyLogContainsErrorFromResource(t, "AxTlbBaseTask.InvalidKeyFileSpecified", t.KeyFile);
 
@@ -158,7 +158,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
                 Assert.Equal(goodParameterValue, t.KeyFile); // "New KeyFile value should be set"
                 CommandLine.ValidateHasParameter(
                     t,
-                    CommandLineBuilder.FixCommandLineSwitch(@"/keyfile:") + goodParameterValue,
+                    @"/keyfile:" + goodParameterValue,
                     false /* no response file */);
                 Utilities.ExecuteTaskAndVerifyLogContainsErrorFromResource(t, "AxTlbBaseTask.StrongNameUtils.NoKeyPairInFile", t.KeyFile);
             }
@@ -184,14 +184,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.KeyFile); // "KeyFile should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/keyfile:"),
+                @"/keyfile:",
                 false /* no response file */);
 
             t.KeyFile = testParameterValue;
             Assert.Equal(testParameterValue, t.KeyFile); // "New KeyFile value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/keyfile:") + testParameterValue,
+                @"/keyfile:" + testParameterValue,
                 false /* no response file */);
         }
 

--- a/src/XMakeTasks/UnitTests/CommandLineBuilderExtension_Tests.cs
+++ b/src/XMakeTasks/UnitTests/CommandLineBuilderExtension_Tests.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Build.UnitTests
             );
 
             Assert.Equal(
-               (NativeMethodsShared.IsWindows ? @"/myswitch:MySoundEffect.wav,Kenny " : @"-myswitch:MySoundEffect.wav,Kenny ")
-               + (NativeMethodsShared.IsWindows ? @"/myswitch:MySplashScreen.bmp,Cartman,c:\foo,Public" : @"-myswitch:MySplashScreen.bmp,Cartman,c:\foo,Public"),
+               @"/myswitch:MySoundEffect.wav,Kenny "
+               + @"/myswitch:MySplashScreen.bmp,Cartman,c:\foo,Public",
                c.ToString());
         }
     }

--- a/src/XMakeTasks/UnitTests/GenerateResourceOutOfProc_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResourceOutOfProc_Tests.cs
@@ -2621,7 +2621,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
 
                 // Since this is resgen 4.0, will be in a response-file, which is line-delineated
                 // and doesn't like spaces in filenames. 
-                Utilities.AssertLogContains(t, CommandLineBuilder.FixCommandLineSwitch("/compile"));
+                Utilities.AssertLogContains(t, "/compile");
                 Utilities.AssertLogContains(t, resxFile + "," + resourcesFile);
             }
             finally
@@ -2660,11 +2660,11 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
 
                 Utilities.AssertLogContains(
                     t,
-                    CommandLineBuilder.FixCommandLineSwitch("/useSourcePath ")
-                    + CommandLineBuilder.FixCommandLineSwitch("/publicClass ")
-                    + CommandLineBuilder.FixCommandLineSwitch("/r:baz ")
-                    + CommandLineBuilder.FixCommandLineSwitch("/r:jazz ") + possiblyQuotedResxFile + " "
-                    + possiblyQuotedResourcesFile + " " + CommandLineBuilder.FixCommandLineSwitch("/str:\"C#\",,,"));
+                    "/useSourcePath "
+                    + "/publicClass "
+                    + "/r:baz "
+                    + "/r:jazz " + possiblyQuotedResxFile + " "
+                    + possiblyQuotedResourcesFile + " " + "/str:\"C#\",,,");
             }
             finally
             {
@@ -2704,11 +2704,11 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
 
                 Utilities.AssertLogContains(
                     t,
-                    CommandLineBuilder.FixCommandLineSwitch("/useSourcePath ")
-                    + CommandLineBuilder.FixCommandLineSwitch("/r:baz ")
-                    + CommandLineBuilder.FixCommandLineSwitch("/r:jazz ") + possiblyQuotedResxFile + " "
+                    "/useSourcePath "
+                    + "/r:baz "
+                    + "/r:jazz " + possiblyQuotedResxFile + " "
                     + possiblyQuotedResourcesFile + " "
-                    + CommandLineBuilder.FixCommandLineSwitch("/str:\"C#\",,wagwag,boo"));
+                    + "/str:\"C#\",,wagwag,boo");
             }
             finally
             {
@@ -2737,7 +2737,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
 
                 // Since this is resgen 4.0, will be in a response-file, which is line-delineated
                 // and doesn't like spaces in filenames. 
-                Utilities.AssertLogContains(t, CommandLineBuilder.FixCommandLineSwitch("/compile"));
+                Utilities.AssertLogContains(t, "/compile");
                 Utilities.AssertLogContains(t, resxFile + "," + resourcesFile);
                 Utilities.AssertLogContains(t, resxFile1 + "," + resourcesFile1);
             }
@@ -2848,7 +2848,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                 t.SdkToolsPath = sdkToolsPath;
                 Assert.True(t.Execute()); // "Task should have completed succesfully"
 
-                Utilities.AssertLogContains(t, CommandLineBuilder.FixCommandLineSwitch("/compile"));
+                Utilities.AssertLogContains(t, "/compile");
                 foreach (ITaskItem i in sources)
                 {
                     Utilities.AssertLogContains(t, i.ItemSpec);

--- a/src/XMakeTasks/UnitTests/TlbImp_Tests.cs
+++ b/src/XMakeTasks/UnitTests/TlbImp_Tests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Equal("Agnostic", t.Machine); // "New TypeLibName value should be set");
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch("/machine:Agnostic"),
+                "/machine:Agnostic",
                 false /* no response file */);
         }
 
@@ -44,11 +44,11 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             t.ReferenceFiles = new string[] { "File1.dll", "File2.dll" };
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch("/reference:File1.dll"),
+                "/reference:File1.dll",
                 false /* no response file */);
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch("/reference:File2.dll"),
+                "/reference:File2.dll",
                 false /* no response file */);
         }
         /// <summary>
@@ -95,14 +95,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.AssemblyNamespace); // "AssemblyNamespace should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/namespace:"),
+                @"/namespace:",
                 false /* no response file */);
 
             t.AssemblyNamespace = testParameterValue;
             Assert.Equal(testParameterValue, t.AssemblyNamespace); // "New AssemblyNamespace value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/namespace:") + testParameterValue,
+                @"/namespace:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -118,14 +118,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.AssemblyVersion); // "AssemblyVersion should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/asmversion:"),
+                @"/asmversion:",
                 false /* no response file */);
 
             t.AssemblyVersion = testParameterValue;
             Assert.Equal(testParameterValue, t.AssemblyVersion); // "New AssemblyNamespace value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/asmversion:") + testParameterValue.ToString(),
+                @"/asmversion:" + testParameterValue.ToString(),
                 false /* no response file */);
         }
 
@@ -140,14 +140,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.NoLogo); // "NoLogo should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/nologo"),
+                @"/nologo",
                 false /* no response file */);
 
             t.NoLogo = true;
             Assert.True(t.NoLogo); // "NoLogo should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/nologo"),
+                @"/nologo",
                 false /* no response file */);
         }
 
@@ -163,14 +163,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.OutputAssembly); // "OutputAssembly should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:"),
+                @"/out:",
                 false /* no response file */);
 
             t.OutputAssembly = testParameterValue;
             Assert.Equal(testParameterValue, t.OutputAssembly); // "New OutputAssembly value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:") + testParameterValue,
+                @"/out:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -186,14 +186,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Null(t.OutputAssembly); // "OutputAssembly should be null by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:"),
+                @"/out:",
                 false /* no response file */);
 
             t.OutputAssembly = testParameterValue;
             Assert.Equal(testParameterValue, t.OutputAssembly); // "New OutputAssembly value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/out:") + testParameterValue,
+                @"/out:" + testParameterValue,
                 false /* no response file */);
         }
 
@@ -208,14 +208,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.PreventClassMembers); // "PreventClassMembers should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/noclassmembers"),
+                @"/noclassmembers",
                 false /* no response file */);
 
             t.PreventClassMembers = true;
             Assert.True(t.PreventClassMembers); // "PreventClassMembers should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/noclassmembers"),
+                @"/noclassmembers",
                 false /* no response file */);
         }
 
@@ -230,14 +230,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.SafeArrayAsSystemArray); // "SafeArrayAsSystemArray should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/sysarray"),
+                @"/sysarray",
                 false /* no response file */);
 
             t.SafeArrayAsSystemArray = true;
             Assert.True(t.SafeArrayAsSystemArray); // "SafeArrayAsSystemArray should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/sysarray"),
+                @"/sysarray",
                 false /* no response file */);
         }
 
@@ -252,14 +252,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.Silent); // "Silent should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/silent"),
+                @"/silent",
                 false /* no response file */);
 
             t.Silent = true;
             Assert.True(t.Silent); // "Silent should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/silent"),
+                @"/silent",
                 false /* no response file */);
         }
 
@@ -281,14 +281,14 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Equal(ResolveComReference.TlbImpTransformFlags.None, t.Transform); // "Transform should be TlbImpTransformFlags.None by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/transform:"),
+                @"/transform:",
                 false /* no response file */);
 
             t.Transform = dispRet;
             Assert.Equal(dispRet, t.Transform); // "New Transform value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/transform:DispRet"),
+                @"/transform:DispRet",
                 false /* no response file */);
 
 
@@ -296,7 +296,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.Equal(serialize, t.Transform); // "New Transform value should be set"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/transform:SerializableValueClasses"),
+                @"/transform:SerializableValueClasses",
                 false /* no response file */);
 
             t.Transform = both;
@@ -314,7 +314,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.False(t.Verbose); // "Verbose should be false by default"
             CommandLine.ValidateNoParameterStartsWith(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/verbose"),
+                @"/verbose",
                 false /* no response file */);
 
 
@@ -322,7 +322,7 @@ namespace Microsoft.Build.UnitTests.AxTlbImp_Tests
             Assert.True(t.Verbose); // "Verbose should be true"
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch(@"/verbose"),
+                @"/verbose",
                 false /* no response file */);
         }
 

--- a/src/XMakeTasks/UnitTests/WinMDExp_Tests.cs
+++ b/src/XMakeTasks/UnitTests/WinMDExp_Tests.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Build.UnitTests
             t.References = new TaskItem[] { mscorlibReference, windowsFoundationReference };
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch("/reference:mscorlib.dll"),
+                "/reference:mscorlib.dll",
                 false);
             CommandLine.ValidateHasParameter(
                 t,
-                CommandLineBuilder.FixCommandLineSwitch("/reference:Windows.Foundation.winmd"),
+                "/reference:Windows.Foundation.winmd",
                 false);
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.DisabledWarnings = "41999,42016";
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/nowarn:41999,42016"), false);
+            CommandLine.ValidateHasParameter(t, "/nowarn:41999,42016", false);
         }
 
 
@@ -61,8 +61,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputDocumentationFile = "output.xml";
             t.InputDocumentationFile = "input.xml";
 
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/d:output.xml"), false);
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/md:input.xml"), false);
+            CommandLine.ValidateHasParameter(t, "/d:output.xml", false);
+            CommandLine.ValidateHasParameter(t, "/md:input.xml", false);
         }
 
         [Fact]
@@ -74,8 +74,8 @@ namespace Microsoft.Build.UnitTests
             t.OutputPDBFile = "output.pdb";
             t.InputPDBFile = "input.pdb";
 
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/pdb:output.pdb"), false);
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/mp:input.pdb"), false);
+            CommandLine.ValidateHasParameter(t, "/pdb:output.pdb", false);
+            CommandLine.ValidateHasParameter(t, "/mp:input.pdb", false);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Microsoft.Build.UnitTests
             WinMDExp t = new WinMDExp();
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Bob.winmd";
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/out:Bob.winmd"), false);
+            CommandLine.ValidateHasParameter(t, "/out:Bob.winmd", false);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests
 
             t.WinMDModule = "Foo.dll";
             t.OutputWindowsMetadataFile = "Foo.winmd";
-            CommandLine.ValidateHasParameter(t, CommandLineBuilder.FixCommandLineSwitch("/out:Foo.winmd"), false);
+            CommandLine.ValidateHasParameter(t, "/out:Foo.winmd", false);
         }
     }
 }


### PR DESCRIPTION
On Unix, we convert switches of the form `/foo` to `-foo`, transparently for
tasks and in some cases explicitly in the tasks. This is not required
as the relevant tools (eg. mcs/csc) accept both style of switches. If it is
really required in a particular case, then the task should do that explicitly,
rather than doing it under the covers (`CommandLineBuilder.AppendSwitch`).

The tests also used `CommandLineBuilder.FixCommandLineSwitch` to match the switch
change on Unix. This is also changed to match the changed behaviour.

Following the same theme, `CommandLineBuilder.FixCommandLineSwitch` is no
longer used or required, so, it is also removed.