### PR TITLE
Preserve Xunit test result XML

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -79,7 +79,8 @@
           DependsOnTargets="Build"
           Condition="'$(IsTestProject)' == 'true'">
     <xunit Assemblies="@(MainAssembly)"
-           ShadowCopy="false" />
+           ShadowCopy="false"
+           Xml="@(MainAssembly->'%(FullPath)_TestResults.xml')"/>
   </Target>
 
   <Target Name="BuildAndTest"


### PR DESCRIPTION
This will allow the CI build to have nice displays for our test results,
as well as an overall pass/fail for the build script.

Note: there's a corresponding Jenkins definition change.  I made it for the PR build so creating this request *should* show test results.