### PR TITLE
Restore NuGet packages from build.proj

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -10,4 +10,11 @@
   <Import Project="dir.targets" />
 
   <Import Project="dir.traversal.targets" />
+
+  <Target Name="BulkRestoreNugetPackages"
+          BeforeTargets="Build;BuildAllProjects"
+          DependsOnTargets="_RestoreBuildTools">
+    <Message Importance="High" Text="Restoring NuGet packages..." />
+    <Exec Command="$(NugetToolPath) restore &quot;$(SourceDir)MSBuild.sln&quot;" StandardOutputImportance="Low" />
+  </Target>
 </Project>


### PR DESCRIPTION
When we moved package restore from build.cmd to build.proj, we stopped
restoring the packages required for "normal" reasons, as opposed to build
tools.

This adds a step that will restore the packages from the entry point
project.

It's unfortunate that nuget doesn't understand traversal projects, which
means restoring packages based on the .sln rather than the list in
build.proj which will actually be built.  We could potentially also
restore **\project.json, but then that would require N calls to nuget.exe.
This seems better for now.

I noticed this problem when I built on my laptop (which hadn't built since before the nuget v3 switcheroo and `build.proj` change, and got some errors:

```
C:\Program Files (x86)\MSBuild\Microsoft\NuGet\Microsoft.NuGet.targets(83,5): error : The package xunit.abstractions with version 2.0.0 could not be found in C
:\Users\raines\.nuget\packages. Run a NuGet package restore to download the package. [C:\src\msbuild\src\Framework\UnitTests\Microsoft.Build.Framework.UnitTest
s.csproj]
```