### PR TITLE
Adding WriteCodeFragment to NetCore build

### DIFF
--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -327,6 +327,7 @@
     <Compile Include="AssignCulture.cs" />
     <Compile Include="Culture.cs" />
     <Compile Include="CultureInfoCache.cs" />
+    <Compile Include="WriteCodeFragment.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Compile Include="Al.cs">
@@ -644,7 +645,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="WinMDExp.cs" />
-    <Compile Include="WriteCodeFragment.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureXamlTypes)' == 'true'">
     <Compile Include="XamlTaskFactory\CommandLineGenerator.cs" />

--- a/src/XMakeTasks/UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/XMakeTasks/UnitTests/WriteCodeFragment_Tests.cs
@@ -530,6 +530,36 @@ namespace Microsoft.Build.UnitTests
 
             File.Delete(task.OutputFile.ItemSpec);
         }
+
+        /// <summary>
+        /// Some attributes only allow positional constructor arguments.
+        /// To set those, use metadata names like "_Parameter1", "_Parameter2" etc.
+        /// These can also be combined with named params.
+        /// </summary>
+        [Fact]
+        public void OneAttributePositionalAndNamedParamsVisualBasic()
+        {
+            WriteCodeFragment task = new WriteCodeFragment();
+            MockEngine engine = new MockEngine(true);
+            task.BuildEngine = engine;
+            TaskItem attribute = new TaskItem("AssemblyTrademarkAttribute");
+            attribute.SetMetadata("_Parameter1", "Microsoft");
+            attribute.SetMetadata("_Parameter2", "2009");
+            attribute.SetMetadata("Copyright", "(C)");
+            task.AssemblyAttributes = new TaskItem[] { attribute };
+            task.Language = "visualbasic";
+            task.OutputDirectory = new TaskItem(Path.GetTempPath());
+            bool result = task.Execute();
+
+            Assert.Equal(true, result);
+
+            string content = File.ReadAllText(task.OutputFile.ItemSpec);
+            Console.WriteLine(content);
+
+            Assert.Equal(true, content.Contains(@"<Assembly: AssemblyTrademarkAttribute(""Microsoft"", ""2009"", Copyright:=""(C)"")>"));
+
+            File.Delete(task.OutputFile.ItemSpec);
+        }
     }
 }
 

--- a/src/XMakeTasks/WriteCodeFragment.cs
+++ b/src/XMakeTasks/WriteCodeFragment.cs
@@ -15,10 +15,9 @@ using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Configuration;
 using System.Security;
 using System.Collections.Generic;
-
+using System.Linq;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -102,7 +101,12 @@ namespace Microsoft.Build.Tasks
             }
 
             string extension;
-            string code = GenerateCode(out extension);
+
+#if FEATURE_CODEDOM
+            var code = GenerateCode(out extension);
+#else
+            var code = GenerateCodeCoreClr(out extension);
+#endif
 
             if (Log.HasLoggedErrors)
             {
@@ -143,6 +147,7 @@ namespace Microsoft.Build.Tasks
             return !Log.HasLoggedErrors;
         }
 
+#if FEATURE_CODEDOM
         /// <summary>
         /// Generates the code into a string.
         /// If it fails, logs an error and returns null.
@@ -161,7 +166,7 @@ namespace Microsoft.Build.Tasks
             {
                 provider = CodeDomProvider.CreateProvider(Language);
             }
-            catch (ConfigurationException ex)
+            catch (System.Configuration.ConfigurationException ex)
             {
                 Log.LogErrorWithCodeFromResources("WriteCodeFragment.CouldNotCreateProvider", Language, ex.Message);
                 return null;
@@ -274,6 +279,135 @@ namespace Microsoft.Build.Tasks
             // If we just generated infrastructure, don't bother returning anything
             // as there's no point writing the file
             return haveGeneratedContent ? code : String.Empty;
+        }
+#endif
+
+        /// <summary>
+        /// Generates the code into a string.
+        /// If it fails, logs an error and returns null.
+        /// If no meaningful code is generated, returns empty string.
+        /// Returns the default language extension as an out parameter.
+        /// </summary>
+        private string GenerateCodeCoreClr(out string extension)
+        {
+            extension = null;
+            bool haveGeneratedContent = false;
+
+            StringBuilder code = new StringBuilder();
+            switch (Language.ToLowerInvariant())
+            {
+                case "c#":
+                    if (AssemblyAttributes == null) return string.Empty; 
+
+                    extension = "cs";
+                    code.AppendLine("// " + ResourceUtilities.FormatResourceString("WriteCodeFragment.Comment", DateTime.Now));
+                    code.AppendLine();
+                    code.AppendLine("using System;");
+                    code.AppendLine("using System.Reflection;");
+                    code.AppendLine();
+
+                    foreach (ITaskItem attributeItem in AssemblyAttributes)
+                    {
+                        string args = GetAttributeArguments(attributeItem, "=");
+                        if (args == null) return null;
+
+                        code.AppendLine(string.Format($"[assembly: {attributeItem.ItemSpec}({args})];"));
+                        haveGeneratedContent = true;
+                    }
+
+                    break;
+                case "visual basic":
+                case "visualbasic":
+                    if (AssemblyAttributes == null) return string.Empty;
+
+                    extension = "vb";
+                    code.AppendLine("' " + ResourceUtilities.FormatResourceString("WriteCodeFragment.Comment", DateTime.Now));
+                    code.AppendLine();
+                    code.AppendLine("Option Strict Off");
+                    code.AppendLine("Option Explicit On");
+                    code.AppendLine();
+                    code.AppendLine("Imports System");
+                    code.AppendLine("Imports System.Reflection");
+
+                    foreach (ITaskItem attributeItem in AssemblyAttributes)
+                    {
+                        string args = GetAttributeArguments(attributeItem, ":=");
+                        if (args == null) return null;
+
+                        code.AppendLine(string.Format($"<Assembly: {attributeItem.ItemSpec}({args})>"));
+                        haveGeneratedContent = true;
+                    }
+                    break;
+                default:
+                    Log.LogErrorWithCodeFromResources("WriteCodeFragment.CouldNotCreateProvider", Language, string.Empty);
+                    return null;
+            }
+
+            // If we just generated infrastructure, don't bother returning anything
+            // as there's no point writing the file
+            return haveGeneratedContent ? code.ToString() : string.Empty; 
+        }
+
+        private string GetAttributeArguments(ITaskItem attributeItem, string namedArgumentString)
+        {
+            // Some attributes only allow positional constructor arguments, or the user may just prefer them.
+            // To set those, use metadata names like "_Parameter1", "_Parameter2" etc.
+            // If a parameter index is skipped, it's an error.
+            IDictionary customMetadata = attributeItem.CloneCustomMetadata();
+            
+            // Initialize count + 1 to access starting at 1
+            List<string> orderedParameters = new List<string>(new string[customMetadata.Count + 1]);
+            List<string> namedParameters = new List<string>();
+
+            foreach (DictionaryEntry entry in customMetadata)
+            {
+                string name = (string) entry.Key;
+                string value = entry.Value is string ? $@"""{entry.Value}""" : entry.Value.ToString();
+
+                if (name.StartsWith("_Parameter", StringComparison.OrdinalIgnoreCase))
+                {
+                    int index;
+
+                    if (!int.TryParse(name.Substring("_Parameter".Length), out index))
+                    {
+                        Log.LogErrorWithCodeFromResources("General.InvalidValue", name, "WriteCodeFragment");
+                        return null;
+                    }
+
+                    if (index > orderedParameters.Count || index < 1)
+                    {
+                        Log.LogErrorWithCodeFromResources("WriteCodeFragment.SkippedNumberedParameter", index);
+                        return null;
+                    }
+
+                    // "_Parameter01" and "_Parameter1" would overwrite each other
+                    orderedParameters[index - 1] = value;
+                }
+                else
+                {
+                    namedParameters.Add($"{name}{namedArgumentString}{value}");
+                }
+            }
+
+            bool encounteredNull = false;
+            
+            for (int i = 0; i < orderedParameters.Count; i++)
+            {
+                if (orderedParameters[i] == null)
+                {
+                    // All subsequent args should be null, else a slot was missed
+                    encounteredNull = true;
+                    continue;
+                }
+
+                if (encounteredNull)
+                {
+                    Log.LogErrorWithCodeFromResources("WriteCodeFragment.SkippedNumberedParameter", i + 1 /* back to 1 based */);
+                    return null;
+                }
+            }
+
+            return string.Join(", ", orderedParameters.Union(namedParameters).Where(p => !string.IsNullOrWhiteSpace(p)));
         }
     }
 }


### PR DESCRIPTION
This is not a great long term solution to this, but it works for all the test cases (and there were quite a few) and it was quick to make. A better solution would be to use Roslyn, but we already have a reference to Microsoft.Build.Tasks.CodeAnalysis which depends on part of Roslyn (but not enough) and I don't want to introduce changes to that at this point.