### PR TITLE
Update to latest xunit and adopt VS test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ TestResult.xml
 dlldata.c
 
 # Nuget v3
-project.lock.json
 *.nuget.targets
 
 *_i.c

--- a/build.cmd
+++ b/build.cmd
@@ -25,7 +25,7 @@ if not exist "%NUGETEXEPATH%" (
 
 echo Restoring NuGet packages
 :: Global packages (targets files needed to load projects, things needed everywhere)
-"%NUGETEXEPATH%" restore "%~dp0src\.nuget\packages.config" -o "%~dp0packages"
+"%NUGETEXEPATH%" restore -ConfigFile "%~dp0src\.nuget\NuGet.config" "%~dp0src\.nuget\packages.config" -o "%~dp0packages"
 :: Packages referenced by individual projects
 "%NUGETEXEPATH%" restore "%~dp0src\MSBuild.sln" -o "%~dp0packages"
 

--- a/build.cmd
+++ b/build.cmd
@@ -25,9 +25,9 @@ if not exist "%NUGETEXEPATH%" (
 
 echo Restoring NuGet packages
 :: Global packages (targets files needed to load projects, things needed everywhere)
-"%NUGETEXEPATH%" restore -ConfigFile "%~dp0src\.nuget\NuGet.config" "%~dp0src\.nuget\packages.config" -o "%~dp0packages"
+"%NUGETEXEPATH%" restore -ConfigFile "%~dp0src\.nuget\NuGet.Config" "%~dp0src\.nuget\packages.config"
 :: Packages referenced by individual projects
-"%NUGETEXEPATH%" restore "%~dp0src\MSBuild.sln" -o "%~dp0packages"
+"%NUGETEXEPATH%" restore "%~dp0src\MSBuild.sln"
 
 echo ** MSBuild Path: %MSBUILDCUSTOMPATH%
 echo ** Building all sources

--- a/dir.props
+++ b/dir.props
@@ -54,6 +54,11 @@
     <NugetRestoreCommand>$(NugetRestoreCommand) $(NuGetConfigCommandLine)</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) -Verbosity detailed</NugetRestoreCommand>
     <NugetRestoreCommand Condition="'$(OsEnvironment)'=='Unix'">mono $(NuGetRestoreCommand)</NugetRestoreCommand>
+
+    <!-- Nuget's resolve-assemblies-from-packages code looks at this
+         variable, but we can't just rename PackagesDir because parts
+         of the BuildTools package depend on that variable name. -->
+    <NugetPackagesDirectory>$(PackagesDir)</NugetPackagesDirectory>
   </PropertyGroup>
 
   <!-- Set default Configuration and Platform -->

--- a/dir.props
+++ b/dir.props
@@ -16,7 +16,7 @@
   <PropertyGroup>
     <BuildToolsVersion>1.0.25-prerelease-00080</BuildToolsVersion>
     <CompilerToolsVersion>1.0.0</CompilerToolsVersion>
-    <XunitVersion>2.1.0-beta4-build3109</XunitVersion>
+    <XunitVersion>2.1.0-rc1-build3168</XunitVersion>
 
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>

--- a/dir.props
+++ b/dir.props
@@ -54,11 +54,6 @@
     <NugetRestoreCommand>$(NugetRestoreCommand) $(NuGetConfigCommandLine)</NugetRestoreCommand>
     <NugetRestoreCommand>$(NugetRestoreCommand) -Verbosity detailed</NugetRestoreCommand>
     <NugetRestoreCommand Condition="'$(OsEnvironment)'=='Unix'">mono $(NuGetRestoreCommand)</NugetRestoreCommand>
-
-    <!-- Nuget's resolve-assemblies-from-packages code looks at this
-         variable, but we can't just rename PackagesDir because parts
-         of the BuildTools package depend on that variable name. -->
-    <NugetPackagesDirectory>$(PackagesDir)</NugetPackagesDirectory>
   </PropertyGroup>
 
   <!-- Set default Configuration and Platform -->

--- a/dir.targets
+++ b/dir.targets
@@ -73,15 +73,15 @@
   </Target>
 
   <!-- Get access to the xunit task from the globally-installed location -->
-  <Import Project="$(PackagesDir)\xunit.runner.msbuild.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.runner.msbuild.props" Condition="Exists('packages\xunit.runner.msbuild.2.1.0-beta4-build3109\build\portable-net45+netcore45+wp8+wpa81\xunit.runner.msbuild.props')" />
+  <Import Project="$(PackagesDir)\xunit.runner.msbuild.$(XunitVersion)\build\portable-net45+win8+wp8+wpa81\xunit.runner.msbuild.props" />
 
   <Target Name="Test"
           DependsOnTargets="Build"
           Condition="'$(IsTestProject)' == 'true'">
     <ItemGroup>
       <AssembliesToCopyLocal Include="$(PackagesDir)xunit.abstractions\2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core\$(XunitVersion)\lib\portable-net45+netcore45+wp8+wpa81\xunit.core.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert\$(XunitVersion)\lib\portable-net45+netcore45+wp8+wpa81\xunit.assert.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll" />
       <AssembliesToCopyLocal Include="$(PackagesDir)xunit.core\$(XunitVersion)\build\_Desktop\xunit.execution.desktop.dll" />
     </ItemGroup>
     <!-- Copy xunit stuff to output directory -->

--- a/dir.targets
+++ b/dir.targets
@@ -72,23 +72,20 @@
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
   </Target>
 
+  <Target Name="EnsurePrerequisitesCopied"
+          BeforeTargets="Build"
+          Condition="'$(IsTestProject)' == 'true'">
+    <MSBuild Projects="$(SourceDir)CopyTestPrerequisites.proj"
+             Targets="CopyPrerequisites"
+             BuildInParallel="true" />
+  </Target>
+
   <!-- Get access to the xunit task from the globally-installed location -->
   <Import Project="$(PackagesDir)\xunit.runner.msbuild.$(XunitVersion)\build\portable-net45+win8+wp8+wpa81\xunit.runner.msbuild.props" />
 
   <Target Name="Test"
-          DependsOnTargets="Build"
+          DependsOnTargets="Build;EnsurePrerequisitesCopied"
           Condition="'$(IsTestProject)' == 'true'">
-    <ItemGroup>
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.abstractions\2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.core\$(XunitVersion)\build\_Desktop\xunit.execution.desktop.dll" />
-    </ItemGroup>
-    <!-- Copy xunit stuff to output directory -->
-    <Copy SourceFiles="@(AssembliesToCopyLocal)"
-          DestinationFolder="$(OutputPath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
     <xunit Assemblies="@(MainAssembly)"
            ShadowCopy="false"
            Xml="@(MainAssembly->'%(FullPath)_TestResults.xml')"/>

--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -1,14 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageRestore>
     <add key="enabled" value="True" />
   </packageRestore>
   <packageSources>
+    <clear />
+    <add key="myget.org buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
+    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
   <config>
-    <add key="repositoryPath" value="..\..\packages" />
+    <add key="repositoryPath" value="../packages" />
   </config>
 </configuration>

--- a/src/.nuget/NuGet.Config
+++ b/src/.nuget/NuGet.Config
@@ -13,6 +13,6 @@
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
   <config>
-    <add key="repositoryPath" value="../packages" />
+    <add key="repositoryPath" value="../../packages" />
   </config>
 </configuration>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,25 +2,5 @@
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00080" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net451" userInstalled="true" />
-
-  <!-- Xunit assemblies *shouldn't* be redundantly listed here; we
-       don't need them to be globally installed.  BUT we need copies
-       of all of the assemblies needed at test runtime to be present
-       in our bin folder.  That should happen by default, but the
-       .props files that cause them to be copied don't get included
-       because we target more than one framework.  Since the whole
-       point of switching now to project.json at the project level is
-       to support multi-targeting to CoreCLR, that's a tough
-       constraint.  For now, list the runtime assemblies (and the
-       msbuild runner) here, so they're in a known location and can be
-       copied by CopyTestPrerequisites.proj.  Note that the normal
-       NuGet v3 restore will *also* restore them to the
-       machine-wide/user-directory location.  That's where the
-       compiler will use them from. -->
   <package id="xunit.runner.msbuild" version="2.1.0-rc1-build3168" />
-  <package id="xunit" version="2.1.0-rc1-build3168" targetFramework="net451" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
-  <package id="xunit.assert" version="2.1.0-rc1-build3168" targetFramework="net451" />
-  <package id="xunit.core" version="2.1.0-rc1-build3168" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.1.0-rc1-build3168" targetFramework="net451" />
 </packages>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00080" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net451" userInstalled="true" />
-  <package id="xunit.runner.msbuild" version="2.1.0-beta4-build3109" />
+  <package id="xunit.runner.msbuild" version="2.1.0-rc1-build3168" />
 </packages>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -2,5 +2,25 @@
 <packages>
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00080" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net451" userInstalled="true" />
+
+  <!-- Xunit assemblies *shouldn't* be redundantly listed here; we
+       don't need them to be globally installed.  BUT we need copies
+       of all of the assemblies needed at test runtime to be present
+       in our bin folder.  That should happen by default, but the
+       .props files that cause them to be copied don't get included
+       because we target more than one framework.  Since the whole
+       point of switching now to project.json at the project level is
+       to support multi-targeting to CoreCLR, that's a tough
+       constraint.  For now, list the runtime assemblies (and the
+       msbuild runner) here, so they're in a known location and can be
+       copied by CopyTestPrerequisites.proj.  Note that the normal
+       NuGet v3 restore will *also* restore them to the
+       machine-wide/user-directory location.  That's where the
+       compiler will use them from. -->
   <package id="xunit.runner.msbuild" version="2.1.0-rc1-build3168" />
+  <package id="xunit" version="2.1.0-rc1-build3168" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.1.0-rc1-build3168" targetFramework="net451" />
+  <package id="xunit.core" version="2.1.0-rc1-build3168" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0-rc1-build3168" targetFramework="net451" />
 </packages>

--- a/src/CopyTestPrerequisites.proj
+++ b/src/CopyTestPrerequisites.proj
@@ -18,21 +18,7 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <Target Name="CopyXunitRunnerAssemblies">
-    <ItemGroup>
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core.$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert.$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.core.$(XunitVersion)\build\_Desktop\xunit.execution.desktop.dll" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(AssembliesToCopyLocal)"
-          DestinationFolder="$(OutputPath)"
-          SkipUnchangedFiles="true"
-          UseHardlinksIfPossible="true" />
-  </Target>
-
   <Target Name="CopyPrerequisites"
-          DependsOnTargets="CopyCompilerTools;CopyXunitConfiguration;CopyXunitRunnerAssemblies" />
+          DependsOnTargets="CopyCompilerTools;CopyXunitConfiguration" />
 
 </Project>

--- a/src/CopyTestPrerequisites.proj
+++ b/src/CopyTestPrerequisites.proj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="CopyPrerequisites" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\dir.props" />
+
+  <!-- Copy Roslyn Compiler tools to the output path (so we have csc.exe, etc) -->
+  <Target Name="CopyCompilerTools">
+    <ItemGroup>
+      <CompilerToolsFiles Include="$(CompilerToolsDir)\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(CompilerToolsFiles)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyXunitConfiguration">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)xunit.runner.json"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="CopyXunitRunnerAssemblies">
+    <ItemGroup>
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.abstractions\2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.core\$(XunitVersion)\build\_Desktop\xunit.execution.desktop.dll" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(AssembliesToCopyLocal)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="true" />
+  </Target>
+
+  <Target Name="CopyPrerequisites"
+          DependsOnTargets="CopyCompilerTools;CopyXunitConfiguration;CopyXunitRunnerAssemblies" />
+
+</Project>

--- a/src/CopyTestPrerequisites.proj
+++ b/src/CopyTestPrerequisites.proj
@@ -20,10 +20,10 @@
 
   <Target Name="CopyXunitRunnerAssemblies">
     <ItemGroup>
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.abstractions\2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert\$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll" />
-      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.core\$(XunitVersion)\build\_Desktop\xunit.execution.desktop.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.extensibility.core.$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.assert.$(XunitVersion)\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll" />
+      <AssembliesToCopyLocal Include="$(PackagesDir)xunit.core.$(XunitVersion)\build\_Desktop\xunit.execution.desktop.dll" />
     </ItemGroup>
 
     <Copy SourceFiles="@(AssembliesToCopyLocal)"

--- a/src/Framework/UnitTests/Microsoft.Build.Framework.UnitTests.csproj
+++ b/src/Framework/UnitTests/Microsoft.Build.Framework.UnitTests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Microsoft.Build.Framework.UnitTests</RootNamespace>
     <AssemblyName>Microsoft.Build.Framework.UnitTests</AssemblyName>
     <IsTestProject>true</IsTestProject>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Framework/UnitTests/project.json
+++ b/src/Framework/UnitTests/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "xunit": "2.1.0-rc1-build3168"
+    "xunit": "2.1.0-rc1-build3168",
+    "xunit.runner.visualstudio": "2.1.0-rc1-build1124"
   },
   "frameworks": {
     "net451": {},

--- a/src/Framework/UnitTests/project.json
+++ b/src/Framework/UnitTests/project.json
@@ -1,9 +1,9 @@
-{
+﻿{
   "dependencies": {
-     "xunit": "2.1.0-beta4-build3109"
+    "xunit": "2.1.0-rc1-build3168"
   },
   "frameworks": {
-    "net451": { },
-    "net46": { }
+    "net451": {},
+    "net46": {}
   }
 }

--- a/src/Framework/UnitTests/project.json
+++ b/src/Framework/UnitTests/project.json
@@ -6,5 +6,8 @@
   "frameworks": {
     "net451": {},
     "net46": {}
+  },
+  "runtimes": {
+    "win-": {}
   }
 }

--- a/src/Framework/UnitTests/project.lock.json
+++ b/src/Framework/UnitTests/project.lock.json
@@ -1,0 +1,278 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    ".NETFramework,Version=v4.5.1": {
+      "xunit/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "compile": {
+          "lib/net35/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-rc1-build3168": {
+        "compile": {
+          "lib/dotnet/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.extensibility.execution": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0, 2.0.0]"
+        },
+        "compile": {
+          "lib/dotnet/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.core.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        },
+        "compile": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        }
+      },
+      "xunit.runner.visualstudio/2.1.0-rc1-build1124": {}
+    },
+    ".NETFramework,Version=v4.6": {
+      "xunit/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "compile": {
+          "lib/net35/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-rc1-build3168": {
+        "compile": {
+          "lib/dotnet/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.extensibility.execution": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0, 2.0.0]"
+        },
+        "compile": {
+          "lib/dotnet/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.core.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        },
+        "compile": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        }
+      },
+      "xunit.runner.visualstudio/2.1.0-rc1-build1124": {}
+    }
+  },
+  "libraries": {
+    "xunit/2.1.0-rc1-build3168": {
+      "sha512": "dVnDKBCIpLE5GaxLALnbnobqtDyTTDKJSRbqhLGrx0Ptc/n3VQRUby/CDx6v+y7xNVPqtqj0XMeDO1DVT8E3tA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/c7931b7f3887423dbf4970aaa1c1dc7b.psmdcp",
+        "xunit.nuspec"
+      ]
+    },
+    "xunit.abstractions/2.0.0": {
+      "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
+        "package/services/metadata/core-properties/24083640fee244bf9de77f4c35d40a72.psmdcp",
+        "xunit.abstractions.nuspec"
+      ]
+    },
+    "xunit.assert/2.1.0-rc1-build3168": {
+      "sha512": "lsTK4OaNGt5IOoKO3ZQ0gSFngjWSHZ5xNurNtLd0MxZv5onv66xlNmWBYCVNt4sZLknQ+RfiqYm1EZ9ZrA0SDw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/xunit.assert.dll",
+        "lib/dotnet/xunit.assert.pdb",
+        "lib/dotnet/xunit.assert.xml",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.pdb",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.xml",
+        "package/services/metadata/core-properties/25b1754808374eeb82f38a86833d4d61.psmdcp",
+        "xunit.assert.nuspec"
+      ]
+    },
+    "xunit.core/2.1.0-rc1-build3168": {
+      "sha512": "IcQo+pNEDYBC9HJfzY08k0NhLZMX8WXudrlhcrIAzkT2szhrLbGhUi1k6vU5n9crsVv+IxosvIH28kYf6/Z32w==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "build/_desktop/xunit.execution.desktop.dll",
+        "build/dnx451/_._",
+        "build/monoandroid/_._",
+        "build/monotouch/_._",
+        "build/net45/_._",
+        "build/portable-net45+win8+wp8+wpa81/xunit.core.props",
+        "build/win8/_._",
+        "build/win81/xunit.core.props",
+        "build/wp8/_._",
+        "build/wpa81/xunit.core.props",
+        "build/xamarinios/_._",
+        "package/services/metadata/core-properties/c4f15e74cde14a09b99e736e49571ec0.psmdcp",
+        "xunit.core.nuspec"
+      ]
+    },
+    "xunit.extensibility.core/2.1.0-rc1-build3168": {
+      "sha512": "8KZaq1mdeaiZxo1ScsGzhkeQRwLLS6+WIno+9gtnYccWmTjCJ/XSYz2fAAlB5mUeyw0vqqrFc+TfNZELs5QiZQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/xunit.core.dll",
+        "lib/dotnet/xunit.core.dll.tdnet",
+        "lib/dotnet/xunit.core.pdb",
+        "lib/dotnet/xunit.core.xml",
+        "lib/dotnet/xunit.runner.tdnet.dll",
+        "lib/dotnet/xunit.runner.utility.desktop.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.dll.tdnet",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.pdb",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.xml",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.tdnet.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.desktop.dll",
+        "package/services/metadata/core-properties/f5b0a8a6af3a41e7abbb1c4e08ab5e31.psmdcp",
+        "xunit.extensibility.core.nuspec"
+      ]
+    },
+    "xunit.extensibility.execution/2.1.0-rc1-build3168": {
+      "sha512": "1w0u3eB7i25hca60r/53oSVb0blMOEm2eVqvwTg9jhMSe/A9raj6UZAVzUnFtA3xLssP4K1udOGTC1qrZ9/VoA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dnx451/xunit.execution.dotnet.dll",
+        "lib/dnx451/xunit.execution.dotnet.pdb",
+        "lib/dnx451/xunit.execution.dotnet.xml",
+        "lib/dotnet/xunit.execution.dotnet.dll",
+        "lib/dotnet/xunit.execution.dotnet.pdb",
+        "lib/dotnet/xunit.execution.dotnet.xml",
+        "lib/monoandroid/xunit.execution.dotnet.dll",
+        "lib/monoandroid/xunit.execution.dotnet.pdb",
+        "lib/monoandroid/xunit.execution.dotnet.xml",
+        "lib/monotouch/xunit.execution.dotnet.dll",
+        "lib/monotouch/xunit.execution.dotnet.pdb",
+        "lib/monotouch/xunit.execution.dotnet.xml",
+        "lib/net35/xunit.execution.desktop.dll",
+        "lib/net35/xunit.execution.desktop.pdb",
+        "lib/net35/xunit.execution.desktop.xml",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.pdb",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.xml",
+        "lib/win8/xunit.execution.dotnet.dll",
+        "lib/win8/xunit.execution.dotnet.pdb",
+        "lib/win8/xunit.execution.dotnet.xml",
+        "lib/wp8/xunit.execution.dotnet.dll",
+        "lib/wp8/xunit.execution.dotnet.pdb",
+        "lib/wp8/xunit.execution.dotnet.xml",
+        "lib/wpa81/xunit.execution.dotnet.dll",
+        "lib/wpa81/xunit.execution.dotnet.pdb",
+        "lib/wpa81/xunit.execution.dotnet.xml",
+        "lib/xamarinios/xunit.execution.dotnet.dll",
+        "lib/xamarinios/xunit.execution.dotnet.pdb",
+        "lib/xamarinios/xunit.execution.dotnet.xml",
+        "package/services/metadata/core-properties/3ba0c9def4ed43d782df6b4b2c8fef45.psmdcp",
+        "xunit.extensibility.execution.nuspec"
+      ]
+    },
+    "xunit.runner.visualstudio/2.1.0-rc1-build1124": {
+      "sha512": "4m6iGj99F92STIfhg/h+t3sWL42JE29UfCAQShdxQxSz7CpTxZScoxlDpanmroYaMD0riTFTZ7fr9Brsd0ABig==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "build/_common/xunit.abstractions.dll",
+        "build/_common/xunit.runner.utility.desktop.dll",
+        "build/_common/xunit.runner.utility.dotnet.dll",
+        "build/_common/xunit.runner.visualstudio.testadapter.dll",
+        "build/monoandroid/_._",
+        "build/monotouch/_._",
+        "build/net20/xunit.runner.visualstudio.props",
+        "build/portable-net45+win8+wp8+wpa81/xunit.runner.visualstudio.props",
+        "build/uap10.0/xunit.runner.visualstudio.props",
+        "build/uap10.0/xunit.runner.visualstudio.targets",
+        "build/uap10.0/xunit.runner.visualstudio.uwp.dll",
+        "build/uap10.0/xunit.runner.visualstudio.uwp.pri",
+        "build/win8/_._",
+        "build/win81/xunit.runner.visualstudio.props",
+        "build/win81/xunit.runner.visualstudio.targets",
+        "build/win81/xunit.runner.visualstudio.win81.dll",
+        "build/win81/xunit.runner.visualstudio.win81.pri",
+        "build/wp8/_._",
+        "build/wpa81/xunit.runner.visualstudio.props",
+        "build/wpa81/xunit.runner.visualstudio.targets",
+        "build/wpa81/xunit.runner.visualstudio.wpa81.dll",
+        "build/wpa81/xunit.runner.visualstudio.wpa81.pri",
+        "build/xamarinios/_._",
+        "package/services/metadata/core-properties/b0a423d21f7f45688579fd6544753269.psmdcp",
+        "xunit.runner.visualstudio.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "xunit >= 2.1.0-rc1-build3168",
+      "xunit.runner.visualstudio >= 2.1.0-rc1-build1124"
+    ],
+    ".NETFramework,Version=v4.5.1": [],
+    ".NETFramework,Version=v4.6": []
+  }
+}

--- a/src/Framework/UnitTests/project.lock.json
+++ b/src/Framework/UnitTests/project.lock.json
@@ -5,8 +5,8 @@
     ".NETFramework,Version=v4.5.1": {
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
-          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
-          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
         }
       },
       "xunit.abstractions/2.0.0": {
@@ -58,8 +58,114 @@
     ".NETFramework,Version=v4.6": {
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
-          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
-          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "compile": {
+          "lib/net35/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-rc1-build3168": {
+        "compile": {
+          "lib/dotnet/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.extensibility.execution": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0, 2.0.0]"
+        },
+        "compile": {
+          "lib/dotnet/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.core.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        },
+        "compile": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        }
+      },
+      "xunit.runner.visualstudio/2.1.0-rc1-build1124": {}
+    },
+    ".NETFramework,Version=v4.5.1/win-": {
+      "xunit/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "compile": {
+          "lib/net35/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0-rc1-build3168": {
+        "compile": {
+          "lib/dotnet/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.extensibility.execution": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        }
+      },
+      "xunit.extensibility.core/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0, 2.0.0]"
+        },
+        "compile": {
+          "lib/dotnet/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.core.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
+        },
+        "compile": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        },
+        "runtime": {
+          "lib/net35/xunit.execution.desktop.dll": {}
+        }
+      },
+      "xunit.runner.visualstudio/2.1.0-rc1-build1124": {}
+    },
+    ".NETFramework,Version=v4.6/win-": {
+      "xunit/2.1.0-rc1-build3168": {
+        "dependencies": {
+          "xunit.core": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
+          "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]"
         }
       },
       "xunit.abstractions/2.0.0": {
@@ -114,48 +220,48 @@
       "sha512": "dVnDKBCIpLE5GaxLALnbnobqtDyTTDKJSRbqhLGrx0Ptc/n3VQRUby/CDx6v+y7xNVPqtqj0XMeDO1DVT8E3tA==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
+        "xunit.nuspec",
         "package/services/metadata/core-properties/c7931b7f3887423dbf4970aaa1c1dc7b.psmdcp",
-        "xunit.nuspec"
+        "[Content_Types].xml"
       ]
     },
     "xunit.abstractions/2.0.0": {
       "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
+        "xunit.abstractions.nuspec",
         "lib/net35/xunit.abstractions.dll",
         "lib/net35/xunit.abstractions.xml",
         "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
         "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
         "package/services/metadata/core-properties/24083640fee244bf9de77f4c35d40a72.psmdcp",
-        "xunit.abstractions.nuspec"
+        "[Content_Types].xml"
       ]
     },
     "xunit.assert/2.1.0-rc1-build3168": {
       "sha512": "lsTK4OaNGt5IOoKO3ZQ0gSFngjWSHZ5xNurNtLd0MxZv5onv66xlNmWBYCVNt4sZLknQ+RfiqYm1EZ9ZrA0SDw==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/xunit.assert.dll",
-        "lib/dotnet/xunit.assert.pdb",
-        "lib/dotnet/xunit.assert.xml",
+        "xunit.assert.nuspec",
         "lib/portable-net45+win8+wp8+wpa81/xunit.assert.dll",
         "lib/portable-net45+win8+wp8+wpa81/xunit.assert.pdb",
         "lib/portable-net45+win8+wp8+wpa81/xunit.assert.xml",
+        "lib/dotnet/xunit.assert.dll",
+        "lib/dotnet/xunit.assert.pdb",
+        "lib/dotnet/xunit.assert.xml",
         "package/services/metadata/core-properties/25b1754808374eeb82f38a86833d4d61.psmdcp",
-        "xunit.assert.nuspec"
+        "[Content_Types].xml"
       ]
     },
     "xunit.core/2.1.0-rc1-build3168": {
       "sha512": "IcQo+pNEDYBC9HJfzY08k0NhLZMX8WXudrlhcrIAzkT2szhrLbGhUi1k6vU5n9crsVv+IxosvIH28kYf6/Z32w==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
+        "xunit.core.nuspec",
         "build/_desktop/xunit.execution.desktop.dll",
         "build/dnx451/_._",
         "build/monoandroid/_._",
@@ -168,15 +274,15 @@
         "build/wpa81/xunit.core.props",
         "build/xamarinios/_._",
         "package/services/metadata/core-properties/c4f15e74cde14a09b99e736e49571ec0.psmdcp",
-        "xunit.core.nuspec"
+        "[Content_Types].xml"
       ]
     },
     "xunit.extensibility.core/2.1.0-rc1-build3168": {
       "sha512": "8KZaq1mdeaiZxo1ScsGzhkeQRwLLS6+WIno+9gtnYccWmTjCJ/XSYz2fAAlB5mUeyw0vqqrFc+TfNZELs5QiZQ==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
+        "xunit.extensibility.core.nuspec",
         "lib/dotnet/xunit.core.dll",
         "lib/dotnet/xunit.core.dll.tdnet",
         "lib/dotnet/xunit.core.pdb",
@@ -190,21 +296,21 @@
         "lib/portable-net45+win8+wp8+wpa81/xunit.runner.tdnet.dll",
         "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.desktop.dll",
         "package/services/metadata/core-properties/f5b0a8a6af3a41e7abbb1c4e08ab5e31.psmdcp",
-        "xunit.extensibility.core.nuspec"
+        "[Content_Types].xml"
       ]
     },
     "xunit.extensibility.execution/2.1.0-rc1-build3168": {
       "sha512": "1w0u3eB7i25hca60r/53oSVb0blMOEm2eVqvwTg9jhMSe/A9raj6UZAVzUnFtA3xLssP4K1udOGTC1qrZ9/VoA==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dnx451/xunit.execution.dotnet.dll",
-        "lib/dnx451/xunit.execution.dotnet.pdb",
-        "lib/dnx451/xunit.execution.dotnet.xml",
+        "xunit.extensibility.execution.nuspec",
         "lib/dotnet/xunit.execution.dotnet.dll",
         "lib/dotnet/xunit.execution.dotnet.pdb",
         "lib/dotnet/xunit.execution.dotnet.xml",
+        "lib/dnx451/xunit.execution.dotnet.dll",
+        "lib/dnx451/xunit.execution.dotnet.pdb",
+        "lib/dnx451/xunit.execution.dotnet.xml",
         "lib/monoandroid/xunit.execution.dotnet.dll",
         "lib/monoandroid/xunit.execution.dotnet.pdb",
         "lib/monoandroid/xunit.execution.dotnet.xml",
@@ -230,40 +336,40 @@
         "lib/xamarinios/xunit.execution.dotnet.pdb",
         "lib/xamarinios/xunit.execution.dotnet.xml",
         "package/services/metadata/core-properties/3ba0c9def4ed43d782df6b4b2c8fef45.psmdcp",
-        "xunit.extensibility.execution.nuspec"
+        "[Content_Types].xml"
       ]
     },
     "xunit.runner.visualstudio/2.1.0-rc1-build1124": {
       "sha512": "4m6iGj99F92STIfhg/h+t3sWL42JE29UfCAQShdxQxSz7CpTxZScoxlDpanmroYaMD0riTFTZ7fr9Brsd0ABig==",
       "type": "Package",
       "files": [
-        "[Content_Types].xml",
         "_rels/.rels",
+        "xunit.runner.visualstudio.nuspec",
         "build/_common/xunit.abstractions.dll",
         "build/_common/xunit.runner.utility.desktop.dll",
-        "build/_common/xunit.runner.utility.dotnet.dll",
         "build/_common/xunit.runner.visualstudio.testadapter.dll",
-        "build/monoandroid/_._",
-        "build/monotouch/_._",
+        "build/_common/xunit.runner.utility.dotnet.dll",
         "build/net20/xunit.runner.visualstudio.props",
         "build/portable-net45+win8+wp8+wpa81/xunit.runner.visualstudio.props",
         "build/uap10.0/xunit.runner.visualstudio.props",
         "build/uap10.0/xunit.runner.visualstudio.targets",
         "build/uap10.0/xunit.runner.visualstudio.uwp.dll",
         "build/uap10.0/xunit.runner.visualstudio.uwp.pri",
-        "build/win8/_._",
         "build/win81/xunit.runner.visualstudio.props",
         "build/win81/xunit.runner.visualstudio.targets",
         "build/win81/xunit.runner.visualstudio.win81.dll",
         "build/win81/xunit.runner.visualstudio.win81.pri",
-        "build/wp8/_._",
         "build/wpa81/xunit.runner.visualstudio.props",
         "build/wpa81/xunit.runner.visualstudio.targets",
         "build/wpa81/xunit.runner.visualstudio.wpa81.dll",
         "build/wpa81/xunit.runner.visualstudio.wpa81.pri",
+        "build/monoandroid/_._",
+        "build/monotouch/_._",
+        "build/win8/_._",
+        "build/wp8/_._",
         "build/xamarinios/_._",
         "package/services/metadata/core-properties/b0a423d21f7f45688579fd6544753269.psmdcp",
-        "xunit.runner.visualstudio.nuspec"
+        "[Content_Types].xml"
       ]
     }
   },

--- a/src/XMakeBuildEngine/project.lock.json
+++ b/src/XMakeBuildEngine/project.lock.json
@@ -1,0 +1,50 @@
+{
+  "locked": false,
+  "version": 1,
+  "targets": {
+    ".NETFramework,Version=v4.5.1": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.Tpl.Dataflow/4.5.24": {
+      "sha512": "6BE4Vu74+dkv5AkJd+UxW1sFMepMZOVlUoMZDUKqhc4Bf7pe7yySzCj6QrowUZbCqcDPwOiQsAgz3nXiLQSyMw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/system.threading.tasks.dataflow.xml",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
+        "License-Stable.rtf",
+        "Microsoft.Tpl.Dataflow.nuspec",
+        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Microsoft.Tpl.Dataflow >= 4.5.24"
+    ],
+    ".NETFramework,Version=v4.5.1": [],
+    ".NETFramework,Version=v4.6": []
+  }
+}

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -1,21 +1,10 @@
 ﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  
-  <!-- Copy Roslyn Compiler tools to the output path (so we have csc.exe, etc) -->
-  <Target Name="AfterBuild">
-    <ItemGroup>
-      <CompilerToolsFiles Include="$(CompilerToolsDir)\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(CompilerToolsFiles)"
-          DestinationFolder="$(OutputPath)"
-          Retries="5"
-          SkipUnchangedFiles="true" />
-  </Target>
-  
+
   <!-- OSS sign assemblies after compile runs. -->
   <Import Project="$(ToolsDir)\sign.targets" />
-    
+
   <!-- Restore packages -->
   <PropertyGroup>
     <PackagesConfig Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</PackagesConfig>
@@ -23,7 +12,7 @@
     <RestorePackagesSemaphore>$(PackagesDir)$(MSBuildProjectFile).package.restored</RestorePackagesSemaphore>
   </PropertyGroup>
 
-  <Target Name="RestorePackages" 
+  <Target Name="RestorePackages"
           BeforeTargets="ResolveNuGetPackages"
           Inputs="$(PackagesConfig)"
           Outputs="$(RestorePackagesSemaphore)"

--- a/src/xunit.runner.json
+++ b/src/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}


### PR DESCRIPTION
Before this change, we couldn't run xunit tests from within Visual Studio because xunit couldn't load the assemblies using shadow copies, and had no way to disable shadow copies.  The latest xunit (2.1.0-rc1), however, fixes xunit/xunit#560 and allows disabling shadow copies.

We now run xunit tests two ways: in VS through the visual studio runner, and at build time using the MSBuild runner.