### PR TITLE
Don't import compilers props file from NuGet package during traversal build (when it may not yet be restored)

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <IsTraversalBuild>true</IsTraversalBuild>
+  </PropertyGroup>
+  
   <Import Project="dir.props" />
 
   <ItemGroup>

--- a/dir.targets
+++ b/dir.targets
@@ -176,5 +176,5 @@
            Xml="@(MainAssembly->'%(FullPath)_TestResults.xml')"/>
   </Target>
 
-  <Import Project="$(CompilerToolsDir)\..\build\Microsoft.Net.Compilers.props" /> 
+  <Import Project="$(CompilerToolsDir)\..\build\Microsoft.Net.Compilers.props" Condition="'$(IsTraversalBuild)'!='true'"/> 
 </Project>


### PR DESCRIPTION
Fixes issue building when NuGet packages aren't present yet