### PR TITLE
Re-enabling unit tests

### DIFF
--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -974,8 +974,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIsEmpty()
         {
             string projectContents = @"
@@ -1017,8 +1015,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIs10()
         {
             string projectContents = @"
@@ -1062,8 +1058,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIs11()
         {
             string projectContents = @"
@@ -3260,8 +3254,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify that the GetPlatformExtensionSDKLocation method can be correctly called during evaluation time as a msbuild function.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyGetInstalledSDKLocations()
         {
             string testDirectoryRoot = Path.Combine(Path.GetTempPath(), "VerifyGetInstalledSDKLocations");
@@ -3331,8 +3323,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify that the GetPlatformExtensionSDKLocation method can be correctly called during evaluation time as a msbuild function.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyGetInstalledSDKLocations2()
         {
             string testDirectoryRoot = Path.Combine(Path.GetTempPath(), "VerifyGetInstalledSDKLocations2");
@@ -3403,8 +3393,6 @@ namespace Microsoft.Build.UnitTests
         /// Setup some fake entries in the registry and verify we get the correct sdk from there.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyGetInstalledSDKLocations3()
         {
             string testDirectoryRoot = Path.Combine(Path.GetTempPath(), "VerifyGetInstalledSDKLocations3");
@@ -3806,8 +3794,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify that the GetPlatformSDKPropsFileLocation method can be correctly called for pre-OneCore SDKs during evaluation time as a msbuild function.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyGetPreOneCoreSDKPropsLocation()
         {
             // This is the mockup layout for SDKs before One Core SDK.
@@ -3878,8 +3864,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify that the GetPlatformSDKPropsFileLocation method can be correctly called for OneCore SDK during evaluation time as a msbuild function.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void VerifyGetOneCoreSDKPropsLocation()
         {
             // This is the mockup layout for One Core SDK. 

--- a/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Build.UnitTests.FileTracking
         [ClassInitialize]
         public static void ClassSetup(TestContext testContext)
         {
-            s_defaultFileTrackerPathUnquoted = null;//FileTracker.GetFileTrackerPath(ExecutableType.SameAsCurrentProcess);
-            s_defaultFileTrackerPath = null; //"\"" + defaultFileTrackerPathUnquoted + "\"";
-            s_defaultTrackerPath = null;//FileTracker.GetTrackerPath(ExecutableType.SameAsCurrentProcess);
+            s_defaultFileTrackerPathUnquoted = FileTracker.GetFileTrackerPath(ExecutableType.SameAsCurrentProcess);
+            s_defaultFileTrackerPath = "\"" + s_defaultFileTrackerPathUnquoted + "\"";
+            s_defaultTrackerPath = FileTracker.GetTrackerPath(ExecutableType.SameAsCurrentProcess);
         }
 
         [TestInitialize]
@@ -72,8 +72,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerHelp()
         {
             Console.WriteLine("Test: FileTracker");
@@ -83,8 +81,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerBadArg()
         {
             Console.WriteLine("Test: FileTrackerBadArg");
@@ -97,8 +93,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerNoUIDll()
         {
             Console.WriteLine("Test: FileTrackerNoUIDll");
@@ -136,8 +130,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerNonexistentRspFile()
         {
             Console.WriteLine("Test: FileTrackerNonexistentRspFile");
@@ -159,8 +151,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerWithDll()
         {
             Console.WriteLine("Test: FileTrackerWithDll");
@@ -171,8 +161,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerReadOnlyTlog()
         {
             Console.WriteLine("Test: FileTrackerTlogWriteFailure");
@@ -205,8 +193,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrIn()
         {
             Console.WriteLine("Test: FileTrackerFindStrIn");
@@ -221,8 +207,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInOperations()
         {
             Console.WriteLine("Test: FileTrackerFindStrInOperations");
@@ -241,8 +225,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInOperationsExtended()
         {
             Console.WriteLine("Test: FileTrackerFindStrInOperationsExtended");
@@ -266,8 +248,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInOperationsExtended_AttributesOnly()
         {
             Console.WriteLine("Test: FileTrackerFindStrInOperationsExtended_AttributesOnly");
@@ -290,8 +270,6 @@ namespace Microsoft.Build.UnitTests.FileTracking
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerExtendedDirectoryTracking()
         {
             Console.WriteLine("Test: FileTrackerExtendedDirectoryTracking");
@@ -414,8 +392,6 @@ namespace ConsoleApplication4
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInIncludeDuplicates()
         {
             Console.WriteLine("Test: FileTrackerFindStrInIncludeDuplicates");
@@ -457,8 +433,6 @@ namespace ConsoleApplication4
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerDoNotRecordWriteAsRead()
         {
             Console.WriteLine("Test: FileTrackerDoNotRecordWriteAsRead");
@@ -533,8 +507,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInCommandLine()
         {
             Console.WriteLine("Test: FileTrackerFindStrInCommandLine");
@@ -550,8 +522,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInArgumentSpaces()
         {
             Console.WriteLine("Test: FileTrackerFindStrIn");
@@ -566,8 +536,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindUnicode()
         {
             Console.WriteLine("Test: FileTrackerFindUnicode");
@@ -583,8 +551,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerStartProcessFindStrIn()
         {
             Console.WriteLine("Test: FileTrackerStartProcessFindStrIn");
@@ -601,8 +567,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerResponseFile()
         {
             Console.WriteLine("Test: FileTrackerResponseFile");
@@ -623,8 +587,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInRootFiles()
         {
             Console.WriteLine("Test: FileTrackerFindStrInRootFiles");
@@ -642,8 +604,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInRootFilesCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInRootFilesCommand");
@@ -664,8 +624,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInRootFilesSpaces()
         {
             Console.WriteLine("Test: FileTrackerFindStrInRootFilesSpaces");
@@ -683,8 +641,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerHelperCommandLine()
         {
             Console.WriteLine("Test: FileTrackerHelperCommandLine");
@@ -702,8 +658,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerSortOut()
         {
             Console.WriteLine("Test: FileTrackerSortOut");
@@ -730,8 +684,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerSortOutIntermediate()
         {
             Console.WriteLine("Test: FileTrackerSortOutIntermediate");
@@ -760,8 +712,6 @@ class X
 
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerIntermediateDirMissing()
         {
             Console.WriteLine("Test: FileTrackerIntermediateDirMissing");
@@ -792,8 +742,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInChain()
         {
             Console.WriteLine("Test: FileTrackerFindStrInChain");
@@ -808,8 +756,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFindStrInChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInChainRepeatCommand");
@@ -829,8 +775,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFileIsUnderPath()
         {
             Console.WriteLine("Test: FileTrackerFileIsUnderPath");
@@ -877,8 +821,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void FileTrackerFileIsExcludedFromDependencies()
         {
             Console.WriteLine("Test: FileTrackerFileIsExcludedFromDependencies");
@@ -927,8 +869,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTest1()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -952,8 +892,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTest2()
         {
             // Do test 1 twice in a row to make sure there is no leakage
@@ -962,8 +900,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTestSuspendResume()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -1002,8 +938,6 @@ class X
 
         [TestMethod]
         [ExpectedException(typeof(COMException))]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTestStopBeforeWrite()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -1095,8 +1029,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTestIteration()
         {
             for (int iter = 0; iter < 50; iter++)
@@ -1106,8 +1038,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingNonStopTestIteration()
         {
             for (int iter = 0; iter < 50; iter++)
@@ -1118,8 +1048,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTwoContexts()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -1161,8 +1089,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingTwoContextsWithRoot()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -1214,8 +1140,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingSpawnsOutOfProcTool()
         {
             string intermediateDir = Path.GetTempPath() + @"InProcTrackingSpawnsOutOfProcTool\";
@@ -1264,8 +1188,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingSpawnsOutOfProcTool_OverrideEnvironment()
         {
             string intermediateDir = Path.GetTempPath() + @"InProcTrackingSpawnsOutOfProcTool_OverrideEnvironment\";
@@ -1316,8 +1238,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingSpawnsToolWithTrackerResponseFile()
         {
             Console.WriteLine("Test: InProcTrackingSpawnsToolWithTrackerResponseFile");
@@ -1326,8 +1246,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingSpawnsToolWithTrackerNoResponseFile()
         {
             Console.WriteLine("Test: InProcTrackingSpawnsToolWithTrackerNoResponseFile");
@@ -1336,8 +1254,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         [ExpectedException(typeof(COMException))]
         public void InProcTrackingTwoContextsTwoEnds()
         {
@@ -1378,8 +1294,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingStartProcessFindStrIn()
         {
             Console.WriteLine("Test: InProcTrackingStartProcessFindStrIn");
@@ -1408,8 +1322,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingStartProcessFindStrNullCommandLine()
         {
             Console.WriteLine("Test: InProcTrackingStartProcessFindStrNullCommandLine");
@@ -1457,8 +1369,6 @@ class X
 
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingStartProcessFindStrInDefaultTaskName()
         {
             Console.WriteLine("Test: InProcTrackingStartProcessFindStrInDefaultTaskName");
@@ -1488,8 +1398,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingChildThreadTrackedAuto()
         {
             FileTracker.SetThreadCount(1);
@@ -1531,8 +1439,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingChildThreadTrackedManual()
         {
             FileTracker.SetThreadCount(1);
@@ -1572,8 +1478,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingChildThreadNotTracked()
         {
             FileTracker.SetThreadCount(1);
@@ -1610,8 +1514,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingChildThreadNotTrackedLocallyTracked()
         {
             FileTracker.SetThreadCount(1);
@@ -1674,8 +1576,6 @@ class X
 
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void InProcTrackingChildCustomEnvironment()
         {
             string sourceFile = "allenvironment.txt";
@@ -1742,8 +1642,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void CreateFileDoesntRecordWriteIfNotWrittenTo()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "CreateFileDoesntRecordWriteIfNotWrittenTo");
@@ -1787,8 +1685,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void CopyAlwaysRecordsWrites()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "CopyAlwaysRecordsWrites");
@@ -1859,7 +1755,7 @@ class X
 
         [TestMethod]
         [Ignore]
-        // Ignore: Test requires installed toolset.
+        // Ignore: Needs investigation
         public void MoveAlwaysRecordsWrites()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "MoveAlwaysRecordsWrites");
@@ -1933,8 +1829,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleOfSameTool_SameCommand()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_SameCommand");
@@ -1967,8 +1861,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleOfSameTool_DifferentCommands1()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands1");
@@ -2002,8 +1894,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleOfSameTool_DifferentCommands2()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands2");
@@ -2054,8 +1944,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleOfSameTool_DifferentCommands3()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands3");
@@ -2111,8 +1999,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleOfSameTool_DifferentCommands4()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands4");
@@ -2167,8 +2053,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleDifferentTools()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleDifferentTools");
@@ -2218,8 +2102,6 @@ class X
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void LaunchMultipleOfSameTool_DifferentContexts()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentContexts");
@@ -2255,7 +2137,7 @@ class X
 
         [TestMethod]
         [Ignore]
-        // Ignore: Test requires installed toolset.
+        // Ignore: Needs investigation
         public void LaunchMultipleOfSameTool_ToolLaunchesOthers()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_ToolLaunchesOthers");

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/BuildManager_Tests.cs
@@ -146,8 +146,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// so that on the next call we get access to them
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void VerifyEnvironmentSavedBetweenCalls()
         {
             string contents1 = ObjectModelHelpers.CleanupFileContents(@"
@@ -340,8 +338,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// get all of the initial properties.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void InProcForwardPropertiesFromChild()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -393,8 +389,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// get all of the initial properties.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void InProcMsBuildForwardAllPropertiesFromChild()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1161,8 +1155,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// A sequential build.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void OverlappingBuildSubmissions()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1562,8 +1554,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// This test verifies that overlapping builds of the same project are allowed.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void OverlappingBuildsOfTheSameProjectSameTargetsAreAllowed()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -1755,8 +1745,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Retrieving a ProjectInstance after another build without resetting the cache keeps the existing instance
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void GhostProjectRootElementCache()
         {
             string contents1 = ObjectModelHelpers.CleanupFileContents(@"
@@ -1911,8 +1899,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// Verify that using a second BuildManager doesn't cause the system to crash.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void Regress251333()
         {
             string contents = ObjectModelHelpers.CleanupFileContents(@"
@@ -2179,8 +2165,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// that failure. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure()
         {
             string projA = null;
@@ -2246,8 +2230,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// AfterTargets, only one of which fails. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure_MultipleEntrypoints()
         {
             string projA = null;
@@ -2329,8 +2311,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// entrypoint target.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void FailedNestedAfterTargetInP2PShouldCauseOverallBuildFailure()
         {
             string projA = null;

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
@@ -39,8 +39,6 @@ namespace Microsoft.Build.UnitTests
         /// throw a path too long exception
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ProjectItemSpecTooLong()
         {
             string currentDirectory = Environment.CurrentDirectory;
@@ -106,8 +104,6 @@ namespace Microsoft.Build.UnitTests
         /// MSBuildSourceTargetName  -- that give an indication of where the items came from.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void OutputItemsAreTaggedWithProjectFileAndTargetName()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -180,8 +176,6 @@ namespace Microsoft.Build.UnitTests
         /// shouldn't error, and it shouldn't try to build itself.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void EmptyProjectsParameterResultsInNoop()
         {
             string projectContents = @"
@@ -203,8 +197,6 @@ namespace Microsoft.Build.UnitTests
         /// Verifies that nonexistent projects aren't normally skipped
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void NormallyDoNotSkipNonexistentProjects()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -226,8 +218,6 @@ namespace Microsoft.Build.UnitTests
         /// Verifies that nonexistent projects aren't normally skipped
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void NormallyDoNotSkipNonexistentProjectsBuildInParallel()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -251,8 +241,6 @@ namespace Microsoft.Build.UnitTests
         /// Verifies that nonexistent projects are skipped when requested
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SkipNonexistentProjects()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -290,8 +278,6 @@ namespace Microsoft.Build.UnitTests
         /// DDB # 125831
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SkipNonexistentProjectsBuildingInParallel()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -325,8 +311,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void LogErrorWhenBuildingVCProj()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -374,8 +358,6 @@ namespace Microsoft.Build.UnitTests
         /// property value and so he can't escape it himself.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void PropertyOverridesContainSemicolon()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -474,8 +456,6 @@ namespace Microsoft.Build.UnitTests
         /// Check if passing different global properites via metadata works
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DifferentGlobalPropertiesWithDefault()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -545,8 +525,6 @@ namespace Microsoft.Build.UnitTests
         /// Check if passing different global properites via metadata works
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DifferentGlobalPropertiesWithoutDefault()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -614,8 +592,6 @@ namespace Microsoft.Build.UnitTests
         /// Check trailing semicolons are ignored
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void VariousPropertiesToMSBuildTask()
         {
             string projectFile = null;
@@ -790,8 +766,6 @@ namespace Microsoft.Build.UnitTests
         /// Check if passing additional global properites via metadata works
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DifferentAdditionalPropertiesWithDefault()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -859,8 +833,6 @@ namespace Microsoft.Build.UnitTests
         /// Check if passing additional global properites via metadata works
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DifferentAdditionalPropertiesWithGlobalProperties()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -930,8 +902,6 @@ namespace Microsoft.Build.UnitTests
         /// Check if passing additional global properites via metadata works
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DifferentAdditionalPropertiesWithoutDefault()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -997,8 +967,6 @@ namespace Microsoft.Build.UnitTests
         /// Properties and Targets that use non-standard separation chars
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TargetsWithSeparationChars()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -1058,8 +1026,6 @@ namespace Microsoft.Build.UnitTests
         /// qa\md\wd\DTP\MSBuild\ShippingExtensions\ShippingTasks\MSBuild\_Tst\MSBuild.StopOnFirstFailure
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void StopOnFirstFailureandBuildInParallelSingleNode()
         {
             string project1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -1187,8 +1153,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify stopOnFirstFailure with BuildInParallel override message are correctly logged when there are multiple nodes
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void StopOnFirstFailureandBuildInParallelMultipleNode()
         {
             string project1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -1384,8 +1348,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify the behavior of Target execution with StopOnFirstFailure
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TargetStopOnFirstFailureBuildInParallel()
         {
             string project1 = ObjectModelHelpers.CreateTempFileOnDisk(@"
@@ -1540,8 +1502,6 @@ namespace Microsoft.Build.UnitTests
         /// Properties and Targets that use non-standard separation chars
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void PropertiesWithSeparationChars()
         {
             string projectFile1 = ObjectModelHelpers.CreateTempFileOnDisk(@"

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -589,8 +589,6 @@ namespace ItemCreationTask
         /// If an item being output from a task has null metadata, we shouldn't crash. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void NullMetadataOnOutputItems()
         {
             string customTaskPath = CustomTaskHelper.GetAssemblyForTask(s_nullMetadataTaskContents);
@@ -615,8 +613,6 @@ namespace ItemCreationTask
         /// If an item being output from a task has null metadata, we shouldn't crash. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void NullMetadataOnLegacyOutputItems()
         {
             string referenceAssembliesPath = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.VersionLatest);
@@ -651,8 +647,6 @@ namespace ItemCreationTask
         /// If an item being output from a task has null metadata, we shouldn't crash. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void NullMetadataOnOutputItems_InlineTask()
         {
             string projectContents = @"
@@ -694,7 +688,7 @@ namespace ItemCreationTask
         /// </summary>
         [TestMethod]
         [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
+        // Ignore: Needs investigation, doesn't like Task.v4.0.dll
         public void NullMetadataOnLegacyOutputItems_InlineTask()
         {
             string projectContents = @"
@@ -748,8 +742,6 @@ namespace ItemCreationTask
         /// which didn't support the defining project metadata.  
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ValidateDefiningProjectMetadataOnTaskOutputs_LegacyItems()
         {
             string referenceAssembliesPath = ToolLocationHelper.GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion.VersionLatest);
@@ -805,8 +797,6 @@ namespace ItemCreationTask
         /// Tests an MTA task with an exception.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TestSTAThreadNotRequiredWithException()
         {
             TestSTATask(false, false, true);
@@ -816,8 +806,6 @@ namespace ItemCreationTask
         /// Tests an MTA task with failure.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TestSTAThreadNotRequiredWithFailure()
         {
             TestSTATask(false, true, false);

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -361,8 +361,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// a task with parameters. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheTaskDoesNotExist_ExactMatch()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -403,8 +401,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// a task with parameters. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheTaskDoesNotExist_FuzzyMatch()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -445,8 +441,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// a task with parameters. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheMatchingTaskDoesNotExist_FuzzyMatch()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -489,8 +483,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// a task with parameters. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheMatchingTaskDoesNotExistOnFirstCallButDoesOnSecond()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -533,8 +525,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// a task with parameters. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheMatchingExactParameters()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -612,8 +602,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// parameters other than those two. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheMatchingExactParameters_AdditionalParameters()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -661,8 +649,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// fuzzy matches.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheFuzzyMatchingParameters()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -746,8 +732,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// fuzzy matches.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheFuzzyMatchingParameters_RecoverFromFailure()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -806,8 +790,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// sets. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheFuzzyMatchingParameters_MultipleUsingTasks()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -938,8 +920,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// record that's in the cache, even if it wasn't the original first record. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheFuzzyMatchingParameters_MultipleUsingTasks_PreferCache()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -992,8 +972,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// fuzzy matches.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheFuzzyMatchingParameters_ExactMatches()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");
@@ -1064,8 +1042,6 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// parameters other than those two. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void RetrieveFromCacheFuzzyMatchingParameters_AdditionalParameters()
         {
             Assert.IsNotNull(s_testTaskLocation, "Need a test task to run this test");

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [TestMethod]
         [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
+        // Ignore: Needs investigation
         public void DefaultSubToolsetIfSolutionVersionSubToolsetDoesntExist()
         {
             Environment.SetEnvironmentVariable("VisualStudioVersion", null);
@@ -285,7 +285,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [TestMethod]
         [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
+        // Ignore: Needs investigation
         public void SolutionPassesSubToolsetToChildProjects2()
         {
             string classLibraryContentsToolsV4 = ObjectModelHelpers.CleanupFileContents(
@@ -433,7 +433,7 @@ namespace Microsoft.Build.UnitTests.Construction
         /// </summary>
         [TestMethod]
         [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
+        // Ignore: Needs investigation
         public void SolutionDoesntPassSubToolsetToChildProjects()
         {
             try
@@ -1406,8 +1406,6 @@ EndGlobal
         /// Tests the algorithm for choosing target framework paths for ResolveAssemblyReferences for Venus
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TestTargetFrameworkPaths1()
         {
             if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)

--- a/src/XMakeBuildEngine/UnitTests/Definition/ItemDefinitionGroup_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ItemDefinitionGroup_Tests.cs
@@ -1697,8 +1697,6 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void MSBuildCallDoesNotAffectCallingProjectsDefinitions()
         {
             string otherProject = null;
@@ -1755,8 +1753,6 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DefaultMetadataTravelWithTargetOutputs()
         {
             string otherProject = null;

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsVersion_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsVersion_Tests.cs
@@ -413,8 +413,6 @@ namespace Microsoft.Build.UnitTests.Definition
         /// Validate that a custom defined toolset is honored
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void CustomToolsVersionIsHonored()
         {
             Environment.SetEnvironmentVariable("MSBUILDTREATALLTOOLSVERSIONSASCURRENT", String.Empty);

--- a/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
         [TestMethod]
         [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
+        // Ignore: This scenario is broken in Roslyn
         public void TestDefaultSubToolsetFor40()
         {
             Toolset t = ProjectCollection.GlobalProjectCollection.GetToolset("4.0");

--- a/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
@@ -512,8 +512,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// they only get unescaped when fed into a subsequent task.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void InferEscapedOutputsFromTask()
         {
             string inputFile = null;
@@ -556,8 +554,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// as an escaped percent sign.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ItemTransformContainingSemicolon()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
@@ -583,8 +579,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// as an escaped percent sign.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ItemTransformContainingSemicolon_InTaskHost()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectSuccess(@"
@@ -646,8 +640,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// won't be unescaped.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void GlobalPropertyWithEscapedCharacters()
         {
             MockLogger logger = new MockLogger();
@@ -672,8 +664,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// literally, not as a wildcard
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void EscapedWildcardsShouldNotBeExpanded()
         {
             MockLogger logger = new MockLogger();
@@ -708,8 +698,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// literally, not as a wildcard
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void EscapedWildcardsShouldNotBeExpanded_InTaskHost()
         {
             MockLogger logger = new MockLogger();
@@ -775,8 +763,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// same name.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TargetNamesAlwaysUnescaped_Override()
         {
             Project project = ObjectModelHelpers.CreateInMemoryProject(@"
@@ -908,8 +894,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         ///     ESCAPING: Escaping in conditionals is broken.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SemicolonInConfiguration()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -968,8 +952,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         ///     ESCAPING: Escaping in conditionals is broken.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void SemicolonInConfiguration_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1038,8 +1020,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         ///     ESCAPING: CopyBuildTarget target fails if the output assembly name contains a semicolon or single-quote
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void SemicolonInAssemblyName()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1092,8 +1072,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         ///     ESCAPING: CopyBuildTarget target fails if the output assembly name contains a semicolon or single-quote
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SemicolonInAssemblyName_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1156,8 +1134,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         ///     ESCAPING: Conversion Issue: Properties with $(xxx) as literals are not being converted correctly
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DollarSignInAssemblyName()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1210,8 +1186,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         ///     ESCAPING: Conversion Issue: Properties with $(xxx) as literals are not being converted correctly
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void DollarSignInAssemblyName_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1274,8 +1248,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// This is the case when one of the source code files in the project has a filename containing a semicolon.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void SemicolonInSourceCodeFilename()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1328,8 +1300,6 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// This is the case when one of the source code files in the project has a filename containing a semicolon.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SemicolonInSourceCodeFilename_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");
@@ -1395,7 +1365,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// </summary>
         [TestMethod]
         [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
+        // Ignore: This scenario is broken in Roslyn
         public void SolutionWithLotsaCrazyCharacters()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -1592,7 +1562,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
         /// </summary>
         [TestMethod]
         [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
+        // Ignore: This scenario is broken in Roslyn
         public void SolutionWithLotsaCrazyCharacters_UsingTaskHost()
         {
             string originalOverrideTaskHostVariable = Environment.GetEnvironmentVariable("MSBUILDFORCEALLTASKSOUTOFPROC");

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
@@ -3193,8 +3193,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// still receive the original value of the global property. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void VerifyGlobalPropertyPassedToP2P()
         {
             string projectContents = ObjectModelHelpers.CleanupFileContents(@"
@@ -3257,8 +3255,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// global property.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void VerifyLocalPropertyPropagatesIfExplicitlyPassedToP2P()
         {
             string projectContents = ObjectModelHelpers.CleanupFileContents(@"

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
@@ -102,58 +102,6 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         }
 
         /// <summary>
-        /// Tests that only a limited number of strong references are held
-        /// </summary>
-        [TestMethod]
-        [Ignore] // "This test seems to be flaky depending on when garbage collection happened"
-        public void AddManyEntriesNotAllStrongReferences()
-        {
-            List<string> paths = new List<string>(55);
-            for (int i = 0; i < 55; i++)
-            {
-                paths.Add(Path.Combine("c:\\", i.ToString()));
-            }
-
-            for (int i = 0; i < paths.Count; i++)
-            {
-                ProjectRootElement.Create(paths[i]);
-            }
-
-            GC.Collect();
-
-            // Boost one
-            ProjectCollection.GlobalProjectCollection.ProjectRootElementCache.Get(paths[2], (p, c) => null, true);
-
-            GC.Collect();
-
-            // Should have only indexes 6 through 54 remaining, except #2 which got boosted
-            for (int i = 0; i < 6; i++)
-            {
-                if (i != 2)
-                {
-                    Assert.IsNull(ProjectCollection.GlobalProjectCollection.ProjectRootElementCache.TryGet(paths[i]), "expected " + i + " to not be in cache");
-                }
-            }
-
-            for (int i = 2; i < 55; i++)
-            {
-                if (i > 5 || i == 2)
-                {
-                    Assert.IsNotNull(ProjectCollection.GlobalProjectCollection.ProjectRootElementCache.TryGet(paths[i]));
-                }
-            }
-
-            ProjectCollection.GlobalProjectCollection.ProjectRootElementCache.DiscardStrongReferences();
-
-            GC.Collect();
-
-            for (int i = 0; i < 55; i++)
-            {
-                Assert.IsNull(ProjectCollection.GlobalProjectCollection.ProjectRootElementCache.TryGet(paths[i]));
-            }
-        }
-
-        /// <summary>
         /// Cache should not return a ProjectRootElement if the file it was loaded from has since changed -
         /// if the cache was configured to auto-reload.
         /// </summary>

--- a/src/XMakeBuildEngine/UnitTests/InvalidProjectFileException_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/InvalidProjectFileException_Tests.cs
@@ -57,8 +57,6 @@ namespace Microsoft.Build.UnitTests
         /// Verify that nesting an IPFE copies the error code
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ErrorCodeShouldAppearForCircularDependency()
         {
             string file = Path.GetTempPath() + Guid.NewGuid().ToString("N");

--- a/src/XMakeBuildEngine/UnitTests/TargetsFile_Test.cs
+++ b/src/XMakeBuildEngine/UnitTests/TargetsFile_Test.cs
@@ -31,8 +31,6 @@ namespace Microsoft.Build.UnitTests
         /// Check that the ARM flag is passed to the compiler when targeting ARM.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TargetARM()
         {
             string file = null;
@@ -85,8 +83,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void AnyCPULibraryProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -137,8 +133,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void ExplicitAnyCPULibraryProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -190,8 +184,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void AnyCPUWinMDObjProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -248,8 +240,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ExplicitAnyCPUWinMDObjProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -307,8 +297,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void AnyCPUExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -359,8 +347,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ExplicitAnyCPUExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -462,8 +448,6 @@ namespace Microsoft.Build.UnitTests
         /// targeting .NET 4.0 do not get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ExplicitAnyCPU40ExeProjectIsNot32BitPreferred()
         {
             string file = null;
@@ -515,8 +499,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void AnyCPUAppContainerExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -573,8 +555,6 @@ namespace Microsoft.Build.UnitTests
         /// get forced to anycpu32bitpreferred by default. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void ExplicitAnyCPUAppContainerExeProjectIs32BitPreferred()
         {
             string file = null;
@@ -632,8 +612,6 @@ namespace Microsoft.Build.UnitTests
         /// not supported for library projects, if Prefer32Bit is explicitly set, we should still respect that. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void AnyCPULibraryProjectIs32BitPreferredIfPrefer32BitSet()
         {
             string file = null;
@@ -686,8 +664,6 @@ namespace Microsoft.Build.UnitTests
         /// so it should also default to Prefer32Bit = true. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void AnyCPUProjectWithNoExplicitOutputTypeIs32BitPreferred()
         {
             string file = null;
@@ -738,8 +714,6 @@ namespace Microsoft.Build.UnitTests
         /// so it should also default to Prefer32Bit = true. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void AnyCPUJupiterProjectWithNoExplicitOutputTypeIs32BitPreferred()
         {
             string file = null;
@@ -792,8 +766,6 @@ namespace Microsoft.Build.UnitTests
         /// Validate that the GetFrameworkPaths target 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void TestGetFrameworkPaths()
         {
             MockLogger logger = new MockLogger();
@@ -829,8 +801,6 @@ namespace Microsoft.Build.UnitTests
         /// Validate that the GetFrameworkPaths target 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void TestTargetFrameworkPaths()
         {
             string[] targetFrameworkVersions = { "v2.0", "v3.0", "v3.5", "v4.0", "v4.5", "" };
@@ -896,8 +866,6 @@ namespace Microsoft.Build.UnitTests
         /// Doesn't synthesize Link metadata if the items are defined in the project  
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void NoLinkMetadataSynthesisWhenDefinedInProject()
         {
             string[] files = null;
@@ -960,8 +928,6 @@ namespace Microsoft.Build.UnitTests
         /// Synthesizes Link metadata if the items are defined in an import and are on the whitelist
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SynthesizeLinkMetadataForItemsOnWhitelist()
         {
             string[] files = null;
@@ -1041,8 +1007,6 @@ namespace Microsoft.Build.UnitTests
         /// Don't synthesize link metadata if the SynthesizeLinkMetadata property is false
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void DontSynthesizeLinkMetadataIfPropertyNotSet()
         {
             string[] files = null;

--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -751,8 +751,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void MSBuildEngineLogger()
         {
             string projectString =
@@ -838,8 +836,6 @@ namespace Microsoft.Build.UnitTests
         /// take priority over any other response files.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ResponseFileInProjectDirectoryFoundImplicitly()
         {
             string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
@@ -2333,8 +2333,6 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
     public class References
     {
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void DontLockP2PReferenceWhenResolvingSystemTypes()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -2508,8 +2506,6 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// Assembly.LoadFrom instead.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires dependent components (e.g. csc2.exe).
         public void ReferencedAssemblySpecifiedUsingRelativePath()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting

--- a/src/XMakeTasks/UnitTests/MSBuild_Tests.cs
+++ b/src/XMakeTasks/UnitTests/MSBuild_Tests.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Build.UnitTests
         /// throw a path too long exception
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void ProjectItemSpecTooLong()
         {
             string currentDirectory = Environment.CurrentDirectory;
@@ -220,8 +218,6 @@ namespace Microsoft.Build.UnitTests
         /// Verifies that nonexistent projects are skipped when requested
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SkipNonexistentProjects()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -257,8 +253,6 @@ namespace Microsoft.Build.UnitTests
         /// DDB # 125831
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SkipNonexistentProjectsBuildingInParallel()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -290,8 +284,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void LogErrorWhenBuildingVCProj()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();
@@ -338,8 +330,6 @@ namespace Microsoft.Build.UnitTests
         /// property value and so he can't escape it himself.
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void PropertyOverridesContainSemicolon()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();

--- a/src/XMakeTasks/UnitTests/XamlDataDrivenToolTask_Tests.cs
+++ b/src/XMakeTasks/UnitTests/XamlDataDrivenToolTask_Tests.cs
@@ -268,8 +268,6 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Test requires installed toolset.
         public void CommandLineErrorsReportFullCommandlineAmpersandTemp()
         {
             string projectFile = @"
@@ -323,8 +321,6 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void CommandLineErrorsReportFullCommandline()
         {
             string projectFile = @"
@@ -361,8 +357,6 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
         /// Tests that when a call to a XamlDataDrivenTask fails, the commandline is reported in the error message. 
         /// </summary>
         [TestMethod]
-        [Ignore]
-        // Ignore: Changes to the current directory interfere with the toolset reader.
         public void SquareBracketEscaping()
         {
             string projectFile = @"


### PR DESCRIPTION
Between the signing change and adding Roslyn toolset components, many of
the unit tests I previously disabled now work. There are a few left that
have issues still, I didn't want to spend too much time right now though.