### PR TITLE
Use local extensions when building post-bootstrap

### DIFF
--- a/BuildAndCopy.cmd
+++ b/BuildAndCopy.cmd
@@ -1,15 +1,12 @@
 :: Usage:
-:: BuildAndCopy <path> <retail framework>
-::    <path> - Where to copy the build output
+:: BuildAndCopy
 :: 
-:: Example: BuildAndCopy.cmd bin\MSBuild
+:: Example: BuildAndCopy.cmd
 
 @echo off
 setlocal
 
-set MSBuild14Path=%ProgramFiles(x86)%\MSBuild\14.0\Bin
 set DebugBuildOutputPath=%~dp0bin\Windows_NT\Debug
-set OutputPath=%~dp0bin\MSBuild
 
 :: Check prerequisites
 if not defined VS140COMNTOOLS (
@@ -22,19 +19,21 @@ if not "%1"=="" (
     set OutputPath=%1
 )
 
-echo ** Creating a build package
-echo ** Output Path: %OutputPath%
+echo ** Building with the installed MSBuild
+echo ** Output Path: %DebugBuildOutputPath%
 echo ** Additional Build Parameters:%AdditionalBuildCommand%
 echo.
 :: Build MSBuild
 call "%~dp0build.cmd" /t:Rebuild %AdditionalBuildCommand%
 
+:: Kill Roslyn, which may have handles open to files we want
+taskkill /F /IM vbcscompiler.exe
+
 :: Make a copy of our build
-echo ** ROBOCOPY bin\Windows_NT\Debug -^> %OutputPath%
-robocopy "%DebugBuildOutputPath%" "%OutputPath%" *.* /S /NFL /NDL /NJH /NJS /nc /ns /np
+echo ** Copying bootstrapped MSBuild to the bootstrap folder
+msbuild /v:m CreatePrivateMSBuildEnvironment.proj
 echo.
 
 echo.
 echo ** Packaging complete.
-set MSBUILDCUSTOMPATH="%OutputPath%\MSBuild.exe"
-echo ** MSBuild = %MSBUILDCUSTOMPATH%
+echo ** MSBuild = %~dp0\bin\bootstrap\14.1\MSBuild.exe

--- a/CreatePrivateMSBuildEnvironment.proj
+++ b/CreatePrivateMSBuildEnvironment.proj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" InitialTargets="CheckForBootstrap" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="dir.props" />
+
+  <ItemGroup>
+    <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.targets" />
+    <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.props" />
+
+    <ShimTargets Include="Microsoft.Data.Entity.targets" />
+    <ShimTargets Include="Microsoft.ServiceModel.targets" />
+    <ShimTargets Include="Microsoft.WinFx.targets" />
+    <ShimTargets Include="Microsoft.WorkflowBuildExtensions.targets" />
+    <ShimTargets Include="Microsoft.Xaml.targets" />
+    <ShimTargets Include="Workflow.Targets" />
+    <ShimTargets Include="Workflow.VisualBasic.Targets" />
+
+    <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.props" />
+    <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.targets" />
+
+    <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
+
+    <FreshlyBuiltBinaries Include="$(OutputPath)*.dll" />
+    <FreshlyBuiltBinaries Include="$(OutputPath)*.exe" />
+    <FreshlyBuiltBinaries Include="$(OutputPath)*.exe.config" />
+
+    <FreshlyBuiltProjects Include="$(OutputPath)*props" />
+    <FreshlyBuiltProjects Include="$(OutputPath)*targets" />
+    <FreshlyBuiltProjects Include="$(OutputPath)*tasks" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <!-- Copy in props and targets from the machine-installed MSBuildExtensionsPath -->
+    <Copy SourceFiles="@(InstalledVersionedExtensions)"
+          DestinationFiles="@(InstalledVersionedExtensions->'$(BootstrapDestination)14.1\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(InstalledMicrosoftExtensions)"
+          DestinationFiles="@(InstalledMicrosoftExtensions->'$(BootstrapDestination)Microsoft\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <Copy SourceFiles="@(InstalledNuGetFiles)"
+          DestinationFiles="@(InstalledNuGetFiles->'$(BootstrapDestination)Microsoft\NuGet\%(Filename)%(Extension)')" />
+
+    <!-- Delete shim projects, because they point where we can't follow. -->
+    <!-- It would be better to just not copy these. -->
+    <Delete Files="@(ShimTargets->'$(BootstrapDestination)14.1\Bin\%(FileName)%(Extension)')" />
+
+    <!-- Copy our binaries -->
+    <Copy SourceFiles="@(FreshlyBuiltBinaries)"
+          DestinationFolder="$(BootstrapDestination)14.1\Bin" />
+
+    <!-- Copy our freshly-built props and targets, overwriting anything we copied from the machine -->
+    <Copy SourceFiles="@(FreshlyBuiltProjects)"
+          DestinationFolder="$(BootstrapDestination)14.1\Bin" />
+  </Target>
+
+  <Target Name="CheckForBootstrap">
+    <Error Text="You must not build $(MSBuildThisFile) with BootstrapBuildPath set.  It needs to see the 'machine-installed' MSBuildExtensionsPath."
+           Condition="'$(BootstrapBuildPath)' != ''" />
+  </Target>
+</Project>

--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -15,9 +15,9 @@ if not defined VS140COMNTOOLS (
     exit /b 1
 )
 
-:: Build and copy output to bin\MSBuild
-call "%~dp0BuildAndCopy.cmd" "%MSBuildTempPath%"
+:: Build and copy output to bin\bootstrap
+call "%~dp0BuildAndCopy.cmd"
 
-:: Rebuild
-set MSBUILDCUSTOMPATH=%MSBuildTempPath%\MSBuild.exe
-"%~dp0build.cmd" /t:RebuildAndTest
+:: Rebuild with bootstrapped msbuild
+set MSBUILDCUSTOMPATH="%~dp0\bin\Bootstrap\14.1\Bin\MSBuild.exe"
+"%~dp0build.cmd" /t:RebuildAndTest /p:BootstrappedMSBuild=true

--- a/dir.props
+++ b/dir.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <!-- This is to workaround an issue with a dependent assembly (Microsoft.Build.Tasks.CodeAnalysis.dll)
-         copying it's dependencies (which are in the GAC).	-->
+         copying its dependencies (which are in the GAC). -->
     <DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
   </PropertyGroup>
 
@@ -11,19 +11,26 @@
      <UseRoslynCompilers>true</UseRoslynCompilers>
      <DebugSymbols Condition="'$(UseRoslynCompilers)' == 'true'">false</DebugSymbols>
   </PropertyGroup>
-   
+
    <!-- Common repo directories -->
   <PropertyGroup>
     <BuildToolsVersion>1.0.25-prerelease-00080</BuildToolsVersion>
-	<CompilerToolsVersion>1.0.0</CompilerToolsVersion>
-    
-	<ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
+    <CompilerToolsVersion>1.0.0</CompilerToolsVersion>
+
+    <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
     <BinDir>$(ProjectDir)bin\</BinDir>
     <TestWorkingDir>$(BinDir)tests\</TestWorkingDir>
     <PackagesDir>$(ProjectDir)packages\</PackagesDir>
     <ToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
-	<CompilerToolsDir>$(PackagesDir)Microsoft.Net.Compilers.$(CompilerToolsVersion)\tools</CompilerToolsDir>
+    <CompilerToolsDir>$(PackagesDir)Microsoft.Net.Compilers.$(CompilerToolsVersion)\tools</CompilerToolsDir>
+
+    <BootstrapDestination>$(BinDir)Bootstrap\</BootstrapDestination>
+  </PropertyGroup>
+
+  <!-- If we're building with a bootstrapped MSBuild, use fresh extensions instead of the installed ones. -->
+  <PropertyGroup Condition="'$(BootstrappedMSBuild)' == 'true'">
+    <MSBuildExtensionsPath>$(BootstrapDestination)</MSBuildExtensionsPath>
   </PropertyGroup>
 
   <!-- list of nuget package sources passed to nuget.exe -->
@@ -31,7 +38,7 @@
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools" />
     <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
   </ItemGroup>
-  
+
   <!-- Common nuget properties -->
   <PropertyGroup>
     <NuGetToolPath>$(PackagesDir)NuGet.exe</NuGetToolPath>
@@ -47,13 +54,13 @@
     <NugetRestoreCommand>$(NugetRestoreCommand) -Verbosity detailed</NugetRestoreCommand>
     <NugetRestoreCommand Condition="'$(OsEnvironment)'=='Unix'">mono $(NuGetRestoreCommand)</NugetRestoreCommand>
   </PropertyGroup>
-  
+
   <!-- Set default Configuration and Platform -->
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' ==''">Debug</Configuration>
     <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
   </PropertyGroup>
-  
+
   <!-- Setup Default symbol and optimization for Configuration -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
@@ -91,7 +98,7 @@
     <BaseIntermediateOutputPath>$(BaseOutputPath)obj\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(MSBuildProjectName)\$(OS)\$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(Platform)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(MSBuildProjectName)\$(Platform)\$(OS)\$(Configuration)\</IntermediateOutputPath>
-    
+
     <TestPath>$(TestWorkingDir)$(MSBuildProjectName)\$(OS)\$(Configuration)\</TestPath>
     <TestPath Condition="'$(Platform)' != 'AnyCPU'">$(TestWorkingDir)$(MSBuildProjectName)\$(Platform)\$(OS)\$(Configuration)\</TestPath>
   </PropertyGroup>


### PR DESCRIPTION
This addresses the issues I ran into in #190, though I agree with @dsplaisted that a better long-term solution (with all targets + tasks packaged up and referenced through nuget) will be necessary.

There was a subtle problem with the way we were building the second time
in RebuildWithLocalMSBuild.cmd before.  Because the newly-built MSBuild
was toolsVersion 14.1, it looked for paths like
 C:\Program Files (x86)\MSBuild\14.1\Microsoft.Common.props
which naturally don't exist--MSBuild 14.1 exists only within this folder
where we built it.

This change alters RebuildWithLocalMSBuild and friends to build out an
MSBuildExtensionsPath folder local to the repo that can be used by setting
/p:BootstrappedMSBuild=true.

Unfortunately, the .targets and .props files contained within the MSBuild
repo aren't sufficient to build MSBuild.  We also need some things, like
NuGet, that are installed at the machine level.

Since there's no way to bridge two MSBuildExtensionsPath values together
(with some sort of fallback), I'm taking the approach of copying stuff
from the "real" MSBuildExtensionsPath into our new folder, then
overwriting anything we do provide with the built version.  That gives us
a reasonably complete experience that builds using local targets.

Ideally, we would be sourcing all of these targets from NuGet packages,
even NuGet's package-resolution logic itself.