### PR TITLE
Fix broken unit tests

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionFile_Tests.cs
@@ -648,10 +648,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         /// <param name="solutionFileContents"></param>
         /// <returns></returns>
-        static internal SolutionFile ParseSolutionHelper
-            (
-            string solutionFileContents
-            )
+        static internal SolutionFile ParseSolutionHelper(string solutionFileContents)
         {
             solutionFileContents = solutionFileContents.Replace('\'', '"');
             StreamReader sr = StreamHelpers.StringToStreamReader(solutionFileContents);
@@ -659,13 +656,9 @@ namespace Microsoft.Build.UnitTests.Construction
             SolutionFile sp = new SolutionFile();
             sp.SolutionFileDirectory = Path.GetTempPath();
             sp.SolutionReader = sr;
-            string tmpFileName = FileUtilities.GetTemporaryFile();
-            sp.FullPath = tmpFileName + ".sln";
-            // This file is not expected to exist at this point, so make sure it doesn't
-            File.Delete(sp.FullPath);
+            sp.FullPath = FileUtilities.GetTemporaryFileName(".sln");
             sp.ParseSolution();
             // Clean up the temporary file that got created with this call
-            File.Delete(tmpFileName);
             return sp;
         }
 

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Build.UnitTests.Construction
         {
             // Need to make sure the environment is cleared up for later tests
             Environment.SetEnvironmentVariable("VisualStudioVersion", _originalVisualStudioVersion);
+            ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
         }
 
         /// <summary>
@@ -1516,8 +1517,6 @@ EndGlobal
         [TestMethod]
         public void SolutionGeneratorEscapingProjectFilePaths()
         {
-            string oldValueForMSBuildEmitSolution = Environment.GetEnvironmentVariable("MSBuildEmitSolution");
-
             string solutionFileContents =
                 @"
                 Microsoft Visual Studio Solution File, Format Version 9.00


### PR DESCRIPTION
 - I think a test was added that changed (static) state in the
   ProjectCollection's Global Project Collection. This was causing a few
   tests to fail asserts depending on what order things ran. I just set it
   to unload after each run.
 - While I was there I couldn't help but change the logic that creates a
   temp file and immediately deletes it and adds an extension to it.

Closed #164