### PR TITLE
Port Microsoft.Build to .NET Core

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -103,6 +103,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_APARTMENT_STATE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>
+    <FeatureAppDomain>true</FeatureAppDomain>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOADFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
@@ -122,10 +123,12 @@
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEREF</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYSTREAM_GETBUFFER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_PARALLEL_BUILD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REFLECTION_EMIT_DEBUG_INFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRYHIVE_DYNDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PERMISSIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PRINCIPAL_WINDOWS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SPECIAL_FOLDERS</DefineConstants>
     <FeatureSpecialFolders>true</FeatureSpecialFolders>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>

--- a/dir.props
+++ b/dir.props
@@ -129,6 +129,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_SPECIAL_FOLDERS</DefineConstants>
     <FeatureSpecialFolders>true</FeatureSpecialFolders>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>
+    <FeatureSystemConfiguration>true</FeatureSystemConfiguration>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ABORT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_CULTURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_PRIORITY</DefineConstants>

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -310,6 +310,7 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static long GenerateHostHandshakeFromBase(long baseHandshake, long clientHandshake)
         {
+#if FEATURE_SECURITY_PRINCIPAL_WINDOWS
             // If we are running in elevated privs, we will only accept a handshake from an elevated process as well.
             WindowsPrincipal principal = new WindowsPrincipal(WindowsIdentity.GetCurrent());
 
@@ -328,6 +329,7 @@ namespace Microsoft.Build.Internal
                     baseHandshake = ~baseHandshake;
                 }
             }
+#endif
 
             // Mask out the first byte. That's because old
             // builds used a single, non zero initial byte,

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -14,7 +14,9 @@ using System.Runtime.Versioning;
 using Microsoft.Build.Evaluation;
 using Microsoft.Win32;
 
+#if FEATURE_SYSTEM_CONFIGURATION
 using PropertyElement = Microsoft.Build.Evaluation.ToolsetElement.PropertyElement;
+#endif
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/src/Shared/LogMessagePacketBase.cs
+++ b/src/Shared/LogMessagePacketBase.cs
@@ -14,7 +14,9 @@ using System.Reflection;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.BackEnd;
+#if FEATURE_APPDOMAIN
 using TaskEngineAssemblyResolver = Microsoft.Build.BackEnd.Logging.TaskEngineAssemblyResolver;
+#endif
 
 namespace Microsoft.Build.Shared
 {
@@ -136,10 +138,12 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static HashSet<string> s_customEventsLoaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// The resolver used to load custom event types.
         /// </summary>
         private static TaskEngineAssemblyResolver s_resolver;
+#endif
 
         /// <summary>
         /// The object used to synchronize access to shared data.
@@ -389,12 +393,14 @@ namespace Microsoft.Build.Shared
                     }
                 }
 
+#if FEATURE_APPDOMAIN
                 if (resolveAssembly)
                 {
                     s_resolver = new TaskEngineAssemblyResolver();
                     s_resolver.InstallHandler();
                     s_resolver.Initialize(fileLocation);
                 }
+#endif
 
                 try
                 {
@@ -404,11 +410,13 @@ namespace Microsoft.Build.Shared
                 }
                 finally
                 {
+#if FEATURE_APPDOMAIN
                     if (resolveAssembly)
                     {
                         s_resolver.RemoveHandler();
                         s_resolver = null;
                     }
+#endif
                 }
             }
 

--- a/src/Shared/TaskEngineAssemblyResolver.cs
+++ b/src/Shared/TaskEngineAssemblyResolver.cs
@@ -15,9 +15,7 @@ namespace Microsoft.Build.BackEnd.Logging
     /// This is a helper class to install an AssemblyResolver event handler in whatever AppDomain this class is created in.
     /// </summary>
     internal class TaskEngineAssemblyResolver
-#if FEATURE_APPDOMAIN
         : MarshalByRefObject
-#endif
     {
         /// <summary>
         /// This public default constructor is needed so that instances of this class can be created by NDP.
@@ -114,7 +112,6 @@ namespace Microsoft.Build.BackEnd.Logging
             return null;
         }
 
-#if FEATURE_APPDOMAIN
         /// <summary>
         /// Overridden to give this class infinite lease time. Otherwise we end up with a limited
         /// lease (5 minutes I think) and instances can expire if they take long time processing.
@@ -125,7 +122,6 @@ namespace Microsoft.Build.BackEnd.Logging
             // null means infinite lease time
             return null;
         }
-#endif
 
         // path to the task assembly, but only if it's loaded using LoadFrom. If it's loaded with Load, this is null.
         private string _taskAssemblyFile = null;

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -7,8 +7,10 @@ using System.Globalization;
 using System.IO;
 using System.Resources;
 using System.Text;
+#if FEATURE_APPDOMAIN
 using System.Runtime.Remoting.Lifetime;
 using System.Runtime.Remoting;
+#endif
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -64,12 +66,14 @@ namespace Microsoft.Build.Tasks
 
         #region Properties
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// A client sponsor is a class
         /// which will respond to a lease renewal request and will
         /// increase the lease time allowing the object to stay in memory
         /// </summary>
         private ClientSponsor _sponsor;
+#endif
 
         // We have to pass an instance of ITask to BuildEngine, and since we call into the engine from this class we
         // need to store the actual task instance.

--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildManager.cs
@@ -1626,8 +1626,10 @@ namespace Microsoft.Build.Execution
                 (
                 -1, /* must be assigned by the NodeManager */
                 _buildParameters,
-                remoteLoggers.ToArray(),
-                AppDomain.CurrentDomain.SetupInformation
+                remoteLoggers.ToArray()
+#if FEATURE_APPDOMAIN
+                , AppDomain.CurrentDomain.SetupInformation
+#endif
                 );
             }
 

--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
@@ -29,6 +29,7 @@ using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
 
 namespace Microsoft.Build.Execution
 {
+    using System.Diagnostics;
     using Utilities = Microsoft.Build.Internal.Utilities;
 
     /// <summary>
@@ -811,6 +812,7 @@ namespace Microsoft.Build.Execution
             set;
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Information for configuring child AppDomains.
         /// </summary>
@@ -819,6 +821,7 @@ namespace Microsoft.Build.Execution
             get;
             set;
         }
+#endif
 
         /// <summary>
         ///  (for diagnostic use) Whether or not this is out of proc
@@ -1002,7 +1005,11 @@ namespace Microsoft.Build.Execution
             }
 
             // Use the default location of the directory from which the engine was loaded.
+#if FEATURE_APPDOMAIN
             path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MSBuild.exe");
+#else
+            path = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+#endif
             if (path != null && CheckMSBuildExeExistsAt(path))
             {
                 _nodeExeLocation = path;
@@ -1025,6 +1032,7 @@ namespace Microsoft.Build.Execution
                 }
             }
 
+#if FEATURE_APPDOMAIN
             // Search in the location of any assemblies we have loaded.
             foreach (System.Reflection.Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
@@ -1056,6 +1064,7 @@ namespace Microsoft.Build.Execution
                     }
                 }
             }
+#endif
 
             // Search in the framework directory.  Checks the COMPLUS_INSTALL_ROOT among other things.
             path = FrameworkLocationHelper.PathToDotNetFrameworkV40;

--- a/src/XMakeBuildEngine/BackEnd/Components/BuildComponentFactoryCollection.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/BuildComponentFactoryCollection.cs
@@ -66,8 +66,10 @@ namespace Microsoft.Build.BackEnd
             _componentEntriesByType[BuildComponentType.TaskHostNodeManager] = new BuildComponentEntry(BuildComponentType.TaskHostNodeManager, TaskHostNodeManager.CreateComponent, CreationPattern.Singleton);
 
             _componentEntriesByType[BuildComponentType.InProcNodeProvider] = new BuildComponentEntry(BuildComponentType.InProcNodeProvider, NodeProviderInProc.CreateComponent, CreationPattern.Singleton);
+#if FEATURE_APPDOMAIN
             _componentEntriesByType[BuildComponentType.OutOfProcNodeProvider] = new BuildComponentEntry(BuildComponentType.OutOfProcNodeProvider, NodeProviderOutOfProc.CreateComponent, CreationPattern.Singleton);
             _componentEntriesByType[BuildComponentType.OutOfProcTaskHostNodeProvider] = new BuildComponentEntry(BuildComponentType.OutOfProcTaskHostNodeProvider, NodeProviderOutOfProcTaskHost.CreateComponent, CreationPattern.Singleton);
+#endif
 
             // PropertyCache,
             // RemoteNodeProvider,

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/LogMessagePacket.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/LogMessagePacket.cs
@@ -14,7 +14,9 @@ using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
+#if FEATURE_APPDOMAIN
 using TaskEngineAssemblyResolver = Microsoft.Build.BackEnd.Logging.TaskEngineAssemblyResolver;
+#endif
 
 namespace Microsoft.Build.BackEnd
 {

--- a/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -303,7 +303,11 @@ namespace Microsoft.Build.BackEnd
                 if (_taskNode != null)
                 {
                     taskHost = new TaskHost(_componentHost, _buildRequestEntry, _targetChildInstance.Location, _targetBuilderCallback);
-                    _taskExecutionHost.InitializeForTask(taskHost, _targetLoggingContext, _buildRequestEntry.RequestConfiguration.Project, _taskNode.Name, _taskNode.Location, _taskHostObject, _continueOnError != ContinueOnError.ErrorAndStop, taskHost.AppDomainSetup, taskHost.IsOutOfProc, _cancellationToken);
+                    _taskExecutionHost.InitializeForTask(taskHost, _targetLoggingContext, _buildRequestEntry.RequestConfiguration.Project, _taskNode.Name, _taskNode.Location, _taskHostObject, _continueOnError != ContinueOnError.ErrorAndStop,
+#if FEATURE_APPDOMAIN
+                        taskHost.AppDomainSetup,
+#endif
+                        taskHost.IsOutOfProc, _cancellationToken);
                 }
 
                 List<string> taskParameterValues = CreateListOfParameterValues();

--- a/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -9,8 +9,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+#if FEATURE_APPDOMAIN
 using System.Runtime.Remoting.Lifetime;
 using System.Runtime.Remoting;
+#endif
 using System.Threading;
 using System.Text;
 using Microsoft.Build.Framework;
@@ -82,12 +84,14 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private object _callbackMonitor;
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// A client sponsor is a class
         /// which will respond to a lease renewal request and will
         /// increase the lease time allowing the object to stay in memory
         /// </summary>
         private ClientSponsor _sponsor;
+#endif
 
         /// <summary>
         /// Legacy continue on error value per batch exposed via IBuildEngine
@@ -214,6 +218,7 @@ namespace Microsoft.Build.BackEnd
             { _taskLoggingContext = value; }
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// For configuring child AppDomains.
         /// </summary>
@@ -224,6 +229,7 @@ namespace Microsoft.Build.BackEnd
                 return _host.BuildParameters.AppDomainSetup;
             }
         }
+#endif
 
         /// <summary>
         /// Whether or not this is out of proc.

--- a/src/XMakeBuildEngine/BackEnd/Node/InProcNode.cs
+++ b/src/XMakeBuildEngine/BackEnd/Node/InProcNode.cs
@@ -513,8 +513,10 @@ namespace Microsoft.Build.BackEnd
             _componentHost.BuildParameters.NodeId = configuration.NodeId;
             _shutdownException = null;
 
+#if FEATURE_APPDOMAIN
             // And the AppDomainSetup
             _componentHost.BuildParameters.AppDomainSetup = configuration.AppDomainSetup;
+#endif
 
             // Declare in-proc
             _componentHost.BuildParameters.IsOutOfProc = false;

--- a/src/XMakeBuildEngine/BackEnd/Node/NodeConfiguration.cs
+++ b/src/XMakeBuildEngine/BackEnd/Node/NodeConfiguration.cs
@@ -34,10 +34,12 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private BuildParameters _buildParameters;
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// The app domain information needed for setting up AppDomain-isolated tasks.
         /// </summary>
         private AppDomainSetup _appDomainSetup;
+#endif
 
         /// <summary>
         /// The forwarding loggers to use.
@@ -55,14 +57,18 @@ namespace Microsoft.Build.BackEnd
             (
             int nodeId,
             BuildParameters buildParameters,
-            LoggerDescription[] forwardingLoggers,
-            AppDomainSetup appDomainSetup
+            LoggerDescription[] forwardingLoggers
+#if FEATURE_APPDOMAIN
+            , AppDomainSetup appDomainSetup
+#endif
             )
         {
             _nodeId = nodeId;
             _buildParameters = buildParameters;
             _forwardingLoggers = forwardingLoggers;
+#if FEATURE_APPDOMAIN
             _appDomainSetup = appDomainSetup;
+#endif
         }
 
         /// <summary>
@@ -106,6 +112,7 @@ namespace Microsoft.Build.BackEnd
             { return _forwardingLoggers; }
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Retrieves the app domain setup information.
         /// </summary>
@@ -115,6 +122,7 @@ namespace Microsoft.Build.BackEnd
             get
             { return _appDomainSetup; }
         }
+#endif
 
         #region INodePacket Members
 
@@ -162,7 +170,11 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal NodeConfiguration Clone()
         {
-            return new NodeConfiguration(_nodeId, _buildParameters, _forwardingLoggers, _appDomainSetup);
+            return new NodeConfiguration(_nodeId, _buildParameters, _forwardingLoggers
+#if FEATURE_APPDOMAIN
+                , _appDomainSetup
+#endif
+                );
         }
     }
 }

--- a/src/XMakeBuildEngine/BackEnd/TaskExecutionHost/AddInParts/ITaskExecutionHost.cs
+++ b/src/XMakeBuildEngine/BackEnd/TaskExecutionHost/AddInParts/ITaskExecutionHost.cs
@@ -67,7 +67,11 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Initialize the host with the objects required to communicate with the host process.
         /// </summary>
-        void InitializeForTask(IBuildEngine2 buildEngine, TargetLoggingContext loggingContext, ProjectInstance projectInstance, string taskName, ElementLocation taskLocation, ITaskHost taskHost, bool continueOnError, AppDomainSetup appDomainSetup, bool isOutOfProc, CancellationToken cancellationToken);
+        void InitializeForTask(IBuildEngine2 buildEngine, TargetLoggingContext loggingContext, ProjectInstance projectInstance, string taskName, ElementLocation taskLocation, ITaskHost taskHost, bool continueOnError,
+#if FEATURE_APPDOMAIN
+            AppDomainSetup appDomainSetup,
+#endif
+            bool isOutOfProc, CancellationToken cancellationToken);
 
         /// <summary>
         /// Ask the task host to find its task in the registry and get it ready for initializing the batch

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -88,7 +88,11 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal static string ReadAllToolsets(Dictionary<string, Toolset> toolsets, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, ToolsetDefinitionLocations locations)
         {
-            return ReadAllToolsets(toolsets, null, null, environmentProperties, globalProperties, locations);
+            return ReadAllToolsets(toolsets, null,
+#if FEATURE_SYSTEM_CONFIGURATION
+                null, 
+#endif
+                environmentProperties, globalProperties, locations);
         }
 
         /// <summary>
@@ -99,7 +103,9 @@ namespace Microsoft.Build.Evaluation
             (
             Dictionary<string, Toolset> toolsets,
             ToolsetRegistryReader registryReader,
+#if FEATURE_SYSTEM_CONFIGURATION
             ToolsetConfigurationReader configurationReader,
+#endif
             PropertyDictionary<ProjectPropertyInstance> environmentProperties,
             PropertyDictionary<ProjectPropertyInstance> globalProperties,
             ToolsetDefinitionLocations locations
@@ -116,6 +122,7 @@ namespace Microsoft.Build.Evaluation
             string overrideTasksPathFromConfiguration = null;
             string defaultOverrideToolsVersionFromConfiguration = null;
 
+#if FEATURE_SYSTEM_CONFIGURATION
             if ((locations & ToolsetDefinitionLocations.ConfigurationFile)
                 == ToolsetDefinitionLocations.ConfigurationFile)
             {
@@ -139,6 +146,7 @@ namespace Microsoft.Build.Evaluation
                         out defaultOverrideToolsVersionFromConfiguration);
                 }
             }
+#endif
 
             string defaultToolsVersionFromRegistry = null;
             string overrideTasksPathFromRegistry = null;

--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -14,8 +14,10 @@ using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Win32;
 
+#if FEATURE_APPDOMAIN
 // Needed for DoesTaskHostExistForParameters
 using NodeProviderOutOfProcTaskHost = Microsoft.Build.BackEnd.NodeProviderOutOfProcTaskHost;
+#endif
 
 namespace Microsoft.Build.Evaluation
 {
@@ -352,12 +354,14 @@ namespace Microsoft.Build.Evaluation
             parameters.Add(XMakeAttributes.architecture, architecture);
 
             TaskHostContext desiredContext = CommunicationsUtilities.GetTaskHostContext(parameters);
+#if FEATURE_APPDOMAIN
             string taskHostLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(desiredContext);
 
             if (taskHostLocation != null && FileUtilities.FileExistsNoThrow(taskHostLocation))
             {
                 return true;
             }
+#endif
 
             return false;
         }

--- a/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectRootElementCache.cs
@@ -20,7 +20,9 @@ using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Build.BackEnd;
 
+#if FEATURE_APPDOMAIN
 using OutOfProcNode = Microsoft.Build.Execution.OutOfProcNode;
+#endif
 
 namespace Microsoft.Build.Evaluation
 {
@@ -610,7 +612,11 @@ namespace Microsoft.Build.Evaluation
         {
             if (s_debugLogCacheActivity)
             {
+#if FEATURE_APPDOMAIN
                 string prefix = OutOfProcNode.IsOutOfProcNode ? "C" : "P";
+#else
+                string prefix = "P";
+#endif
                 Trace.WriteLine(prefix + " " + Process.GetCurrentProcess().Id + " | " + message + param1);
             }
         }

--- a/src/XMakeBuildEngine/Instance/TaskRegistry.cs
+++ b/src/XMakeBuildEngine/Instance/TaskRegistry.cs
@@ -20,7 +20,9 @@ using Microsoft.Build.BackEnd;
 
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
+#if FEATURE_APPDOMAIN
 using TaskEngineAssemblyResolver = Microsoft.Build.BackEnd.Logging.TaskEngineAssemblyResolver;
+#endif
 using ProjectXmlUtilities = Microsoft.Build.Internal.ProjectXmlUtilities;
 using TargetLoggingContext = Microsoft.Build.BackEnd.Logging.TargetLoggingContext;
 using System.Collections.ObjectModel;
@@ -1233,10 +1235,13 @@ namespace Microsoft.Build.Execution
                     ITaskFactory factory = null;
                     LoadedType loadedType = null;
 
+
                     bool isAssemblyTaskFactory = String.Equals(TaskFactoryAttributeName, AssemblyTaskFactory, StringComparison.OrdinalIgnoreCase);
                     bool isTaskHostFactory = String.Equals(TaskFactoryAttributeName, TaskHostFactory, StringComparison.OrdinalIgnoreCase);
 
+#if FEATURE_APPDOMAIN
                     if (isAssemblyTaskFactory || isTaskHostFactory)
+#endif
                     {
                         bool explicitlyLaunchTaskHost =
                             isTaskHostFactory ||
@@ -1251,6 +1256,7 @@ namespace Microsoft.Build.Execution
                         loadedType = taskFactory.InitializeFactory(taskFactoryLoadInfo, RegisteredName, ParameterGroupAndTaskBody.UsingTaskParameters, ParameterGroupAndTaskBody.InlineTaskXmlBody, TaskFactoryParameters, explicitlyLaunchTaskHost, targetLoggingContext, elementLocation, taskProjectFile);
                         factory = taskFactory;
                     }
+#if FEATURE_APPDOMAIN
                     else
                     {
                         // We are not one of the default factories. 
@@ -1351,9 +1357,7 @@ namespace Microsoft.Build.Execution
                                 }
                                 finally
                                 {
-#if FEATURE_APPDOMAIN
                                     taskFactoryLoggingHost.MarkAsInactive();
-#endif
                                 }
 
                                 if (!initialized)
@@ -1408,6 +1412,7 @@ namespace Microsoft.Build.Execution
                             }
                         }
                     }
+#endif
 
                     _taskFactoryWrapperInstance = new TaskFactoryWrapper(factory, loadedType, RegisteredName, TaskFactoryParameters);
                 }

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -356,8 +356,8 @@
     <Compile Include="Definition\ResolvedImport.cs" />
     <Compile Include="Definition\SubToolset.cs" />
     <Compile Include="Definition\Toolset.cs" />
-    <Compile Include="Definition\ToolsetConfigurationReader.cs" />
-    <Compile Include="..\Shared\ToolsetElement.cs">
+    <Compile Include="Definition\ToolsetConfigurationReader.cs" Condition="$(FeatureSystemConfiguration) == 'true'"/>
+    <Compile Include="..\Shared\ToolsetElement.cs" Condition="$(FeatureSystemConfiguration) == 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Definition\ToolsetPropertyDefinition.cs" />

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -116,7 +116,7 @@
     <Compile Include="..\Shared\NodeEngineShutdownReason.cs" />
     <Compile Include="..\Shared\IKeyed.cs" />
     <Compile Include="..\Shared\INodeEndpoint.cs" />
-    <Compile Include="..\Shared\NodeEndpointOutOfProcBase.cs" />
+    <Compile Include="..\Shared\NodeEndpointOutOfProcBase.cs" Condition="$(FeatureAppDomain) == 'true'"/>
     <Compile Include="..\Shared\INodePacket.cs" />
     <Compile Include="..\Shared\INodePacketFactory.cs" />
     <Compile Include="..\Shared\INodePacketHandler.cs" />
@@ -139,7 +139,7 @@
     <Compile Include="..\Shared\TaskParameterTypeVerifier.cs" />
     <Compile Include="..\Shared\CommunicationsUtilities.cs" />
     <Compile Include="..\Shared\InterningBinaryReader.cs" />
-    <Compile Include="..\Shared\TaskEngineAssemblyResolver.cs">
+    <Compile Include="..\Shared\TaskEngineAssemblyResolver.cs" Condition="$(FeatureAppDomain) == 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="..\Shared\ReuseableStringBuilder.cs" />
@@ -206,7 +206,7 @@
     <Compile Include="Construction\Solution\SolutionProjectGenerator.cs" />
     <Compile Include="Evaluation\IToolsetProvider.cs" />
     <Compile Include="BackEnd\Components\Caching\ResultsCacheResponse.cs" />
-    <Compile Include="BackEnd\Components\Communications\NodeEndpointOutOfProc.cs" />
+    <Compile Include="BackEnd\Components\Communications\NodeEndpointOutOfProc.cs" Condition="$(FeatureAppDomain) == 'true'"/>
     <Compile Include="BackEnd\Components\Communications\NodeManager.cs" />
     <Compile Include="BackEnd\Components\Communications\TaskHostNodeManager.cs" />
     <Compile Include="BackEnd\Components\Communications\LogMessagePacket.cs" />
@@ -221,9 +221,9 @@
     <Compile Include="BackEnd\Components\Caching\IPropertyCache.cs" />
     <Compile Include="BackEnd\Components\Caching\IResultsCache.cs" />
     <Compile Include="BackEnd\Components\Communications\NodePacketTranslatorExtensions.cs" />
-    <Compile Include="BackEnd\Components\Communications\NodeProviderOutOfProc.cs" />
-    <Compile Include="BackEnd\Components\Communications\NodeProviderOutOfProcBase.cs" />
-    <Compile Include="BackEnd\Components\Communications\NodeProviderOutOfProcTaskHost.cs" />
+    <Compile Include="BackEnd\Components\Communications\NodeProviderOutOfProc.cs" Condition="$(FeatureAppDomain) == 'true'"/>
+    <Compile Include="BackEnd\Components\Communications\NodeProviderOutOfProcBase.cs" Condition="$(FeatureAppDomain) == 'true'"/>
+    <Compile Include="BackEnd\Components\Communications\NodeProviderOutOfProcTaskHost.cs" Condition="$(FeatureAppDomain) == 'true'"/>
     <Compile Include="BackEnd\Components\RequestBuilder\BatchingEngine.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -235,7 +235,7 @@
     <Compile Include="BackEnd\Components\RequestBuilder\TargetSpecification.cs" />
     <Compile Include="BackEnd\Node\InProcNode.cs" />
     <Compile Include="BackEnd\Node\NodeConfiguration.cs" />
-    <Compile Include="BackEnd\Node\OutOfProcNode.cs" />
+    <Compile Include="BackEnd\Node\OutOfProcNode.cs" Condition="$(FeatureAppDomain) == 'true'" />
     <Compile Include="BackEnd\Node\NativeMethods.cs" />
     <Compile Include="BackEnd\Shared\BuildAbortedException.cs" />
     <Compile Include="BackEnd\Components\RequestBuilder\IRequestBuilder.cs" />


### PR DESCRIPTION
This pull request finishes the changes necessary to successfully compile Microsoft.Build for .NET Core.  Lots of code which depended on features which weren't available was simply disabled, so more work will be needed to make sure that the code works on .NET Core.