### PR TITLE
Merge Unicode-related exec changes into xplat

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
@@ -1007,14 +1007,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 EndGlobal
                 ";
 
-            try
-            {
-                SolutionFile solution = ParseSolutionHelper(solutionFileContents);
-            }
-            catch (InvalidProjectFileException ex)
-            {
-                Assert.Fail();
-            }
+            ParseSolutionHelper(solutionFileContents);
         }
 
         /// <summary>

--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -287,6 +287,32 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        /// <summary>
+        /// Tests that Exec still executes properly when there's a non-ansi character in the command
+        /// </summary>
+        [Test]
+        public void ExecTaskUnicodeCharacterInCommand()
+        {
+            string nonAnsiCharacters = "创建";
+            string folder = Path.Combine(Path.GetTempPath(), nonAnsiCharacters);
+            string command = Path.Combine(folder, "test.cmd");
+
+            try
+            {
+                Directory.CreateDirectory(folder);
+                File.WriteAllText(command, "echo [hello]");
+                Exec exec = PrepareExec(command);
+
+                Assert.IsTrue(exec.Execute(), "Task should have succeeded");
+                ((MockEngine)exec.BuildEngine).AssertLogContains("[hello]");
+            }
+            finally
+            {
+                if (Directory.Exists(folder))
+                    Directory.Delete(folder, true);
+            }
+        }
+
         [Test]
         public void InvalidUncDirectorySet()
         {


### PR DESCRIPTION
This just catches us up to the latest master, but it's a nontrivial merge so I figured I'd get it reviewed separately.