### PR TITLE
Made MSBuild Debugger compilation conditional.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -59,13 +59,20 @@
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
     <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
     <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
+    <MsbuildDebugger>true</MsbuildDebugger>
     <DefineConstants>$(DefineConstants);DEBUG;TRACE;STANDALONEBUILD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
     <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+    <MsbuildDebugger>true</MsbuildDebugger>
     <DefineConstants>$(DefineConstants);TRACE;STANDALONEBUILD</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Change define constants as needed -->
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);FEATURE_MSBUILD_DEBUGGER</DefineConstants>
   </PropertyGroup>
 
   <!-- Setup some common paths -->

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Build.Framework
             // NOTE: String.Format() does not allow a null arguments array
             if ((args != null) && (args.Length > 0))
             {
-#if DEBUG && !BUILDING_DF_LKG
+#if DEBUG
 
 #if VALIDATERESOURCESTRINGS
                 // The code below reveals many places in our codebase where

--- a/src/Shared/ProjectErrorUtilities.cs
+++ b/src/Shared/ProjectErrorUtilities.cs
@@ -15,7 +15,9 @@ using System.Xml;
  * 
  * 
  ******************************************************************************/
+#if FEATURE_MSBUILD_DEBUGGER
 using Microsoft.Build.Debugging;
+#endif
 using Microsoft.Build.Evaluation;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 
@@ -413,6 +415,7 @@ namespace Microsoft.Build.Shared
 
             Exception exceptionToThrow = new InvalidProjectFileException(elementLocation.File, elementLocation.Line, elementLocation.Column, 0 /* Unknown end line */, 0 /* Unknown end column */, message, errorSubCategory, errorCode, helpKeyword);
 
+#if FEATURE_MSBUILD_DEBUGGER
             if (!DebuggerManager.DebuggingEnabled)
             {
                 throw exceptionToThrow;
@@ -434,6 +437,9 @@ namespace Microsoft.Build.Shared
                 Debugger.Break();
                 throw;
             }
+#else
+            throw exceptionToThrow;
+#endif
         }
     }
 }

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
-#if DEBUG && !BUILDING_DF_LKG
+#if DEBUG
 using Microsoft.Build.Framework;
 #endif
 using System.Reflection;
@@ -211,7 +211,7 @@ namespace Microsoft.Build.Shared
             // NOTE: String.Format() does not allow a null arguments array
             if ((args != null) && (args.Length > 0))
             {
-#if DEBUG && !BUILDING_DF_LKG
+#if DEBUG
 
 #if VALIDATERESOURCESTRINGS
                 // The code below reveals many places in our codebase where

--- a/src/Shared/TaskLoggingHelperExtension.cs
+++ b/src/Shared/TaskLoggingHelperExtension.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Helper logging class for tasks, used for dealing with two resource streams.
     /// </summary>
-#if WHIDBEY_VISIBILITY || BUILD_ENGINE
+#if BUILD_ENGINE
     internal
 #else
     public

--- a/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
+++ b/src/Utilities/TrackedDependencies/CanonicalTrackedOutputFiles.cs
@@ -32,12 +32,7 @@ namespace Microsoft.Build.Utilities
         #region Properties
 
         // Provide external access to the dependencyTable
-#if WHIDBEY_VISIBILITY
-        internal
-#else
-        public
-#endif
-        Dictionary<string, Dictionary<string, DateTime>> DependencyTable
+        internal Dictionary<string, Dictionary<string, DateTime>> DependencyTable
         {
             get { return _dependencyTable; }
         }

--- a/src/Utilities/TrackedDependencies/FlatTrackingData.cs
+++ b/src/Utilities/TrackedDependencies/FlatTrackingData.cs
@@ -68,12 +68,7 @@ namespace Microsoft.Build.Utilities
         #region Properties
 
         // Provide external access to the dependencyTable
-#if WHIDBEY_VISIBILITY
-        internal
-#else
-        public
-#endif
-        IDictionary<string, DateTime> DependencyTable
+        internal IDictionary<string, DateTime> DependencyTable
         {
             get { return _dependencyTable; }
         }
@@ -675,11 +670,11 @@ namespace Microsoft.Build.Utilities
                 // empty all tlogs
                 foreach (ITaskItem tlogFile in _tlogFiles)
                 {
-                    File.WriteAllText(tlogFile.ItemSpec, "", System.Text.Encoding.Unicode);
+                    File.WriteAllText(tlogFile.ItemSpec, "", Encoding.Unicode);
                 }
 
                 // Write out the dependency information as a new tlog
-                using (StreamWriter newTlog = new StreamWriter(firstTlog, false, System.Text.Encoding.Unicode))
+                using (StreamWriter newTlog = new StreamWriter(firstTlog, false, Encoding.Unicode))
                 {
                     foreach (string fileEntry in _dependencyTable.Keys)
                     {
@@ -748,7 +743,7 @@ namespace Microsoft.Build.Utilities
             FlatTrackingData outputs = new FlatTrackingData(hostTask, writeTLogNames, DateTime.MinValue);
 
             // Find out if we are up to date
-            isUpToDate = FlatTrackingData.IsUpToDate(hostTask.Log, upToDateCheckType, inputs, outputs);
+            isUpToDate = IsUpToDate(hostTask.Log, upToDateCheckType, inputs, outputs);
 
             // We're going to execute, so clear out the tlogs so
             // the new execution will correctly populate the tlogs a-new
@@ -959,12 +954,7 @@ namespace Microsoft.Build.Utilities
     /// <summary>
     /// The possible types of up to date check that we can support
     /// </summary>
-#if WHIDBEY_VISIBILITY
-    internal
-#else
-    public
-#endif
-    enum UpToDateCheckType
+    public enum UpToDateCheckType
     {
         InputNewerThanOutput,
         InputOrOutputNewerThanTracking,

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -15,12 +15,7 @@ namespace Microsoft.Build.Utilities
     /// <summary>
     /// This class contains utility functions to assist with tracking dependencies
     /// </summary>
-#if WHIDBEY_VISIBILITY
-    internal
-#else
-    public
-#endif
-    static class TrackedDependencies
+    internal static class TrackedDependencies
     {
         #region Methods
         /// <summary>

--- a/src/Utilities/UnitTests/TrackedDependencies/MockEngine.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/MockEngine.cs
@@ -27,11 +27,7 @@ namespace Microsoft.Build.UnitTests.TrackedDependencies
      * is somewhat of a no-no for task assemblies.
      * 
      **************************************************************************/
-#if WHIDBEY_BUILD
-    sealed internal class MockEngine : IBuildEngine
-#else
     sealed internal class MockEngine : IBuildEngine2
-#endif
     {
         private bool _isRunningMultipleNodes;
         private int _messages = 0;

--- a/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -13,7 +13,9 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Collections;
+#if FEATURE_MSBUILD_DEBUGGER
 using Microsoft.Build.Debugging;
+#endif
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
@@ -791,19 +793,22 @@ namespace Microsoft.Build.BackEnd
                 {
                     ProjectTargetInstanceChild targetChildInstance = _target.Children[currentTask];
 
+#if FEATURE_MSBUILD_DEBUGGER
                     if (DebuggerManager.DebuggingEnabled)
                     {
                         DebuggerManager.EnterState(targetChildInstance.Location, lookupForExecution.GlobalsForDebugging /* does not matter which lookup we get this from */);
                     }
+#endif
 
                     // Execute the task.
                     lastResult = await taskBuilder.ExecuteTask(targetLoggingContext, _requestEntry, _targetBuilderCallback, targetChildInstance, mode, lookupForInference, lookupForExecution, _cancellationToken);
 
+#if FEATURE_MSBUILD_DEBUGGER
                     if (DebuggerManager.DebuggingEnabled)
                     {
                         DebuggerManager.LeaveState(targetChildInstance.Location);
                     }
-
+#endif
                     if (lastResult.ResultCode == WorkUnitResultCode.Failed)
                     {
                         aggregatedTaskResult = WorkUnitResultCode.Failed;

--- a/src/XMakeBuildEngine/Debugger/DebuggerLocalType.cs
+++ b/src/XMakeBuildEngine/Debugger/DebuggerLocalType.cs
@@ -5,6 +5,8 @@
 // <summary>Description of a local type for a debugger local.</summary>
 //-----------------------------------------------------------------------
 
+#if FEATURE_MSBUILD_DEBUGGER
+
 using System;
 using Microsoft.Build.Shared;
 using System.Diagnostics;
@@ -58,3 +60,4 @@ namespace Microsoft.Build.Debugging
         }
     }
 }
+#endif

--- a/src/XMakeBuildEngine/Debugger/DebuggerManager.cs
+++ b/src/XMakeBuildEngine/Debugger/DebuggerManager.cs
@@ -5,6 +5,8 @@
 // <summary>Provides debugging support for state machines.</summary>
 //-----------------------------------------------------------------------
 
+#if FEATURE_MSBUILD_DEBUGGER
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -906,3 +908,4 @@ namespace Microsoft.Build.Debugging
         }
     }
 }
+#endif

--- a/src/XMakeBuildEngine/Instance/ProjectInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectInstance.cs
@@ -24,7 +24,9 @@ using Utilities = Microsoft.Build.Internal.Utilities;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
 using ProjectItemInstanceFactory = Microsoft.Build.Execution.ProjectItemInstance.TaskItem.ProjectItemInstanceFactory;
+#if MSBUILD_DEBUGGER
 using Microsoft.Build.Debugging;
+#endif
 using System.Xml;
 using System.IO;
 using System.Collections;

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -13,10 +13,10 @@
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DefineConstants>TRACE;DEBUG;STANDALONEBUILD;BUILD_ENGINE</DefineConstants>
+    <DefineConstants>$(DefineConstants);BUILD_ENGINE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DefineConstants>TRACE;STANDALONEBUILD;BUILD_ENGINE</DefineConstants>
+    <DefineConstants>$(DefineConstants);BUILD_ENGINE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -24,7 +24,6 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\build\Debug</OutputPath>
-    <DefineConstants>TRACE;DEBUG;VS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -39,7 +38,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\..\build\Debug-MONO\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;VS;MONO</DefineConstants>
+    <DefineConstants>$(DefineConstants);VS;MONO</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/src/XMakeCommandLine/native.rc
+++ b/src/XMakeCommandLine/native.rc
@@ -7,6 +7,4 @@
 #include <vsver.rc>
 
 APPICON               ICON    "MSBuild.ico"
-#ifndef BUILDING_DF_LKG
 1		RT_MANIFEST   "msbuild.exe.manifest"
-#endif

--- a/src/XMakeTasks/CommandLineBuilderExtension.cs
+++ b/src/XMakeTasks/CommandLineBuilderExtension.cs
@@ -14,12 +14,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// CommandLineBuilder derived class for specialized logic specific to MSBuild tasks
     /// </summary>
-#if WHIDBEY_VISIBILITY
-    internal
-#else
-    public /* because its used by VJ# Vjc task. */
-#endif
-    class CommandLineBuilderExtension : CommandLineBuilder
+    public class CommandLineBuilderExtension : CommandLineBuilder
     {
         /// <summary>
         /// Set a boolean switch iff its value exists and its value is 'true'.

--- a/src/XMakeTasks/DataDriven/DataDrivenToolTask.cs
+++ b/src/XMakeTasks/DataDriven/DataDrivenToolTask.cs
@@ -58,20 +58,11 @@ namespace Microsoft.Build.Tasks.DataDriven
         /// <summary>
         /// Default constructor
         /// </summary>
-#if WHIDBEY_VISIBILITY
-        internal
-#else
-        protected
-#endif
-        DataDrivenToolTask(ResourceManager taskResources)
+        protected DataDrivenToolTask(ResourceManager taskResources)
             : base(taskResources)
         {
             logPrivate = new TaskLoggingHelper(this);
-#if WHIDBEY_BUILD
-            logPrivate.TaskResources = AssemblyResources.DataDrivenToolTaskResources;
-#else
             logPrivate.TaskResources = AssemblyResources.PrimaryResources;
-#endif
             logPrivate.HelpKeywordPrefix = "MSBuild.";
         }
 
@@ -80,12 +71,7 @@ namespace Microsoft.Build.Tasks.DataDriven
         /// <summary>
         /// The list of all the switches that have been set
         /// </summary>
-#if WHIDBEY_VISIBILITY
-        internal
-#else
-        protected
-#endif
-        Dictionary<string, ToolSwitch> ActiveToolSwitches
+        protected Dictionary<string, ToolSwitch> ActiveToolSwitches
         {
             get
             {
@@ -199,12 +185,7 @@ namespace Microsoft.Build.Tasks.DataDriven
         /// Returns the generated command line
         /// </summary>
         /// <returns></returns>
-#if WHIDBEY_VISIBILITY
-        internal virtual 
-#else
-        internal
-#endif
-        string GetCommandLine_ForUnitTestsOnly() 
+        internal string GetCommandLine_ForUnitTestsOnly() 
         {
             return GenerateResponseFileCommands();
         }

--- a/src/XMakeTasks/XMakeTasksUnitTests/XMakeTasksUnitTests.csproj
+++ b/src/XMakeTasks/XMakeTasksUnitTests/XMakeTasksUnitTests.csproj
@@ -18,7 +18,6 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -26,7 +25,6 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
An MsbuildDebugger property must be added to a configuration to enable.
Removed a few unused condition constants that are no longer used.