### PR TITLE
Bootstrap NuGet download with msbuild instead of build.comd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -13,22 +13,6 @@ if not defined MSBUILDCUSTOMPATH (
     set MSBUILDCUSTOMPATH=MSBuild.exe
 )
 
-set NUGETEXEPATH="%~dp0packages\NuGet.exe"
-
-if not exist "%~dp0packages" mkdir "%~dp0packages"
-if not exist "%NUGETEXEPATH%" (
-    :: This will need to be fixed for non-windows
-    echo ** Downloading NuGet.exe from https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe...
-    echo PS^> Invoke-WebRequest -OutFile %NUGETEXEPATH% "https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe"
-    powershell -Command "Invoke-WebRequest -OutFile %NUGETEXEPATH% "https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe""
-)
-
-echo Restoring NuGet packages
-:: Global packages (targets files needed to load projects, things needed everywhere)
-"%NUGETEXEPATH%" restore -ConfigFile "%~dp0src\.nuget\NuGet.Config" "%~dp0src\.nuget\packages.config"
-:: Packages referenced by individual projects
-"%NUGETEXEPATH%" restore "%~dp0src\MSBuild.sln"
-
 echo ** MSBuild Path: %MSBUILDCUSTOMPATH%
 echo ** Building all sources
 

--- a/build.proj
+++ b/build.proj
@@ -7,5 +7,7 @@
     <Project Include="Samples\dirs.proj" />
   </ItemGroup>
 
+  <Import Project="dir.targets" />
+
   <Import Project="dir.traversal.targets" />
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -1,4 +1,12 @@
 ﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
+  -->
+  <PropertyGroup>
+    <OsEnvironment Condition="'$(OsEnvironment)'==''">$(OS)</OsEnvironment>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <!-- This is to workaround an issue with a dependent assembly (Microsoft.Build.Tasks.CodeAnalysis.dll)
@@ -20,8 +28,12 @@
 
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
+
+    <!-- Output directories -->
     <BinDir>$(ProjectDir)bin\</BinDir>
     <TestWorkingDir>$(BinDir)tests\</TestWorkingDir>
+    
+    <!-- Input Directories -->
     <PackagesDir>$(ProjectDir)packages\</PackagesDir>
     <ToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
     <CompilerToolsDir>$(PackagesDir)Microsoft.Net.Compilers.$(CompilerToolsVersion)\tools</CompilerToolsDir>
@@ -42,7 +54,7 @@
 
   <!-- Common nuget properties -->
   <PropertyGroup>
-    <NuGetToolPath>$(PackagesDir)NuGet.exe</NuGetToolPath>
+    <NuGetToolPath Condition="'$(NuGetToolPath)'==''">$(PackagesDir)NuGet.exe</NuGetToolPath>
     <NuGetConfigFile>$(SourceDir).nuget\NuGet.Config</NuGetConfigFile>
     <NuGetPackageSource>@(NuGetSourceList -> '-source %(Identity)', ' ')</NuGetPackageSource>
     <NuGetConfigCommandLine>$(NuGetPackageSource) -ConfigFile "$(NuGetConfigFile)"</NuGetConfigCommandLine>

--- a/dir.targets
+++ b/dir.targets
@@ -18,8 +18,31 @@
             var tempFile = Path.Combine(directory, Path.GetRandomFileName());
             var client = new System.Net.WebClient();
             client.Proxy = System.Net.WebRequest.DefaultWebProxy;
-            client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+            if (client.Proxy != null) client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+            var tryCount = 1;
+            var maxTries = 3;
+
+            while (tryCount <= maxTries)
+            {
+                try
+                {
+                    Log.LogMessage("Attempting to download {0}...", Address);
             client.DownloadFile(Address, tempFile);
+                    break;
+                }
+                catch (System.Net.WebException e)
+                {
+                    tryCount++;
+                    if (tryCount > maxTries)
+                    {
+                        throw;
+                    }
+                    else
+                    {
+                        Log.LogMessage(MessageImportance.High, "Download failed, retrying: {0}", e.Message);
+                    }
+                }
+            }
 
             try
             {
@@ -37,7 +60,14 @@
   </UsingTask>
 
   <!--
-    Needed to avoid the InitialTargets from having an Output which ends up getting
+    Use a semaphore file to determine the need to restore build tools to avoid conflicts with locked binaries.
+  -->
+  <PropertyGroup>
+    <BuildToolsSemaphore>$(ToolsDir)BuildTools.semaphore</BuildToolsSemaphore>
+  </PropertyGroup>
+
+  <!--
+    Needed to avoid the IntialTargets from having an Output which ends up getting
     added to the output references when you have a project to project reference.
   -->
   <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
@@ -57,20 +87,52 @@
   </Target>
 
   <Target Name="_RestoreBuildTools"
-          Inputs="$(MSBuildThisFileFullPath);$(MSBuildThisFileDirectory)dir.props"
-          Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath)">
+          Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget/packages.config"
+          Outputs="$(BuildToolsSemaphore)">
+    <Message Importance="High" Text="Restoring build tools..." />
+
+    <Copy Condition="Exists('$(NuGetCachedPath)')" SourceFiles="$(NuGetCachedPath)" DestinationFiles="$(NuGetToolPath)" SkipUnchangedFiles="true" />
 
     <!-- Download latest nuget.exe -->
     <DownloadFile FileName="$(NuGetToolPath)"
-                  Address="http://nuget.org/nuget.exe"
-                  Condition="!Exists('$(NuGetToolPath)')" />
+                  Address="https://www.nuget.org/nuget.exe"
+                  Condition="!Exists('$(NuGetToolPath)') and '$(OsEnvironment)'=='Windows_NT'" />
+
+    <Exec Command="curl -sSL --create-dirs -o $(NuGetToolPath) https://api.nuget.org/downloads/nuget.exe"
+          Condition="!Exists('$(NuGetToolPath)') and '$(OsEnvironment)'=='Unix'" />
+
+    <PropertyGroup>
+      <_RestoreBuildToolsCommand>$(NugetRestoreCommand) "$(SourceDir).nuget/packages.config"</_RestoreBuildToolsCommand>
+    </PropertyGroup>
 
     <!-- Restore build tools -->
-    <Exec Command="$(NugetRestoreCommand) &quot;$(SourceDir).nuget\packages.config&quot;" StandardOutputImportance="Low" />
+    <Exec Command="$(_RestoreBuildToolsCommand)" StandardOutputImportance="Low" />
+
+    <!-- Add DNU and Roslyn tool execute rights -->
+    <Exec Condition="'$(OsEnvironment)'=='Unix'"
+          Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnu&quot;" />
+    <Exec Condition="'$(OsEnvironment)'=='Unix'"
+          Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnx&quot;" />
+    <Exec Condition="'$(OsEnvironment)'=='Unix'"
+          Command="find '$(RoslynPackageDir)tools' -name &quot;*.exe&quot; -exec chmod &quot;+x&quot; '{}' ';'" />
+
+    <!--
+      Touch our semaphore file to ensure Inputs/Outputs comparison for this target will show that we're up to date.
+      Ignore failures in the unlikely, but possible, event that we hit this from two projects simultaneously.
+    -->
+    <Touch Files="$(BuildToolsSemaphore)"
+           ContinueOnError="WarnAndContinue"
+           AlwaysCreate="true"
+           ForceTouch="true" />
 
     <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
            Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
   </Target>
+
+  <!-- Provide default targets which can be hooked onto or overridden as necessary -->
+  <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
+  <Target Name="Test" />
 
   <Target Name="EnsurePrerequisitesCopied"
           BeforeTargets="Build"
@@ -90,8 +152,5 @@
            ShadowCopy="false"
            Xml="@(MainAssembly->'%(FullPath)_TestResults.xml')"/>
   </Target>
-
-  <Target Name="BuildAndTest"
-          DependsOnTargets="Build;Test" />
 
 </Project>

--- a/dir.targets
+++ b/dir.targets
@@ -95,7 +95,7 @@
 
     <!-- Download latest nuget.exe -->
     <DownloadFile FileName="$(NuGetToolPath)"
-                  Address="https://www.nuget.org/nuget.exe"
+                  Address="https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe"
                   Condition="!Exists('$(NuGetToolPath)') and '$(OsEnvironment)'=='Windows_NT'" />
 
     <Exec Command="curl -sSL --create-dirs -o $(NuGetToolPath) https://api.nuget.org/downloads/nuget.exe"

--- a/dir.targets
+++ b/dir.targets
@@ -143,7 +143,8 @@
   </Target>
 
   <!-- Get access to the xunit task from the globally-installed location -->
-  <Import Project="$(PackagesDir)\xunit.runner.msbuild.$(XunitVersion)\build\portable-net45+win8+wp8+wpa81\xunit.runner.msbuild.props" />
+  <Import Project="$(PackagesDir)\xunit.runner.msbuild.$(XunitVersion)\build\portable-net45+win8+wp8+wpa81\xunit.runner.msbuild.props" 
+          Condition="'$(IsTestProject)' == 'true'" />
 
   <Target Name="Test"
           DependsOnTargets="Build;EnsurePrerequisitesCopied"


### PR DESCRIPTION
This PR updates the build infrastructure to be closer to the current version in dotnet/buildtools.  It also downloads NuGet.exe as part of the MSBuild build instead of build.cmd.  This will help it work with the build lab infrastructure which needs to invoke an MSBuild project for the build.