### PR TITLE
Add nuget.exe to outputs of _RestoreBuildTools

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -88,7 +88,7 @@
 
   <Target Name="_RestoreBuildTools"
           Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget/packages.config"
-          Outputs="$(BuildToolsSemaphore)">
+          Outputs="$(NuGetToolPath);$(BuildToolsSemaphore)">
     <Message Importance="High" Text="Restoring build tools..." />
 
     <Copy Condition="Exists('$(NuGetCachedPath)')" SourceFiles="$(NuGetCachedPath)" DestinationFiles="$(NuGetToolPath)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
I had a situation where I wanted to make sure I had the latest nuget.exe,
so I deleted it, assuming that this target would re-download it.  It
didn't, because the only listed output of the target (the
I-downloaded-stuff semaphore) was up to date relative to the inputs.

Adding the .exe as an output resolves this.

Really, we should probablys split this target into two (download nuget.exe
and restore tools) for finer-grained incrementality, but this is quicker
(we should also resolve the race conditions here by moving these tasks to
a separate project so that there's no race created by doing the restore in
all projects).