### PR TITLE
Undo CodeFormatter private field name changes

### DIFF
--- a/src/Framework/BuildEngineResult.cs
+++ b/src/Framework/BuildEngineResult.cs
@@ -22,23 +22,23 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Did the build pass or fail
         /// </summary>
-        private bool _buildResult;
+        private bool buildResult;
 
         /// <summary>
         /// Target outputs by project
         /// </summary>
-        private List<IDictionary<string, ITaskItem[]>> _targetOutputsPerProject;
+        private List<IDictionary<string, ITaskItem[]>> targetOutputsPerProject;
 
         /// <summary>
         /// The constructor takes the result of the build and a list of the target outputs per project
         /// </summary>
         public BuildEngineResult(bool result, List<IDictionary<string, ITaskItem[]>> targetOutputsPerProject)
         {
-            _buildResult = result;
-            _targetOutputsPerProject = targetOutputsPerProject;
-            if (_targetOutputsPerProject == null)
+            buildResult = result;
+            this.targetOutputsPerProject = targetOutputsPerProject;
+            if (this.targetOutputsPerProject == null)
             {
-                _targetOutputsPerProject = new List<IDictionary<string, ITaskItem[]>>();
+                this.targetOutputsPerProject = new List<IDictionary<string, ITaskItem[]>>();
             }
         }
 
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _buildResult;
+                return buildResult;
             }
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetOutputsPerProject;
+                return targetOutputsPerProject;
             }
         }
     }

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -27,42 +27,42 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Subcategory of the error
         /// </summary>
-        private string _subcategory;
+        private string subcategory;
 
         /// <summary>
         /// Error code
         /// </summary>
-        private string _code;
+        private string code;
 
         /// <summary>
         /// File name
         /// </summary>
-        private string _file;
+        private string file;
 
         /// <summary>
         /// The project which issued the event
         /// </summary>
-        private string _projectFile;
+        private string projectFile;
 
         /// <summary>
         /// Line number
         /// </summary>
-        private int _lineNumber;
+        private int lineNumber;
 
         /// <summary>
         /// Column number
         /// </summary>
-        private int _columnNumber;
+        private int columnNumber;
 
         /// <summary>
         /// End line number
         /// </summary>
-        private int _endLineNumber;
+        private int endLineNumber;
 
         /// <summary>
         /// End column number
         /// </summary>
-        private int _endColumnNumber;
+        private int endColumnNumber;
 
         /// <summary>
         /// This constructor allows all event data to be initialized
@@ -159,13 +159,13 @@ namespace Microsoft.Build.Framework
             )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)
         {
-            _subcategory = subcategory;
-            _code = code;
-            _file = file;
-            _lineNumber = lineNumber;
-            _columnNumber = columnNumber;
-            _endLineNumber = endLineNumber;
-            _endColumnNumber = endColumnNumber;
+            this.subcategory = subcategory;
+            this.code = code;
+            this.file = file;
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.endLineNumber = endLineNumber;
+            this.endColumnNumber = endColumnNumber;
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _subcategory;
+                return subcategory;
             }
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _code;
+                return code;
             }
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _file;
+                return file;
             }
         }
 
@@ -217,12 +217,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
 
             set
             {
-                _projectFile = value;
+                projectFile = value;
             }
         }
 
@@ -233,7 +233,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _lineNumber;
+                return lineNumber;
             }
         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _columnNumber;
+                return columnNumber;
             }
         }
 
@@ -255,7 +255,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _endLineNumber;
+                return endLineNumber;
             }
         }
 
@@ -266,7 +266,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _endColumnNumber;
+                return endColumnNumber;
             }
         }
 
@@ -279,53 +279,53 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
             #region SubCategory
-            if (_subcategory == null)
+            if (subcategory == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_subcategory);
+                writer.Write(subcategory);
             }
             #endregion
             #region Code
-            if (_code == null)
+            if (code == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_code);
+                writer.Write(code);
             }
             #endregion
             #region File
-            if (_file == null)
+            if (file == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_file);
+                writer.Write(file);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
-            writer.Write((Int32)_lineNumber);
-            writer.Write((Int32)_columnNumber);
-            writer.Write((Int32)_endLineNumber);
-            writer.Write((Int32)_endColumnNumber);
+            writer.Write((Int32)lineNumber);
+            writer.Write((Int32)columnNumber);
+            writer.Write((Int32)endLineNumber);
+            writer.Write((Int32)endColumnNumber);
         }
 
         /// <summary>
@@ -339,31 +339,31 @@ namespace Microsoft.Build.Framework
             #region SubCategory
             if (reader.ReadByte() == 0)
             {
-                _subcategory = null;
+                subcategory = null;
             }
             else
             {
-                _subcategory = reader.ReadString();
+                subcategory = reader.ReadString();
             }
             #endregion
             #region Code
             if (reader.ReadByte() == 0)
             {
-                _code = null;
+                code = null;
             }
             else
             {
-                _code = reader.ReadString();
+                code = reader.ReadString();
             }
             #endregion
             #region File
             if (reader.ReadByte() == 0)
             {
-                _file = null;
+                file = null;
             }
             else
             {
-                _file = reader.ReadString();
+                file = reader.ReadString();
             }
             #endregion
             #region ProjectFile
@@ -371,22 +371,22 @@ namespace Microsoft.Build.Framework
             {
                 if (reader.ReadByte() == 0)
                 {
-                    _projectFile = null;
+                    projectFile = null;
                 }
                 else
                 {
-                    _projectFile = reader.ReadString();
+                    projectFile = reader.ReadString();
                 }
             }
             else
             {
-                _projectFile = null;
+                projectFile = null;
             }
             #endregion
-            _lineNumber = reader.ReadInt32();
-            _columnNumber = reader.ReadInt32();
-            _endLineNumber = reader.ReadInt32();
-            _endColumnNumber = reader.ReadInt32();
+            lineNumber = reader.ReadInt32();
+            columnNumber = reader.ReadInt32();
+            endLineNumber = reader.ReadInt32();
+            endColumnNumber = reader.ReadInt32();
         }
         #endregion
 

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -30,33 +30,33 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Message
         /// </summary>
-        private string _message;
+        private string message;
 
         /// <summary>
         /// Help keyword
         /// </summary>
-        private string _helpKeyword;
+        private string helpKeyword;
 
         /// <summary>
         /// Sender name
         /// </summary>
-        private string _senderName;
+        private string senderName;
 
         /// <summary>
         /// Timestamp
         /// </summary>
-        private DateTime _timestamp;
+        private DateTime timestamp;
 
         /// <summary>
         /// Thread id
         /// </summary>
-        private int _threadId;
+        private int threadId;
 
         /// <summary>
         /// Build event context
         /// </summary>
         [OptionalField(VersionAdded = 2)]
-        private BuildEventContext _buildEventContext;
+        private BuildEventContext buildEventContext;
 
         /// <summary>
         /// Default constructor
@@ -86,11 +86,11 @@ namespace Microsoft.Build.Framework
         /// <param name="eventTimeStamp">TimeStamp of when the event was created</param>
         protected BuildEventArgs(string message, string helpKeyword, string senderName, DateTime eventTimestamp)
         {
-            _message = message;
-            _helpKeyword = helpKeyword;
-            _senderName = senderName;
-            _timestamp = eventTimestamp;
-            _threadId = System.Threading.Thread.CurrentThread.GetHashCode();
+            this.message = message;
+            this.helpKeyword = helpKeyword;
+            this.senderName = senderName;
+            timestamp = eventTimestamp;
+            threadId = System.Threading.Thread.CurrentThread.GetHashCode();
         }
 
         /// <summary>
@@ -103,12 +103,12 @@ namespace Microsoft.Build.Framework
                 // Rather than storing dates in Local time all the time, we store in UTC type, and only
                 // convert to Local when the user requests access to this field.  This lets us avoid the
                 // expensive conversion to Local time unless it's absolutely necessary.
-                if (_timestamp.Kind == DateTimeKind.Utc)
+                if (timestamp.Kind == DateTimeKind.Utc)
                 {
-                    _timestamp = _timestamp.ToLocalTime();
+                    timestamp = timestamp.ToLocalTime();
                 }
 
-                return _timestamp;
+                return timestamp;
             }
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _threadId;
+                return threadId;
             }
         }
 
@@ -130,12 +130,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _message;
+                return message;
             }
 
             protected set
             {
-                _message = value;
+                message = value;
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _helpKeyword;
+                return helpKeyword;
             }
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _senderName;
+                return senderName;
             }
         }
 
@@ -168,12 +168,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _buildEventContext;
+                return buildEventContext;
             }
 
             set
             {
-                _buildEventContext = value;
+                buildEventContext = value;
             }
         }
 
@@ -185,57 +185,57 @@ namespace Microsoft.Build.Framework
         internal virtual void WriteToStream(BinaryWriter writer)
         {
             #region Message
-            if (_message == null)
+            if (message == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_message);
+                writer.Write(message);
             }
             #endregion
             #region HelpKeyword
-            if (_helpKeyword == null)
+            if (helpKeyword == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_helpKeyword);
+                writer.Write(helpKeyword);
             }
             #endregion
             #region SenderName
-            if (_senderName == null)
+            if (senderName == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_senderName);
+                writer.Write(senderName);
             }
             #endregion
             #region TimeStamp
-            writer.Write((Int64)_timestamp.Ticks);
-            writer.Write((Int32)_timestamp.Kind);
+            writer.Write((Int64)timestamp.Ticks);
+            writer.Write((Int32)timestamp.Kind);
             #endregion
-            writer.Write((Int32)_threadId);
+            writer.Write((Int32)threadId);
             #region BuildEventContext
-            if (_buildEventContext == null)
+            if (buildEventContext == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write((Int32)_buildEventContext.NodeId);
-                writer.Write((Int32)_buildEventContext.ProjectContextId);
-                writer.Write((Int32)_buildEventContext.TargetId);
-                writer.Write((Int32)_buildEventContext.TaskId);
-                writer.Write((Int32)_buildEventContext.SubmissionId);
-                writer.Write((Int32)_buildEventContext.ProjectInstanceId);
+                writer.Write((Int32)buildEventContext.NodeId);
+                writer.Write((Int32)buildEventContext.ProjectContextId);
+                writer.Write((Int32)buildEventContext.TargetId);
+                writer.Write((Int32)buildEventContext.TaskId);
+                writer.Write((Int32)buildEventContext.SubmissionId);
+                writer.Write((Int32)buildEventContext.ProjectInstanceId);
             }
             #endregion
         }
@@ -250,31 +250,31 @@ namespace Microsoft.Build.Framework
             #region Message
             if (reader.ReadByte() == 0)
             {
-                _message = null;
+                message = null;
             }
             else
             {
-                _message = reader.ReadString();
+                message = reader.ReadString();
             }
             #endregion
             #region HelpKeyword
             if (reader.ReadByte() == 0)
             {
-                _helpKeyword = null;
+                helpKeyword = null;
             }
             else
             {
-                _helpKeyword = reader.ReadString();
+                helpKeyword = reader.ReadString();
             }
             #endregion
             #region SenderName
             if (reader.ReadByte() == 0)
             {
-                _senderName = null;
+                senderName = null;
             }
             else
             {
-                _senderName = reader.ReadString();
+                senderName = reader.ReadString();
             }
             #endregion
             #region TimeStamp
@@ -282,18 +282,18 @@ namespace Microsoft.Build.Framework
             if (version > 20)
             {
                 DateTimeKind kind = (DateTimeKind)reader.ReadInt32();
-                _timestamp = new DateTime(timestampTicks, kind);
+                timestamp = new DateTime(timestampTicks, kind);
             }
             else
             {
-                _timestamp = new DateTime(timestampTicks);
+                timestamp = new DateTime(timestampTicks);
             }
             #endregion
-            _threadId = reader.ReadInt32();
+            threadId = reader.ReadInt32();
             #region BuildEventContext
             if (reader.ReadByte() == 0)
             {
-                _buildEventContext = null;
+                buildEventContext = null;
             }
             else
             {
@@ -306,11 +306,11 @@ namespace Microsoft.Build.Framework
                 {
                     int submissionId = reader.ReadInt32();
                     int projectInstanceId = reader.ReadInt32();
-                    _buildEventContext = new BuildEventContext(submissionId, nodeId, projectInstanceId, projectContextId, targetId, taskId);
+                    buildEventContext = new BuildEventContext(submissionId, nodeId, projectInstanceId, projectContextId, targetId, taskId);
                 }
                 else
                 {
-                    _buildEventContext = new BuildEventContext(nodeId, targetId, projectContextId, taskId);
+                    buildEventContext = new BuildEventContext(nodeId, targetId, projectContextId, taskId);
                 }
             }
             #endregion
@@ -328,7 +328,7 @@ namespace Microsoft.Build.Framework
         {
             // Don't want to create a new one here as default all the time as that would be a lot of 
             // possibly useless allocations
-            _buildEventContext = null;
+            buildEventContext = null;
         }
 
         /// <summary>
@@ -337,9 +337,9 @@ namespace Microsoft.Build.Framework
         [OnDeserialized]
         private void SetBuildEventContextDefaultAfterSerialization(StreamingContext sc)
         {
-            if (_buildEventContext == null)
+            if (buildEventContext == null)
             {
-                _buildEventContext = new BuildEventContext
+                buildEventContext = new BuildEventContext
                                        (
                                        BuildEventContext.InvalidNodeId,
                                        BuildEventContext.InvalidTargetId,

--- a/src/Framework/BuildEventContext.cs
+++ b/src/Framework/BuildEventContext.cs
@@ -20,32 +20,32 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Node event was in 
         /// </summary>
-        private int _nodeId;
+        private int nodeId;
 
         /// <summary>
         /// Target event was in
         /// </summary>
-        private int _targetId;
+        private int targetId;
 
         /// <summary>
         ///The node-unique project request context the event was in
         /// </summary>
-        private int _projectContextId;
+        private int projectContextId;
 
         /// <summary>
         /// Id of the task the event was caused from
         /// </summary>
-        private int _taskId;
+        private int taskId;
 
         /// <summary>
         /// The id of the project instance to which this event refers.
         /// </summary>
-        private int _projectInstanceId;
+        private int projectInstanceId;
 
         /// <summary>
         /// The id of the submission.
         /// </summary>
-        private int _submissionId;
+        private int submissionId;
 
         #endregion
 
@@ -94,12 +94,12 @@ namespace Microsoft.Build.Framework
             int taskId
         )
         {
-            _submissionId = submissionId;
-            _nodeId = nodeId;
-            _targetId = targetId;
-            _projectContextId = projectContextId;
-            _taskId = taskId;
-            _projectInstanceId = projectInstanceId;
+            this.submissionId = submissionId;
+            this.nodeId = nodeId;
+            this.targetId = targetId;
+            this.projectContextId = projectContextId;
+            this.taskId = taskId;
+            this.projectInstanceId = projectInstanceId;
         }
 
         #endregion
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _nodeId;
+                return nodeId;
             }
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetId;
+                return targetId;
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectContextId;
+                return projectContextId;
             }
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _taskId;
+                return taskId;
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectInstanceId;
+                return projectInstanceId;
             }
         }
 
@@ -179,7 +179,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _submissionId;
+                return submissionId;
             }
         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return ((long)_nodeId << 32) + _projectContextId;
+                return ((long)nodeId << 32) + projectContextId;
             }
         }
 
@@ -287,10 +287,10 @@ namespace Microsoft.Build.Framework
         /// <returns>True if the value fields are the same, false if otherwise</returns>
         private bool InternalEquals(BuildEventContext buildEventContext)
         {
-            return ((_nodeId == buildEventContext.NodeId)
-                   && (_projectContextId == buildEventContext.ProjectContextId)
-                   && (_targetId == buildEventContext.TargetId)
-                   && (_taskId == buildEventContext.TaskId));
+            return ((nodeId == buildEventContext.NodeId)
+                   && (projectContextId == buildEventContext.ProjectContextId)
+                   && (targetId == buildEventContext.TargetId)
+                   && (taskId == buildEventContext.TaskId));
         }
         #endregion
 

--- a/src/Framework/BuildFinishedEventArgs.cs
+++ b/src/Framework/BuildFinishedEventArgs.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Whether the build succeeded
         /// </summary>
-        private bool _succeeded;
+        private bool succeeded;
 
         /// <summary>
         /// Default constructor
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp, messageArgs)
         {
-            _succeeded = succeeded;
+            this.succeeded = succeeded;
         }
 
 
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            writer.Write(_succeeded);
+            writer.Write(succeeded);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            _succeeded = reader.ReadBoolean();
+            succeeded = reader.ReadBoolean();
         }
         #endregion
         /// <summary>
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _succeeded;
+                return succeeded;
             }
         }
     }

--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -220,41 +220,41 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)
         {
-            _importance = importance;
-            _subcategory = subcategory;
-            _code = code;
-            _file = file;
-            _lineNumber = lineNumber;
-            _columnNumber = columnNumber;
-            _endLineNumber = endLineNumber;
-            _endColumnNumber = endColumnNumber;
+            this.importance = importance;
+            this.subcategory = subcategory;
+            this.code = code;
+            this.file = file;
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.endLineNumber = endLineNumber;
+            this.endColumnNumber = endColumnNumber;
         }
 
-        private MessageImportance _importance;
+        private MessageImportance importance;
 
         [OptionalField(VersionAdded = 2)]
-        private string _subcategory;
+        private string subcategory;
 
         [OptionalField(VersionAdded = 2)]
-        private string _code;
+        private string code;
 
         [OptionalField(VersionAdded = 2)]
-        private string _file;
+        private string file;
 
         [OptionalField(VersionAdded = 2)]
-        private string _projectFile;
+        private string projectFile;
 
         [OptionalField(VersionAdded = 2)]
-        private int _lineNumber;
+        private int lineNumber;
 
         [OptionalField(VersionAdded = 2)]
-        private int _columnNumber;
+        private int columnNumber;
 
         [OptionalField(VersionAdded = 2)]
-        private int _endLineNumber;
+        private int endLineNumber;
 
         [OptionalField(VersionAdded = 2)]
-        private int _endColumnNumber;
+        private int endColumnNumber;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -264,55 +264,55 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            writer.Write((Int32)_importance);
+            writer.Write((Int32)importance);
             #region SubCategory
-            if (_subcategory == null)
+            if (subcategory == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_subcategory);
+                writer.Write(subcategory);
             }
             #endregion
             #region Code
-            if (_code == null)
+            if (code == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_code);
+                writer.Write(code);
             }
             #endregion
             #region File
-            if (_file == null)
+            if (file == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_file);
+                writer.Write(file);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
-            writer.Write((Int32)_lineNumber);
-            writer.Write((Int32)_columnNumber);
-            writer.Write((Int32)_endLineNumber);
-            writer.Write((Int32)_endColumnNumber);
+            writer.Write((Int32)lineNumber);
+            writer.Write((Int32)columnNumber);
+            writer.Write((Int32)endLineNumber);
+            writer.Write((Int32)endColumnNumber);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            _importance = (MessageImportance)reader.ReadInt32();
+            importance = (MessageImportance)reader.ReadInt32();
 
             //The data in the stream beyond this point are new to 4.0
             if (version > 20)
@@ -331,47 +331,47 @@ namespace Microsoft.Build.Framework
                 #region SubCategory
                 if (reader.ReadByte() == 0)
                 {
-                    _subcategory = null;
+                    subcategory = null;
                 }
                 else
                 {
-                    _subcategory = reader.ReadString();
+                    subcategory = reader.ReadString();
                 }
                 #endregion
                 #region Code
                 if (reader.ReadByte() == 0)
                 {
-                    _code = null;
+                    code = null;
                 }
                 else
                 {
-                    _code = reader.ReadString();
+                    code = reader.ReadString();
                 }
                 #endregion
                 #region File
                 if (reader.ReadByte() == 0)
                 {
-                    _file = null;
+                    file = null;
                 }
                 else
                 {
-                    _file = reader.ReadString();
+                    file = reader.ReadString();
                 }
                 #endregion
                 #region ProjectFile
                 if (reader.ReadByte() == 0)
                 {
-                    _projectFile = null;
+                    projectFile = null;
                 }
                 else
                 {
-                    _projectFile = reader.ReadString();
+                    projectFile = reader.ReadString();
                 }
                 #endregion
-                _lineNumber = reader.ReadInt32();
-                _columnNumber = reader.ReadInt32();
-                _endLineNumber = reader.ReadInt32();
-                _endColumnNumber = reader.ReadInt32();
+                lineNumber = reader.ReadInt32();
+                columnNumber = reader.ReadInt32();
+                endLineNumber = reader.ReadInt32();
+                endColumnNumber = reader.ReadInt32();
             }
         }
         #endregion
@@ -383,7 +383,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _importance;
+                return importance;
             }
         }
 
@@ -394,7 +394,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _subcategory;
+                return subcategory;
             }
         }
 
@@ -405,7 +405,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _code;
+                return code;
             }
         }
 
@@ -416,7 +416,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _file;
+                return file;
             }
         }
 
@@ -427,7 +427,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _lineNumber;
+                return lineNumber;
             }
         }
 
@@ -438,7 +438,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _columnNumber;
+                return columnNumber;
             }
         }
 
@@ -449,7 +449,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _endLineNumber;
+                return endLineNumber;
             }
         }
 
@@ -460,7 +460,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _endColumnNumber;
+                return endColumnNumber;
             }
         }
 
@@ -471,12 +471,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
 
             set
             {
-                _projectFile = value;
+                projectFile = value;
             }
         }
     }

--- a/src/Framework/BuildStartedEventArgs.cs
+++ b/src/Framework/BuildStartedEventArgs.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Framework
     [Serializable]
     public class BuildStartedEventArgs : BuildStatusEventArgs
     {
-        private IDictionary<string, string> _environmentOnBuildStart;
+        private IDictionary<string, string> environmentOnBuildStart;
 
         /// <summary>
         /// Default constructor
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Framework
         )
             : this(message, helpKeyword, DateTime.UtcNow)
         {
-            _environmentOnBuildStart = environmentOfBuild;
+            environmentOnBuildStart = environmentOfBuild;
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Microsoft.Build.Framework
         /// </summary>
         public IDictionary<string, string> BuildEnvironment
         {
-            get { return _environmentOnBuildStart; }
+            get { return environmentOnBuildStart; }
         }
     }
 }

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -125,23 +125,23 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, senderName, eventTimestamp, messageArgs)
         {
-            _subcategory = subcategory;
-            _code = code;
-            _file = file;
-            _lineNumber = lineNumber;
-            _columnNumber = columnNumber;
-            _endLineNumber = endLineNumber;
-            _endColumnNumber = endColumnNumber;
+            this.subcategory = subcategory;
+            this.code = code;
+            this.file = file;
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.endLineNumber = endLineNumber;
+            this.endColumnNumber = endColumnNumber;
         }
 
-        private string _subcategory;
-        private string _code;
-        private string _file;
-        private string _projectFile;
-        private int _lineNumber;
-        private int _columnNumber;
-        private int _endLineNumber;
-        private int _endColumnNumber;
+        private string subcategory;
+        private string code;
+        private string file;
+        private string projectFile;
+        private int lineNumber;
+        private int columnNumber;
+        private int endLineNumber;
+        private int endColumnNumber;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -152,53 +152,53 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
             #region SubCategory
-            if (_subcategory == null)
+            if (subcategory == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_subcategory);
+                writer.Write(subcategory);
             }
             #endregion
             #region Code
-            if (_code == null)
+            if (code == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_code);
+                writer.Write(code);
             }
             #endregion
             #region File
-            if (_file == null)
+            if (file == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_file);
+                writer.Write(file);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
-            writer.Write((Int32)_lineNumber);
-            writer.Write((Int32)_columnNumber);
-            writer.Write((Int32)_endLineNumber);
-            writer.Write((Int32)_endColumnNumber);
+            writer.Write((Int32)lineNumber);
+            writer.Write((Int32)columnNumber);
+            writer.Write((Int32)endLineNumber);
+            writer.Write((Int32)endColumnNumber);
         }
 
         /// <summary>
@@ -212,31 +212,31 @@ namespace Microsoft.Build.Framework
             #region SubCategory
             if (reader.ReadByte() == 0)
             {
-                _subcategory = null;
+                subcategory = null;
             }
             else
             {
-                _subcategory = reader.ReadString();
+                subcategory = reader.ReadString();
             }
             #endregion
             #region Code
             if (reader.ReadByte() == 0)
             {
-                _code = null;
+                code = null;
             }
             else
             {
-                _code = reader.ReadString();
+                code = reader.ReadString();
             }
             #endregion
             #region File
             if (reader.ReadByte() == 0)
             {
-                _file = null;
+                file = null;
             }
             else
             {
-                _file = reader.ReadString();
+                file = reader.ReadString();
             }
             #endregion
             #region ProjectFile
@@ -244,18 +244,18 @@ namespace Microsoft.Build.Framework
             {
                 if (reader.ReadByte() == 0)
                 {
-                    _projectFile = null;
+                    projectFile = null;
                 }
                 else
                 {
-                    _projectFile = reader.ReadString();
+                    projectFile = reader.ReadString();
                 }
             }
             #endregion
-            _lineNumber = reader.ReadInt32();
-            _columnNumber = reader.ReadInt32();
-            _endLineNumber = reader.ReadInt32();
-            _endColumnNumber = reader.ReadInt32();
+            lineNumber = reader.ReadInt32();
+            columnNumber = reader.ReadInt32();
+            endLineNumber = reader.ReadInt32();
+            endColumnNumber = reader.ReadInt32();
         }
         #endregion
         /// <summary>
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _subcategory;
+                return subcategory;
             }
         }
 
@@ -276,7 +276,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _code;
+                return code;
             }
         }
 
@@ -287,7 +287,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _file;
+                return file;
             }
         }
 
@@ -298,7 +298,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _lineNumber;
+                return lineNumber;
             }
         }
 
@@ -309,7 +309,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _columnNumber;
+                return columnNumber;
             }
         }
 
@@ -320,7 +320,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _endLineNumber;
+                return endLineNumber;
             }
         }
 
@@ -331,7 +331,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _endColumnNumber;
+                return endColumnNumber;
             }
         }
 
@@ -342,12 +342,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
 
             set
             {
-                _projectFile = value;
+                projectFile = value;
             }
         }
     }

--- a/src/Framework/ExternalProjectFinishedEventArgs.cs
+++ b/src/Framework/ExternalProjectFinishedEventArgs.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, senderName, eventTimestamp)
         {
-            _projectFile = projectFile;
-            _succeeded = succeeded;
+            this.projectFile = projectFile;
+            this.succeeded = succeeded;
         }
 
-        private string _projectFile;
+        private string projectFile;
 
         /// <summary>
         /// Project name
@@ -82,11 +82,11 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
-        private bool _succeeded;
+        private bool succeeded;
 
         /// <summary>
         /// True if project built successfully, false otherwise
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _succeeded;
+                return succeeded;
             }
         }
     }

--- a/src/Framework/ExternalProjectStartedEventArgs.cs
+++ b/src/Framework/ExternalProjectStartedEventArgs.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, senderName, eventTimestamp)
         {
-            _projectFile = projectFile;
-            _targetNames = targetNames;
+            this.projectFile = projectFile;
+            this.targetNames = targetNames;
         }
 
-        private string _projectFile;
+        private string projectFile;
 
         /// <summary>
         /// Project name
@@ -82,11 +82,11 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
-        private string _targetNames;
+        private string targetNames;
 
         /// <summary>
         /// Targets that we will build in the project. This may mean different things for different project types,
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetNames;
+                return targetNames;
             }
         }
     }

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -21,18 +21,18 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Stores the message arguments.
         /// </summary>
-        private object[] _arguments;
+        private object[] arguments;
 
         /// <summary>
         /// Stores the original culture for String.Format.
         /// </summary>
-        private CultureInfo _originalCulture;
+        private CultureInfo originalCulture;
 
         /// <summary>
         /// Lock object.
         /// </summary>
         [NonSerialized]
-        private Object _locker;
+        private Object locker;
 
         /// <summary>
         /// This constructor allows all event data to be initialized.
@@ -68,9 +68,9 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, senderName, eventTimestamp)
         {
-            _arguments = messageArgs;
-            _originalCulture = CultureInfo.CurrentCulture;
-            _locker = new Object();
+            arguments = messageArgs;
+            originalCulture = CultureInfo.CurrentCulture;
+            locker = new Object();
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Framework
         protected LazyFormattedBuildEventArgs()
             : base()
         {
-            _locker = new Object();
+            locker = new Object();
         }
 
         /// <summary>
@@ -89,12 +89,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                lock (_locker)
+                lock (locker)
                 {
-                    if (_arguments != null && _arguments.Length > 0)
+                    if (arguments != null && arguments.Length > 0)
                     {
-                        base.Message = FormatString(_originalCulture, base.Message, _arguments);
-                        _arguments = null;
+                        base.Message = FormatString(originalCulture, base.Message, arguments);
+                        arguments = null;
                     }
                 }
 
@@ -111,21 +111,21 @@ namespace Microsoft.Build.Framework
             // Locking is needed here as this is invoked on the serialization thread,
             // whereas a local logger (a distributed logger) may concurrently invoke this.Message
             // which will trigger formatting and thus the exception below
-            lock (_locker)
+            lock (locker)
             {
-                bool hasArguments = _arguments != null;
+                bool hasArguments = arguments != null;
                 base.WriteToStream(writer);
 
-                if (hasArguments && _arguments == null)
+                if (hasArguments && arguments == null)
                 {
                     throw new InvalidOperationException("BuildEventArgs has formatted message while serializing!");
                 }
 
-                if (_arguments != null)
+                if (arguments != null)
                 {
-                    writer.Write(_arguments.Length);
+                    writer.Write(arguments.Length);
 
-                    foreach (object argument in _arguments)
+                    foreach (object argument in arguments)
                     {
                         // Arguments may be ints, etc, so explicitly convert
                         // Convert.ToString returns String.Empty when it cannot convert, rather than throwing
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Framework
                     writer.Write((Int32)(-1));
                 }
 
-                writer.Write(_originalCulture != null ? _originalCulture.LCID : 0);
+                writer.Write(originalCulture != null ? originalCulture.LCID : 0);
             }
         }
 
@@ -165,18 +165,18 @@ namespace Microsoft.Build.Framework
                     }
                 }
 
-                _arguments = messageArgs;
+                arguments = messageArgs;
 
                 int originalCultureId = reader.ReadInt32();
                 if (originalCultureId != 0)
                 {
                     if (originalCultureId == CultureInfo.CurrentCulture.LCID)
                     {
-                        _originalCulture = CultureInfo.CurrentCulture;
+                        originalCulture = CultureInfo.CurrentCulture;
                     }
                     else
                     {
-                        _originalCulture = new CultureInfo(originalCultureId);
+                        originalCulture = new CultureInfo(originalCultureId);
                     }
                 }
             }
@@ -290,7 +290,7 @@ namespace Microsoft.Build.Framework
         [OnDeserialized]
         private void OnDeserialized(StreamingContext context)
         {
-            _locker = new Object();
+            locker = new Object();
         }
     }
 }

--- a/src/Framework/LoggerException.cs
+++ b/src/Framework/LoggerException.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Build.Framework
             : this(message, innerException)
         {
             // We do no verification of these parameters. Any can be null.
-            _errorCode = errorCode;
-            _helpKeyword = helpKeyword;
+            this.errorCode = errorCode;
+            this.helpKeyword = helpKeyword;
         }
 
         #region Serialization (update when adding new class members)
@@ -81,8 +81,8 @@ namespace Microsoft.Build.Framework
         protected LoggerException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            _errorCode = info.GetString("errorCode");
-            _helpKeyword = info.GetString("helpKeyword");
+            errorCode = info.GetString("errorCode");
+            helpKeyword = info.GetString("helpKeyword");
         }
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Microsoft.Build.Framework
         {
             base.GetObjectData(info, context);
 
-            info.AddValue("errorCode", _errorCode);
-            info.AddValue("helpKeyword", _helpKeyword);
+            info.AddValue("errorCode", errorCode);
+            info.AddValue("helpKeyword", helpKeyword);
         }
 
         #endregion
@@ -112,7 +112,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _errorCode;
+                return errorCode;
             }
         }
 
@@ -124,15 +124,15 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _helpKeyword;
+                return helpKeyword;
             }
         }
 
         #endregion
 
         // the error code for this exception's message (not the inner exception)
-        private string _errorCode;
+        private string errorCode;
         // the F1-help keyword for the host IDE
-        private string _helpKeyword;
+        private string helpKeyword;
     }
 }

--- a/src/Framework/ProjectFinishedEventArgs.cs
+++ b/src/Framework/ProjectFinishedEventArgs.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp)
         {
-            _projectFile = projectFile;
-            _succeeded = succeeded;
+            this.projectFile = projectFile;
+            this.succeeded = succeeded;
         }
 
-        private string _projectFile;
-        private bool _succeeded;
+        private string projectFile;
+        private bool succeeded;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -84,17 +84,17 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
 
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
 
-            writer.Write(_succeeded);
+            writer.Write(succeeded);
         }
 
         /// <summary>
@@ -108,14 +108,14 @@ namespace Microsoft.Build.Framework
 
             if (reader.ReadByte() == 0)
             {
-                _projectFile = null;
+                projectFile = null;
             }
             else
             {
-                _projectFile = reader.ReadString();
+                projectFile = reader.ReadString();
             }
 
-            _succeeded = reader.ReadBoolean();
+            succeeded = reader.ReadBoolean();
         }
         #endregion
 
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _succeeded;
+                return succeeded;
             }
         }
     }

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -140,19 +140,19 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp)
         {
-            _projectFile = projectFile;
+            this.projectFile = projectFile;
 
             if (targetNames == null)
             {
-                _targetNames = String.Empty;
+                this.targetNames = String.Empty;
             }
             else
             {
-                _targetNames = targetNames;
+                this.targetNames = targetNames;
             }
 
-            _properties = properties;
-            _items = items;
+            this.properties = properties;
+            this.items = items;
         }
 
         /// <summary>
@@ -181,8 +181,8 @@ namespace Microsoft.Build.Framework
         )
             : this(message, helpKeyword, projectFile, targetNames, properties, items, eventTimestamp)
         {
-            _parentProjectBuildEventContext = parentBuildEventContext;
-            _projectId = projectId;
+            parentProjectBuildEventContext = parentBuildEventContext;
+            this.projectId = projectId;
         }
 
         // ProjectId is only contained in the project started event.
@@ -190,18 +190,18 @@ namespace Microsoft.Build.Framework
         // used when debugging to determine if two projects with the same name
         // are the same project instance or different instances
         [OptionalField(VersionAdded = 2)]
-        private int _projectId;
+        private int projectId;
 
         public int ProjectId
         {
             get
             {
-                return _projectId;
+                return projectId;
             }
         }
 
         [OptionalField(VersionAdded = 2)]
-        private BuildEventContext _parentProjectBuildEventContext;
+        private BuildEventContext parentProjectBuildEventContext;
 
         /// <summary>
         /// Event context information, where the event was fired from in terms of the build location
@@ -210,14 +210,14 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _parentProjectBuildEventContext;
+                return parentProjectBuildEventContext;
             }
         }
 
         /// <summary>
         /// The name of the project file
         /// </summary>
-        private string _projectFile;
+        private string projectFile;
 
         /// <summary>
         /// Project name
@@ -226,14 +226,14 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
         /// <summary>
         /// Targets that we will build in the project
         /// </summary>
-        private string _targetNames;
+        private string targetNames;
 
         /// <summary>
         /// Targets that we will build in the project
@@ -242,7 +242,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetNames;
+                return targetNames;
             }
         }
 
@@ -250,7 +250,7 @@ namespace Microsoft.Build.Framework
         /// Gets the set of global properties used to evaluate this project.
         /// </summary>
         [OptionalField(VersionAdded = 2)]
-        private IDictionary<string, string> _globalProperties;
+        private IDictionary<string, string> globalProperties;
 
         /// <summary>
         /// Gets the set of global properties used to evaluate this project.
@@ -259,17 +259,17 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _globalProperties;
+                return globalProperties;
             }
 
             internal set
             {
-                _globalProperties = value;
+                globalProperties = value;
             }
         }
 
         [OptionalField(VersionAdded = 2)]
-        private string _toolsVersion;
+        private string toolsVersion;
 
         /// <summary>
         /// Gets the tools version used to evaluate this project.
@@ -278,12 +278,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _toolsVersion;
+                return toolsVersion;
             }
 
             internal set
             {
-                _toolsVersion = value;
+                toolsVersion = value;
             }
         }
 
@@ -291,7 +291,7 @@ namespace Microsoft.Build.Framework
         // (a) this event will not be thrown by tasks, so it should not generally cross AppDomain boundaries
         // (b) this event still makes sense when this field is "null"
         [NonSerialized]
-        private IEnumerable _properties;
+        private IEnumerable properties;
 
         /// <summary>
         /// List of properties in this project. This is a live, read-only list.
@@ -308,7 +308,7 @@ namespace Microsoft.Build.Framework
                 // up the live list of properties from the loaded project, which is stored in the configuration as well.
                 // By doing this, we no longer need to transmit properties using this message because they've already
                 // been transmitted as part of the BuildRequestConfiguration.
-                return _properties;
+                return properties;
             }
         }
 
@@ -316,7 +316,7 @@ namespace Microsoft.Build.Framework
         // (a) this event will not be thrown by tasks, so it should not generally cross AppDomain boundaries
         // (b) this event still makes sense when this field is "null"
         [NonSerialized]
-        private IEnumerable _items;
+        private IEnumerable items;
 
         /// <summary>
         /// List of items in this project. This is a live, read-only list.
@@ -332,7 +332,7 @@ namespace Microsoft.Build.Framework
                 // case, this access is to the live list.  For the central logger in the multi-proc case, the main node 
                 // has likely not loaded this project, and therefore the live items would not be available to them, which is 
                 // the same as the current functionality.
-                return _items;
+                return items;
             }
         }
 
@@ -345,38 +345,38 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            writer.Write((Int32)_projectId);
+            writer.Write((Int32)projectId);
             #region ParentProjectBuildEventContext
-            if (_parentProjectBuildEventContext == null)
+            if (parentProjectBuildEventContext == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write((Int32)_parentProjectBuildEventContext.NodeId);
-                writer.Write((Int32)_parentProjectBuildEventContext.ProjectContextId);
-                writer.Write((Int32)_parentProjectBuildEventContext.TargetId);
-                writer.Write((Int32)_parentProjectBuildEventContext.TaskId);
-                writer.Write((Int32)_parentProjectBuildEventContext.SubmissionId);
-                writer.Write((Int32)_parentProjectBuildEventContext.ProjectInstanceId);
+                writer.Write((Int32)parentProjectBuildEventContext.NodeId);
+                writer.Write((Int32)parentProjectBuildEventContext.ProjectContextId);
+                writer.Write((Int32)parentProjectBuildEventContext.TargetId);
+                writer.Write((Int32)parentProjectBuildEventContext.TaskId);
+                writer.Write((Int32)parentProjectBuildEventContext.SubmissionId);
+                writer.Write((Int32)parentProjectBuildEventContext.ProjectInstanceId);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
 
             #region TargetNames
             // TargetNames cannot be null as per line 61 in the constructor
-            writer.Write(_targetNames);
+            writer.Write(targetNames);
             #endregion
 
             #region Properties
@@ -416,7 +416,7 @@ namespace Microsoft.Build.Framework
         /// <returns>Null if properties is null, or a list containing one or more of the  properties in the properties enumerator</returns>
         private Dictionary<string, string> GeneratePropertyList()
         {
-            if (_properties == null)
+            if (properties == null)
             {
                 return null;
             }
@@ -424,7 +424,7 @@ namespace Microsoft.Build.Framework
             Dictionary<string, string> propertyList = new Dictionary<string, string>();
 
             // Loop through the properties and add them to the keyvalue pair list
-            foreach (DictionaryEntry property in _properties)
+            foreach (DictionaryEntry property in properties)
             {
                 object propertyKey = property.Key;
                 object propertyValue = property.Value;
@@ -448,11 +448,11 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            _projectId = reader.ReadInt32();
+            projectId = reader.ReadInt32();
             #region ParentProjectBuildEventContext
             if (reader.ReadByte() == 0)
             {
-                _parentProjectBuildEventContext = null;
+                parentProjectBuildEventContext = null;
             }
             else
             {
@@ -465,34 +465,34 @@ namespace Microsoft.Build.Framework
                 {
                     int submissionId = reader.ReadInt32();
                     int projectInstanceId = reader.ReadInt32();
-                    _parentProjectBuildEventContext = new BuildEventContext(submissionId, nodeId, projectInstanceId, projectContextId, targetId, taskId);
+                    parentProjectBuildEventContext = new BuildEventContext(submissionId, nodeId, projectInstanceId, projectContextId, targetId, taskId);
                 }
                 else
                 {
-                    _parentProjectBuildEventContext = new BuildEventContext(nodeId, targetId, projectContextId, taskId);
+                    parentProjectBuildEventContext = new BuildEventContext(nodeId, targetId, projectContextId, taskId);
                 }
             }
             #endregion
             #region ProjectFile
             if (reader.ReadByte() == 0)
             {
-                _projectFile = null;
+                projectFile = null;
             }
             else
             {
-                _projectFile = reader.ReadString();
+                projectFile = reader.ReadString();
             }
             #endregion
             #region TargetNames
             // TargetNames cannot be null as per line 61 in the constructor
-            _targetNames = reader.ReadString();
+            targetNames = reader.ReadString();
             #endregion
             #region Properties
 
             // Check to see if properties was null
             if (reader.ReadByte() == 0)
             {
-                _properties = null;
+                properties = null;
             }
             else
             {
@@ -515,7 +515,7 @@ namespace Microsoft.Build.Framework
                     }
                 }
 
-                _properties = dictionaryList;
+                properties = dictionaryList;
             }
 
             #endregion
@@ -526,18 +526,18 @@ namespace Microsoft.Build.Framework
         [OnDeserializing] // Will happen before the object is deserialized
         private void SetDefaultsBeforeSerialization(StreamingContext sc)
         {
-            _projectId = InvalidProjectId;
+            projectId = InvalidProjectId;
             // Don't want to set the default before deserialization is completed to a new event context because
             // that would most likely be a lot of wasted allocations
-            _parentProjectBuildEventContext = null;
+            parentProjectBuildEventContext = null;
         }
 
         [OnDeserialized]
         private void SetDefaultsAfterSerialization(StreamingContext sc)
         {
-            if (_parentProjectBuildEventContext == null)
+            if (parentProjectBuildEventContext == null)
             {
-                _parentProjectBuildEventContext = new BuildEventContext
+                parentProjectBuildEventContext = new BuildEventContext
                                                 (
                                                     BuildEventContext.InvalidNodeId,
                                                     BuildEventContext.InvalidTargetId,

--- a/src/Framework/TargetFinishedEventArgs.cs
+++ b/src/Framework/TargetFinishedEventArgs.cs
@@ -103,18 +103,18 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp)
         {
-            _targetName = targetName;
-            _succeeded = succeeded;
-            _projectFile = projectFile;
-            _targetFile = targetFile;
-            _targetOutputs = targetOutputs;
+            this.targetName = targetName;
+            this.succeeded = succeeded;
+            this.projectFile = projectFile;
+            this.targetFile = targetFile;
+            this.targetOutputs = targetOutputs;
         }
 
-        private string _projectFile;
-        private string _targetFile;
-        private string _targetName;
-        private bool _succeeded;
-        private IEnumerable _targetOutputs;
+        private string projectFile;
+        private string targetFile;
+        private string targetName;
+        private bool succeeded;
+        private IEnumerable targetOutputs;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -125,39 +125,39 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
             #region TargetFile
-            if (_targetFile == null)
+            if (targetFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_targetFile);
+                writer.Write(targetFile);
             }
             #endregion TargetFile
             #region TargetName
-            if (_targetName == null)
+            if (targetName == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_targetName);
+                writer.Write(targetName);
             }
             #endregion
-            writer.Write(_succeeded);
+            writer.Write(succeeded);
         }
 
         /// <summary>
@@ -171,34 +171,34 @@ namespace Microsoft.Build.Framework
             #region ProjectFile
             if (reader.ReadByte() == 0)
             {
-                _projectFile = null;
+                projectFile = null;
             }
             else
             {
-                _projectFile = reader.ReadString();
+                projectFile = reader.ReadString();
             }
             #endregion
             #region TargetFile
             if (reader.ReadByte() == 0)
             {
-                _targetFile = null;
+                targetFile = null;
             }
             else
             {
-                _targetFile = reader.ReadString();
+                targetFile = reader.ReadString();
             }
             #endregion
             #region TargetName
             if (reader.ReadByte() == 0)
             {
-                _targetName = null;
+                targetName = null;
             }
             else
             {
-                _targetName = reader.ReadString();
+                targetName = reader.ReadString();
             }
             #endregion
-            _succeeded = reader.ReadBoolean();
+            succeeded = reader.ReadBoolean();
         }
         #endregion
 
@@ -209,7 +209,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetName;
+                return targetName;
             }
         }
 
@@ -220,7 +220,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _succeeded;
+                return succeeded;
             }
         }
 
@@ -231,7 +231,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetFile;
+                return targetFile;
             }
         }
 
@@ -253,12 +253,12 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetOutputs;
+                return targetOutputs;
             }
 
             set
             {
-                _targetOutputs = value;
+                targetOutputs = value;
             }
         }
     }

--- a/src/Framework/TargetStartedEventArgs.cs
+++ b/src/Framework/TargetStartedEventArgs.cs
@@ -72,16 +72,16 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp)
         {
-            _targetName = targetName;
-            _projectFile = projectFile;
-            _targetFile = targetFile;
-            _parentTarget = parentTarget;
+            this.targetName = targetName;
+            this.projectFile = projectFile;
+            this.targetFile = targetFile;
+            this.parentTarget = parentTarget;
         }
 
-        private string _targetName;
-        private string _projectFile;
-        private string _targetFile;
-        private string _parentTarget;
+        private string targetName;
+        private string projectFile;
+        private string targetFile;
+        private string parentTarget;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -92,47 +92,47 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
             #region TargetName
-            if (_targetName == null)
+            if (targetName == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_targetName);
+                writer.Write(targetName);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
             #region TargetFile
-            if (_targetFile == null)
+            if (targetFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_targetFile);
+                writer.Write(targetFile);
             }
             #endregion
             #region ParentTarget
-            if (_parentTarget == null)
+            if (parentTarget == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_parentTarget);
+                writer.Write(parentTarget);
             }
             #endregion
         }
@@ -148,31 +148,31 @@ namespace Microsoft.Build.Framework
             #region TargetName
             if (reader.ReadByte() == 0)
             {
-                _targetName = null;
+                targetName = null;
             }
             else
             {
-                _targetName = reader.ReadString();
+                targetName = reader.ReadString();
             }
             #endregion
             #region ProjectFile
             if (reader.ReadByte() == 0)
             {
-                _projectFile = null;
+                projectFile = null;
             }
             else
             {
-                _projectFile = reader.ReadString();
+                projectFile = reader.ReadString();
             }
             #endregion
             #region TargetFile
             if (reader.ReadByte() == 0)
             {
-                _targetFile = null;
+                targetFile = null;
             }
             else
             {
-                _targetFile = reader.ReadString();
+                targetFile = reader.ReadString();
             }
             #endregion
             #region ParentTarget
@@ -180,11 +180,11 @@ namespace Microsoft.Build.Framework
             {
                 if (reader.ReadByte() == 0)
                 {
-                    _parentTarget = null;
+                    parentTarget = null;
                 }
                 else
                 {
-                    _parentTarget = reader.ReadString();
+                    parentTarget = reader.ReadString();
                 }
             }
             #endregion
@@ -198,7 +198,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetName;
+                return targetName;
             }
         }
 
@@ -209,7 +209,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _parentTarget;
+                return parentTarget;
             }
         }
 
@@ -220,7 +220,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
@@ -231,7 +231,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _targetFile;
+                return targetFile;
             }
         }
     }

--- a/src/Framework/TaskFinishedEventArgs.cs
+++ b/src/Framework/TaskFinishedEventArgs.cs
@@ -80,16 +80,16 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp)
         {
-            _taskName = taskName;
-            _taskFile = taskFile;
-            _succeeded = succeeded;
-            _projectFile = projectFile;
+            this.taskName = taskName;
+            this.taskFile = taskFile;
+            this.succeeded = succeeded;
+            this.projectFile = projectFile;
         }
 
-        private string _taskName;
-        private string _projectFile;
-        private string _taskFile;
-        private bool _succeeded;
+        private string taskName;
+        private string projectFile;
+        private string taskFile;
+        private bool succeeded;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -100,39 +100,39 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
             #region TaskName
-            if (_taskName == null)
+            if (taskName == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_taskName);
+                writer.Write(taskName);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
             #region TaskFile
-            if (_taskFile == null)
+            if (taskFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_taskFile);
+                writer.Write(taskFile);
             }
             #endregion
-            writer.Write(_succeeded);
+            writer.Write(succeeded);
         }
 
         /// <summary>
@@ -146,34 +146,34 @@ namespace Microsoft.Build.Framework
             #region TaskName
             if (reader.ReadByte() == 0)
             {
-                _taskName = null;
+                taskName = null;
             }
             else
             {
-                _taskName = reader.ReadString();
+                taskName = reader.ReadString();
             }
             #endregion
             #region ProjectFile
             if (reader.ReadByte() == 0)
             {
-                _projectFile = null;
+                projectFile = null;
             }
             else
             {
-                _projectFile = reader.ReadString();
+                projectFile = reader.ReadString();
             }
             #endregion
             #region TaskFile
             if (reader.ReadByte() == 0)
             {
-                _taskFile = null;
+                taskFile = null;
             }
             else
             {
-                _taskFile = reader.ReadString();
+                taskFile = reader.ReadString();
             }
             #endregion
-            _succeeded = reader.ReadBoolean();
+            succeeded = reader.ReadBoolean();
         }
         #endregion
 
@@ -184,7 +184,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _taskName;
+                return taskName;
             }
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _succeeded;
+                return succeeded;
             }
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
@@ -217,7 +217,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _taskFile;
+                return taskFile;
             }
         }
     }

--- a/src/Framework/TaskStartedEventArgs.cs
+++ b/src/Framework/TaskStartedEventArgs.cs
@@ -75,14 +75,14 @@ namespace Microsoft.Build.Framework
         )
             : base(message, helpKeyword, "MSBuild", eventTimestamp)
         {
-            _taskName = taskName;
-            _projectFile = projectFile;
-            _taskFile = taskFile;
+            this.taskName = taskName;
+            this.projectFile = projectFile;
+            this.taskFile = taskFile;
         }
 
-        private string _taskName;
-        private string _projectFile;
-        private string _taskFile;
+        private string taskName;
+        private string projectFile;
+        private string taskFile;
 
         #region CustomSerializationToStream
         /// <summary>
@@ -93,36 +93,36 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
             #region TaskName
-            if (_taskName == null)
+            if (taskName == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_taskName);
+                writer.Write(taskName);
             }
             #endregion
             #region ProjectFile
-            if (_projectFile == null)
+            if (projectFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_projectFile);
+                writer.Write(projectFile);
             }
             #endregion
             #region TaskFile
-            if (_taskFile == null)
+            if (taskFile == null)
             {
                 writer.Write((byte)0);
             }
             else
             {
                 writer.Write((byte)1);
-                writer.Write(_taskFile);
+                writer.Write(taskFile);
             }
             #endregion
         }
@@ -138,31 +138,31 @@ namespace Microsoft.Build.Framework
             #region TaskName
             if (reader.ReadByte() == 0)
             {
-                _taskName = null;
+                taskName = null;
             }
             else
             {
-                _taskName = reader.ReadString();
+                taskName = reader.ReadString();
             }
             #endregion
             #region ProjectFile
             if (reader.ReadByte() == 0)
             {
-                _projectFile = null;
+                projectFile = null;
             }
             else
             {
-                _projectFile = reader.ReadString();
+                projectFile = reader.ReadString();
             }
             #endregion
             #region TaskFile
             if (reader.ReadByte() == 0)
             {
-                _taskFile = null;
+                taskFile = null;
             }
             else
             {
-                _taskFile = reader.ReadString();
+                taskFile = reader.ReadString();
             }
             #endregion
         }
@@ -175,7 +175,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _taskName;
+                return taskName;
             }
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _projectFile;
+                return projectFile;
             }
         }
 
@@ -197,7 +197,7 @@ namespace Microsoft.Build.Framework
         {
             get
             {
-                return _taskFile;
+                return taskFile;
             }
         }
     }

--- a/src/Framework/UnitTests/EventArgs_Tests.cs
+++ b/src/Framework/UnitTests/EventArgs_Tests.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Verify a whidbey project started event can be deserialized, the whidbey event is stored in a serialized base64 string.
         /// </summary>
-        [Fact(Skip = "Ignored in MSTest")]
-        // Ignore: Type in serialized string targets MSBuild retail public key, will not de-serialize
+        [Fact]
         public void TestDeserialization()
         {
             string base64OldProjectStarted = "AAEAAAD/////AQAAAAAAAAAMAgAAAFxNaWNyb3NvZnQuQnVpbGQuRnJhbWV3b3JrLCBWZXJzaW9uPTIuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49YjAzZjVmN2YxMWQ1MGEzYQUBAAAAMU1pY3Jvc29mdC5CdWlsZC5GcmFtZXdvcmsuUHJvamVjdFN0YXJ0ZWRFdmVudEFyZ3MHAAAAC3Byb2plY3RGaWxlC3RhcmdldE5hbWVzFkJ1aWxkRXZlbnRBcmdzK21lc3NhZ2UaQnVpbGRFdmVudEFyZ3MraGVscEtleXdvcmQZQnVpbGRFdmVudEFyZ3Mrc2VuZGVyTmFtZRhCdWlsZEV2ZW50QXJncyt0aW1lc3RhbXAXQnVpbGRFdmVudEFyZ3MrdGhyZWFkSWQBAQEBAQAADQgCAAAABgMAAAALcHJvamVjdEZpbGUGBAAAAAt0YXJnZXROYW1lcwYFAAAAB21lc3NhZ2UGBgAAAAtoZWxwS2V5d29yZAYHAAAAB01TQnVpbGQBl5vjTYvIiAsAAAAL";

--- a/src/Shared/AssemblyNameComparer.cs
+++ b/src/Shared/AssemblyNameComparer.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Should the comparer consider the retargetable flag when doing comparisons
         /// </summary>
-        private bool _considerRetargetableFlag;
+        private bool considerRetargetableFlag;
 
         /// <summary>
         /// Private construct so there's only one instance.
         /// </summary>
         private AssemblyNameComparer(bool considerRetargetableFlag)
         {
-            _considerRetargetableFlag = considerRetargetableFlag;
+            this.considerRetargetableFlag = considerRetargetableFlag;
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Shared
             AssemblyNameExtension a1 = (AssemblyNameExtension)o1;
             AssemblyNameExtension a2 = (AssemblyNameExtension)o2;
 
-            int result = a1.CompareTo(a2, _considerRetargetableFlag);
+            int result = a1.CompareTo(a2, considerRetargetableFlag);
             return result;
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         public bool Equals(AssemblyNameExtension x, AssemblyNameExtension y)
         {
-            bool result = x.Equals(y, _considerRetargetableFlag);
+            bool result = x.Equals(y, considerRetargetableFlag);
             return result;
         }
 

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -52,16 +52,16 @@ namespace Microsoft.Build.Shared
     [Serializable]
     sealed internal class AssemblyNameExtension
     {
-        private AssemblyName _asAssemblyName = null;
-        private string _asString = null;
-        private bool _isSimpleName = false;
-        private bool _hasProcessorArchitectureInFusionName;
-        private bool _immutable;
+        private AssemblyName asAssemblyName = null;
+        private string asString = null;
+        private bool isSimpleName = false;
+        private bool hasProcessorArchitectureInFusionName;
+        private bool immutable;
 
         /// <summary>
         /// Set of assemblyNameExtensions that THIS assemblyname was remapped from.
         /// </summary>
-        private HashSet<AssemblyNameExtension> _remappedFrom;
+        private HashSet<AssemblyNameExtension> remappedFrom;
 
         static private AssemblyNameExtension s_unnamedAssembly = new AssemblyNameExtension();
 
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Shared
         /// <param name="assemblyName"></param>
         internal AssemblyNameExtension(AssemblyName assemblyName) : this()
         {
-            _asAssemblyName = assemblyName;
+            asAssemblyName = assemblyName;
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Microsoft.Build.Shared
         /// <param name="assemblyName"></param>
         internal AssemblyNameExtension(string assemblyName) : this()
         {
-            _asString = assemblyName;
+            asString = assemblyName;
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.Build.Shared
         /// </param>
         internal AssemblyNameExtension(string assemblyName, bool validate) : this()
         {
-            _asString = assemblyName;
+            asString = assemblyName;
 
             if (validate)
             {
@@ -162,9 +162,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private void InitializeRemappedFrom()
         {
-            if (_remappedFrom == null)
+            if (remappedFrom == null)
             {
-                _remappedFrom = new HashSet<AssemblyNameExtension>(AssemblyNameComparer.GenericComparerConsiderRetargetable);
+                remappedFrom = new HashSet<AssemblyNameExtension>(AssemblyNameComparer.GenericComparerConsiderRetargetable);
             }
         }
 
@@ -173,14 +173,14 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private void CreateAssemblyName()
         {
-            if (_asAssemblyName == null)
+            if (asAssemblyName == null)
             {
-                _asAssemblyName = GetAssemblyNameFromDisplayName(_asString);
+                asAssemblyName = GetAssemblyNameFromDisplayName(asString);
 
-                if (_asAssemblyName != null)
+                if (asAssemblyName != null)
                 {
-                    _hasProcessorArchitectureInFusionName = _asString.IndexOf("ProcessorArchitecture", StringComparison.OrdinalIgnoreCase) != -1;
-                    _isSimpleName = ((Version == null) && (CultureInfo == null) && (GetPublicKeyToken() == null) && (!_hasProcessorArchitectureInFusionName));
+                    hasProcessorArchitectureInFusionName = asString.IndexOf("ProcessorArchitecture", StringComparison.OrdinalIgnoreCase) != -1;
+                    isSimpleName = ((Version == null) && (CultureInfo == null) && (GetPublicKeyToken() == null) && (!hasProcessorArchitectureInFusionName));
                 }
             }
         }
@@ -190,9 +190,9 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private void CreateFullName()
         {
-            if (_asString == null)
+            if (asString == null)
             {
-                _asString = _asAssemblyName.FullName;
+                asString = asAssemblyName.FullName;
             }
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.Build.Shared
             {
                 // Is there a string?
                 CreateAssemblyName();
-                return _asAssemblyName.Name;
+                return asAssemblyName.Name;
             }
         }
 
@@ -217,9 +217,9 @@ namespace Microsoft.Build.Shared
         {
             get
             {
-                if (_asAssemblyName != null)
+                if (asAssemblyName != null)
                 {
-                    return _asAssemblyName.ProcessorArchitecture;
+                    return asAssemblyName.ProcessorArchitecture;
                 }
                 else
                 {
@@ -238,7 +238,7 @@ namespace Microsoft.Build.Shared
             {
                 // Is there a string?
                 CreateAssemblyName();
-                return _asAssemblyName.Version;
+                return asAssemblyName.Version;
             }
         }
 
@@ -251,7 +251,7 @@ namespace Microsoft.Build.Shared
             get
             {
                 CreateAssemblyName();
-                return _isSimpleName;
+                return isSimpleName;
             }
         }
 
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Shared
             get
             {
                 CreateAssemblyName();
-                return _hasProcessorArchitectureInFusionName;
+                return hasProcessorArchitectureInFusionName;
             }
         }
 
@@ -273,14 +273,14 @@ namespace Microsoft.Build.Shared
         /// <param name="version"></param>
         internal void ReplaceVersion(Version version)
         {
-            ErrorUtilities.VerifyThrow(!_immutable, "Object is immutable cannot replace the version");
+            ErrorUtilities.VerifyThrow(!immutable, "Object is immutable cannot replace the version");
             CreateAssemblyName();
-            if (_asAssemblyName.Version != version)
+            if (asAssemblyName.Version != version)
             {
-                _asAssemblyName.Version = version;
+                asAssemblyName.Version = version;
 
                 // String would now be invalid.
-                _asString = null;
+                asString = null;
             }
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.Build.Shared
             {
                 // Is there a string?
                 CreateAssemblyName();
-                return _asAssemblyName.CultureInfo;
+                return asAssemblyName.CultureInfo;
             }
         }
 
@@ -309,7 +309,7 @@ namespace Microsoft.Build.Shared
                 // Is there a string?
                 CreateAssemblyName();
                 // Cannot use the HasFlag method on the Flags enum because this class needs to work with 3.5
-                return ((_asAssemblyName.Flags & AssemblyNameFlags.Retargetable) == AssemblyNameFlags.Retargetable);
+                return ((asAssemblyName.Flags & AssemblyNameFlags.Retargetable) == AssemblyNameFlags.Retargetable);
             }
         }
 
@@ -321,7 +321,7 @@ namespace Microsoft.Build.Shared
             get
             {
                 InitializeRemappedFrom();
-                return _remappedFrom;
+                return remappedFrom;
             }
         }
 
@@ -332,7 +332,7 @@ namespace Microsoft.Build.Shared
         {
             ErrorUtilities.VerifyThrow(extensionToAdd.Immutable, "ExtensionToAdd is not immutable");
             InitializeRemappedFrom();
-            _remappedFrom.Add(extensionToAdd);
+            remappedFrom.Add(extensionToAdd);
         }
 
         /// <summary>
@@ -345,7 +345,7 @@ namespace Microsoft.Build.Shared
             {
                 // Is there a string?
                 CreateAssemblyName();
-                return _asAssemblyName;
+                return asAssemblyName;
             }
         }
 
@@ -359,7 +359,7 @@ namespace Microsoft.Build.Shared
             {
                 // Is there a string?
                 CreateFullName();
-                return _asString;
+                return asString;
             }
         }
 
@@ -371,7 +371,7 @@ namespace Microsoft.Build.Shared
         {
             // Is there a string?
             CreateAssemblyName();
-            return _asAssemblyName.GetPublicKeyToken();
+            return asAssemblyName.GetPublicKeyToken();
         }
 
 
@@ -460,15 +460,15 @@ namespace Microsoft.Build.Shared
             int result = CompareBaseNameToImpl(that);
 #if DEBUG
             // Now, compare to the real value to make sure the result was accurate.
-            AssemblyName a1 = _asAssemblyName;
-            AssemblyName a2 = that._asAssemblyName;
+            AssemblyName a1 = asAssemblyName;
+            AssemblyName a2 = that.asAssemblyName;
             if (a1 == null)
             {
-                a1 = new AssemblyName(_asString);
+                a1 = new AssemblyName(asString);
             }
             if (a2 == null)
             {
-                a2 = new AssemblyName(that._asString);
+                a2 = new AssemblyName(that.asString);
             }
 
             int baselineResult = String.Compare(a1.Name, a2.Name, StringComparison.OrdinalIgnoreCase);
@@ -492,23 +492,23 @@ namespace Microsoft.Build.Shared
                 return 0;
             }
             // Do both have assembly names?
-            if (_asAssemblyName != null && that._asAssemblyName != null)
+            if (asAssemblyName != null && that.asAssemblyName != null)
             {
                 // Pointer compare.
-                if (_asAssemblyName == that._asAssemblyName)
+                if (asAssemblyName == that.asAssemblyName)
                 {
                     return 0;
                 }
 
                 // Base name compare.
-                return String.Compare(_asAssemblyName.Name, that._asAssemblyName.Name, StringComparison.OrdinalIgnoreCase);
+                return String.Compare(asAssemblyName.Name, that.asAssemblyName.Name, StringComparison.OrdinalIgnoreCase);
             }
 
             // Do both have strings?
-            if (_asString != null && that._asString != null)
+            if (asString != null && that.asString != null)
             {
                 // If we have two random-case strings, then we need to compare case sensitively.
-                return CompareBaseNamesStringWise(_asString, that._asString);
+                return CompareBaseNamesStringWise(asString, that.asString);
             }
 
             // Fall back to comparing by name. This is the slow path.
@@ -560,18 +560,18 @@ namespace Microsoft.Build.Shared
         {
             AssemblyNameExtension newExtension = new AssemblyNameExtension();
 
-            if (_asAssemblyName != null)
+            if (asAssemblyName != null)
             {
-                newExtension._asAssemblyName = (AssemblyName)_asAssemblyName.Clone();
+                newExtension.asAssemblyName = (AssemblyName)asAssemblyName.Clone();
             }
 
-            newExtension._asString = _asString;
-            newExtension._isSimpleName = _isSimpleName;
-            newExtension._hasProcessorArchitectureInFusionName = _hasProcessorArchitectureInFusionName;
-            newExtension._remappedFrom = _remappedFrom;
+            newExtension.asString = asString;
+            newExtension.isSimpleName = isSimpleName;
+            newExtension.hasProcessorArchitectureInFusionName = hasProcessorArchitectureInFusionName;
+            newExtension.remappedFrom = remappedFrom;
 
             // We are cloning so we can now party on the object even if the parent was immutable
-            newExtension._immutable = false;
+            newExtension.immutable = false;
 
             return newExtension;
         }
@@ -594,7 +594,7 @@ namespace Microsoft.Build.Shared
         {
             get
             {
-                return _immutable;
+                return immutable;
             }
         }
 
@@ -603,7 +603,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal void MarkImmutable()
         {
-            _immutable = true;
+            immutable = true;
         }
 
         /// <summary>
@@ -654,19 +654,19 @@ namespace Microsoft.Build.Shared
             }
 
             // Do both have assembly names?
-            if (_asAssemblyName != null && that._asAssemblyName != null)
+            if (asAssemblyName != null && that.asAssemblyName != null)
             {
                 // Pointer compare.
-                if (Object.ReferenceEquals(_asAssemblyName, that._asAssemblyName))
+                if (Object.ReferenceEquals(asAssemblyName, that.asAssemblyName))
                 {
                     return true;
                 }
             }
 
             // Do both have strings that equal each-other?
-            if (_asString != null && that._asString != null)
+            if (asString != null && that.asString != null)
             {
-                if (_asString == that._asString)
+                if (asString == that.asString)
                 {
                     return true;
                 }
@@ -776,7 +776,7 @@ namespace Microsoft.Build.Shared
         {
             get
             {
-                return _asAssemblyName == null && _asString == null;
+                return asAssemblyName == null && asString == null;
             }
         }
 
@@ -819,7 +819,7 @@ namespace Microsoft.Build.Shared
         override public string ToString()
         {
             CreateFullName();
-            return _asString;
+            return asString;
         }
 
         /// <summary>
@@ -874,10 +874,10 @@ namespace Microsoft.Build.Shared
             }
 
             // Do both have assembly names?
-            if (_asAssemblyName != null && that._asAssemblyName != null)
+            if (asAssemblyName != null && that.asAssemblyName != null)
             {
                 // Pointer compare.
-                if (Object.ReferenceEquals(_asAssemblyName, that._asAssemblyName))
+                if (Object.ReferenceEquals(asAssemblyName, that.asAssemblyName))
                 {
                     return true;
                 }

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// The equality comparer to use when the dictionary is created.
         /// </summary>
-        private readonly IEqualityComparer<K> _keyComparer;
+        private readonly IEqualityComparer<K> keyComparer;
 
         /// <summary>
         /// The default capacity.
         /// </summary>
-        private readonly int _capacity;
+        private readonly int capacity;
 
         /// <summary>
         /// A special single dummy instance that always appears empty.
@@ -67,7 +67,7 @@ namespace Microsoft.Build.Collections
         /// The backing dictionary.
         /// Lazily created.
         /// </summary>
-        private CopyOnWriteBackingDictionary<K, V> _backing;
+        private CopyOnWriteBackingDictionary<K, V> backing;
 
         /// <summary>
         /// Constructor. Consider supplying a comparer instead.
@@ -97,8 +97,8 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal CopyOnWriteDictionary(int capacity, IEqualityComparer<K> keyComparer)
         {
-            _capacity = capacity;
-            _keyComparer = keyComparer;
+            this.capacity = capacity;
+            this.keyComparer = keyComparer;
         }
 
         /// <summary>
@@ -115,13 +115,13 @@ namespace Microsoft.Build.Collections
         /// </summary>
         private CopyOnWriteDictionary(CopyOnWriteDictionary<K, V> that)
         {
-            _keyComparer = that._keyComparer;
-            _backing = that._backing;
-            if (_backing != null)
+            keyComparer = that.keyComparer;
+            backing = that.backing;
+            if (backing != null)
             {
-                lock (((ICollection)_backing).SyncRoot)
+                lock (((ICollection)backing).SyncRoot)
                 {
-                    _backing.AddRef();
+                    backing.AddRef();
                 }
             }
         }
@@ -234,7 +234,7 @@ namespace Microsoft.Build.Collections
             {
                 if (Object.ReferenceEquals(this, Dummy))
                 {
-                    ErrorUtilities.VerifyThrow(_backing == null || _backing.Count == 0, "count"); // check count without recursion
+                    ErrorUtilities.VerifyThrow(backing == null || backing.Count == 0, "count"); // check count without recursion
                     return true;
                 }
 
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal IEqualityComparer<K> Comparer
         {
-            get { return _keyComparer; }
+            get { return keyComparer; }
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                ErrorUtilities.VerifyThrow(!IsDummy || _backing == null || _backing.Count == 0, "count"); // check count without recursion
+                ErrorUtilities.VerifyThrow(!IsDummy || backing == null || backing.Count == 0, "count"); // check count without recursion
 #if DEBUG
                 if (s_forceWrite)
                 {
@@ -267,12 +267,12 @@ namespace Microsoft.Build.Collections
                     }
                 }
 #endif
-                if (_backing == null)
+                if (backing == null)
                 {
                     return CopyOnWriteBackingDictionary<K, V>.ReadOnlyEmptyInstance;
                 }
 
-                return _backing;
+                return backing;
             }
         }
 
@@ -285,19 +285,19 @@ namespace Microsoft.Build.Collections
             {
                 ErrorUtilities.VerifyThrow(!IsDummy, "dummy");
 
-                if (_backing == null)
+                if (backing == null)
                 {
-                    _backing = new CopyOnWriteBackingDictionary<K, V>(_capacity, _keyComparer);
+                    backing = new CopyOnWriteBackingDictionary<K, V>(capacity, keyComparer);
                 }
                 else
                 {
-                    lock (((ICollection)_backing).SyncRoot)
+                    lock (((ICollection)backing).SyncRoot)
                     {
-                        _backing = _backing.CloneForWriteIfNecessary();
+                        backing = backing.CloneForWriteIfNecessary();
                     }
                 }
 
-                return _backing;
+                return backing;
             }
         }
 
@@ -537,7 +537,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal bool HasSameBacking(CopyOnWriteDictionary<K, V> other)
         {
-            return Object.ReferenceEquals(other._backing, _backing);
+            return Object.ReferenceEquals(other.backing, backing);
         }
 
         /// <summary>

--- a/src/Shared/HybridDictionary.cs
+++ b/src/Shared/HybridDictionary.cs
@@ -34,12 +34,12 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// The dictionary, list, or pair used for a store
         /// </summary>
-        private Object _store;
+        private Object store;
 
         /// <summary>
         /// The comparer used to look up an item.
         /// </summary>
-        private IEqualityComparer<TKey> _comparer;
+        private IEqualityComparer<TKey> comparer;
 
         /// <summary>
         /// Static constructor
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Collections
         public HybridDictionary(IEqualityComparer<TKey> comparer)
             : this()
         {
-            _comparer = comparer;
+            this.comparer = comparer;
         }
 
         /// <summary>
@@ -87,19 +87,19 @@ namespace Microsoft.Build.Collections
         /// <param name="comparer">The comparer to use.</param>
         public HybridDictionary(int capacity, IEqualityComparer<TKey> comparer)
         {
-            _comparer = comparer;
-            if (_comparer == null)
+            this.comparer = comparer;
+            if (this.comparer == null)
             {
-                _comparer = EqualityComparer<TKey>.Default;
+                this.comparer = EqualityComparer<TKey>.Default;
             }
 
             if (capacity > MaxListSize)
             {
-                _store = new Dictionary<TKey, TValue>(capacity, comparer);
+                store = new Dictionary<TKey, TValue>(capacity, comparer);
             }
             else if (capacity > 1)
             {
-                _store = new List<KeyValuePair<TKey, TValue>>(capacity);
+                store = new List<KeyValuePair<TKey, TValue>>(capacity);
             }
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public IEqualityComparer<TKey> Comparer
         {
-            get { return _comparer; }
+            get { return comparer; }
         }
 
         /// <summary>
@@ -138,17 +138,17 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                if (_store == null)
+                if (store == null)
                 {
                     return ReadOnlyEmptyCollection<TKey>.Instance;
                 }
 
-                if (_store is KeyValuePair<TKey, TValue>)
+                if (store is KeyValuePair<TKey, TValue>)
                 {
-                    return new TKey[] { ((KeyValuePair<TKey, TValue>)_store).Key };
+                    return new TKey[] { ((KeyValuePair<TKey, TValue>)store).Key };
                 }
 
-                var list = _store as List<KeyValuePair<TKey, TValue>>;
+                var list = store as List<KeyValuePair<TKey, TValue>>;
                 if (list != null)
                 {
                     TKey[] keys = new TKey[list.Count];
@@ -160,7 +160,7 @@ namespace Microsoft.Build.Collections
                     return keys;
                 }
 
-                var dictionary = _store as Dictionary<TKey, TValue>;
+                var dictionary = store as Dictionary<TKey, TValue>;
                 if (dictionary != null)
                 {
                     return dictionary.Keys;
@@ -178,17 +178,17 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                if (_store == null)
+                if (store == null)
                 {
                     return ReadOnlyEmptyCollection<TValue>.Instance;
                 }
 
-                if (_store is KeyValuePair<TKey, TValue>) // Can't use 'as' for structs
+                if (store is KeyValuePair<TKey, TValue>) // Can't use 'as' for structs
                 {
-                    return new TValue[] { ((KeyValuePair<TKey, TValue>)_store).Value };
+                    return new TValue[] { ((KeyValuePair<TKey, TValue>)store).Value };
                 }
 
-                var list = _store as List<KeyValuePair<TKey, TValue>>;
+                var list = store as List<KeyValuePair<TKey, TValue>>;
                 if (list != null)
                 {
                     TValue[] values = new TValue[list.Count];
@@ -200,7 +200,7 @@ namespace Microsoft.Build.Collections
                     return values;
                 }
 
-                var dictionary = _store as Dictionary<TKey, TValue>;
+                var dictionary = store as Dictionary<TKey, TValue>;
                 if (dictionary != null)
                 {
                     return dictionary.Values;
@@ -218,17 +218,17 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                if (_store == null)
+                if (store == null)
                 {
                     return 0;
                 }
 
-                if (_store is KeyValuePair<TKey, TValue>)
+                if (store is KeyValuePair<TKey, TValue>)
                 {
                     return 1;
                 }
 
-                return ((ICollection)_store).Count;
+                return ((ICollection)store).Count;
             }
         }
 
@@ -304,33 +304,33 @@ namespace Microsoft.Build.Collections
 
             set
             {
-                if (_store == null)
+                if (store == null)
                 {
-                    _store = new KeyValuePair<TKey, TValue>(key, value);
+                    store = new KeyValuePair<TKey, TValue>(key, value);
                     return;
                 }
 
-                if (_store is KeyValuePair<TKey, TValue>)
+                if (store is KeyValuePair<TKey, TValue>)
                 {
-                    var single = ((KeyValuePair<TKey, TValue>)_store);
-                    if (_comparer.Equals(single.Key, key))
+                    var single = ((KeyValuePair<TKey, TValue>)store);
+                    if (comparer.Equals(single.Key, key))
                     {
-                        _store = new KeyValuePair<TKey, TValue>(key, value);
+                        store = new KeyValuePair<TKey, TValue>(key, value);
                         return;
                     }
 
-                    _store = new List<KeyValuePair<TKey, TValue>> { { single }, { new KeyValuePair<TKey, TValue>(key, value) } };
+                    store = new List<KeyValuePair<TKey, TValue>> { { single }, { new KeyValuePair<TKey, TValue>(key, value) } };
                     return;
                 }
 
-                var list = _store as List<KeyValuePair<TKey, TValue>>;
+                var list = store as List<KeyValuePair<TKey, TValue>>;
                 if (list != null)
                 {
                     AddToOrUpdateList(list, key, value, throwIfPresent: false);
                     return;
                 }
 
-                var dictionary = _store as Dictionary<TKey, TValue>;
+                var dictionary = store as Dictionary<TKey, TValue>;
                 if (dictionary != null)
                 {
                     dictionary[key] = value;
@@ -357,32 +357,32 @@ namespace Microsoft.Build.Collections
         {
             ErrorUtilities.VerifyThrowArgumentNull(key, "key");
 
-            if (_store == null)
+            if (store == null)
             {
-                _store = new KeyValuePair<TKey, TValue>(key, value);
+                store = new KeyValuePair<TKey, TValue>(key, value);
                 return;
             }
 
-            if (_store is KeyValuePair<TKey, TValue>)
+            if (store is KeyValuePair<TKey, TValue>)
             {
-                var single = ((KeyValuePair<TKey, TValue>)_store);
-                if (_comparer.Equals(single.Key, key))
+                var single = ((KeyValuePair<TKey, TValue>)store);
+                if (comparer.Equals(single.Key, key))
                 {
                     throw new ArgumentException("A value with the same key is already in the collection.");
                 }
 
-                _store = new List<KeyValuePair<TKey, TValue>> { { single }, { new KeyValuePair<TKey, TValue>(key, value) } };
+                store = new List<KeyValuePair<TKey, TValue>> { { single }, { new KeyValuePair<TKey, TValue>(key, value) } };
                 return;
             }
 
-            var list = _store as List<KeyValuePair<TKey, TValue>>;
+            var list = store as List<KeyValuePair<TKey, TValue>>;
             if (list != null)
             {
                 AddToOrUpdateList(list, key, value, throwIfPresent: true);
                 return;
             }
 
-            var dictionary = _store as Dictionary<TKey, TValue>;
+            var dictionary = store as Dictionary<TKey, TValue>;
             if (dictionary != null)
             {
                 dictionary.Add(key, value);
@@ -408,28 +408,28 @@ namespace Microsoft.Build.Collections
         {
             ErrorUtilities.VerifyThrowArgumentNull(key, "key");
 
-            if (_store == null)
+            if (store == null)
             {
                 return false;
             }
 
-            if (_store is KeyValuePair<TKey, TValue>)
+            if (store is KeyValuePair<TKey, TValue>)
             {
-                if (_comparer.Equals(((KeyValuePair<TKey, TValue>)_store).Key, key))
+                if (comparer.Equals(((KeyValuePair<TKey, TValue>)store).Key, key))
                 {
-                    _store = null;
+                    store = null;
                     return true;
                 }
 
                 return false;
             }
 
-            var list = _store as List<KeyValuePair<TKey, TValue>>;
+            var list = store as List<KeyValuePair<TKey, TValue>>;
             if (list != null)
             {
                 for (int i = 0; i < list.Count; i++)
                 {
-                    if (_comparer.Equals(list[i].Key, key))
+                    if (comparer.Equals(list[i].Key, key))
                     {
                         list.RemoveAt(i); // POLICY: copy into new shorter list
                         return true;
@@ -439,7 +439,7 @@ namespace Microsoft.Build.Collections
                 return false;
             }
 
-            var dictionary = _store as Dictionary<TKey, TValue>;
+            var dictionary = store as Dictionary<TKey, TValue>;
             if (dictionary != null)
             {
                 return dictionary.Remove(key);
@@ -456,15 +456,15 @@ namespace Microsoft.Build.Collections
         {
             value = null;
 
-            if (_store == null)
+            if (store == null)
             {
                 return false;
             }
 
-            if (_store is KeyValuePair<TKey, TValue>)
+            if (store is KeyValuePair<TKey, TValue>)
             {
-                var single = ((KeyValuePair<TKey, TValue>)_store);
-                if (_comparer.Equals(single.Key, key))
+                var single = ((KeyValuePair<TKey, TValue>)store);
+                if (comparer.Equals(single.Key, key))
                 {
                     value = single.Value;
                     return true;
@@ -475,12 +475,12 @@ namespace Microsoft.Build.Collections
                 }
             }
 
-            var list = _store as List<KeyValuePair<TKey, TValue>>;
+            var list = store as List<KeyValuePair<TKey, TValue>>;
             if (list != null)
             {
                 foreach (var entry in list)
                 {
-                    if (_comparer.Equals(entry.Key, key))
+                    if (comparer.Equals(entry.Key, key))
                     {
                         value = entry.Value;
                         return true;
@@ -490,7 +490,7 @@ namespace Microsoft.Build.Collections
                 return false;
             }
 
-            var dictionary = _store as Dictionary<TKey, TValue>;
+            var dictionary = store as Dictionary<TKey, TValue>;
             if (dictionary != null)
             {
                 return dictionary.TryGetValue(key, out value);
@@ -513,7 +513,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Clear()
         {
-            _store = null;
+            store = null;
         }
 
         /// <summary>
@@ -551,23 +551,23 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
         {
-            if (_store == null)
+            if (store == null)
             {
                 return ReadOnlyEmptyCollection<KeyValuePair<TKey, TValue>>.Instance.GetEnumerator();
             }
 
-            if (_store is KeyValuePair<TKey, TValue>)
+            if (store is KeyValuePair<TKey, TValue>)
             {
-                return new SingleEnumerator((KeyValuePair<TKey, TValue>)_store);
+                return new SingleEnumerator((KeyValuePair<TKey, TValue>)store);
             }
 
-            var list = _store as List<KeyValuePair<TKey, TValue>>;
+            var list = store as List<KeyValuePair<TKey, TValue>>;
             if (list != null)
             {
                 return list.GetEnumerator();
             }
 
-            var dictionary = _store as Dictionary<TKey, TValue>;
+            var dictionary = store as Dictionary<TKey, TValue>;
             if (dictionary != null)
             {
                 return dictionary.GetEnumerator();
@@ -618,23 +618,23 @@ namespace Microsoft.Build.Collections
         /// </summary>
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
-            if (_store == null)
+            if (store == null)
             {
                 return ((IDictionary)(ReadOnlyEmptyDictionary<TKey, TValue>.Instance)).GetEnumerator();
             }
 
-            if (_store is KeyValuePair<TKey, TValue>)
+            if (store is KeyValuePair<TKey, TValue>)
             {
-                return new SingleDictionaryEntryEnumerator(new DictionaryEntry(((KeyValuePair<TKey, TValue>)_store).Key, ((KeyValuePair<TKey, TValue>)_store).Value));
+                return new SingleDictionaryEntryEnumerator(new DictionaryEntry(((KeyValuePair<TKey, TValue>)store).Key, ((KeyValuePair<TKey, TValue>)store).Value));
             }
 
-            var list = _store as List<KeyValuePair<TKey, TValue>>;
+            var list = store as List<KeyValuePair<TKey, TValue>>;
             if (list != null)
             {
                 return new ListDictionaryEntryEnumerator<TKey, TValue>(list);
             }
 
-            var dictionary = _store as IDictionary;
+            var dictionary = store as IDictionary;
             if (dictionary != null)
             {
                 return dictionary.GetEnumerator();
@@ -661,7 +661,7 @@ namespace Microsoft.Build.Collections
             {
                 for (int i = 0; i < list.Count; i++)
                 {
-                    if (_comparer.Equals(list[i].Key, key))
+                    if (comparer.Equals(list[i].Key, key))
                     {
                         if (throwIfPresent)
                         {
@@ -677,7 +677,7 @@ namespace Microsoft.Build.Collections
             }
             else
             {
-                var newDictionary = new Dictionary<TKey, TValue>(list.Count + 1, _comparer); // POLICY: Don't aggressively encourage extra capacity
+                var newDictionary = new Dictionary<TKey, TValue>(list.Count + 1, comparer); // POLICY: Don't aggressively encourage extra capacity
                 foreach (KeyValuePair<TKey, TValue> entry in list)
                 {
                     newDictionary.Add(entry.Key, entry.Value);
@@ -692,7 +692,7 @@ namespace Microsoft.Build.Collections
                     newDictionary[key] = value;
                 }
 
-                _store = newDictionary;
+                store = newDictionary;
             }
         }
 
@@ -704,20 +704,20 @@ namespace Microsoft.Build.Collections
             /// <summary>
             /// The single value.
             /// </summary>
-            private KeyValuePair<TKey, TValue> _value;
+            private KeyValuePair<TKey, TValue> value;
 
             /// <summary>
             /// Flag indicating when we are at the end of the enumeration.
             /// </summary>
-            private bool _enumerationComplete;
+            private bool enumerationComplete;
 
             /// <summary>
             /// Constructor.
             /// </summary>
             public SingleEnumerator(KeyValuePair<TKey, TValue> value)
             {
-                _value = value;
-                _enumerationComplete = false;
+                this.value = value;
+                enumerationComplete = false;
             }
 
             /// <summary>
@@ -727,9 +727,9 @@ namespace Microsoft.Build.Collections
             {
                 get
                 {
-                    if (_enumerationComplete)
+                    if (enumerationComplete)
                     {
-                        return _value;
+                        return value;
                     }
 
                     throw new InvalidOperationException("Past end of enumeration");
@@ -756,9 +756,9 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public bool MoveNext()
             {
-                if (!_enumerationComplete)
+                if (!enumerationComplete)
                 {
-                    _enumerationComplete = true;
+                    enumerationComplete = true;
                     return true;
                 }
 
@@ -770,7 +770,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public void Reset()
             {
-                _enumerationComplete = false;
+                enumerationComplete = false;
             }
         }
 
@@ -786,20 +786,20 @@ namespace Microsoft.Build.Collections
             /// <summary>
             /// The single value.
             /// </summary>
-            private DictionaryEntry _value;
+            private DictionaryEntry value;
 
             /// <summary>
             /// Flag indicating when we are at the end of the enumeration.
             /// </summary>
-            private bool _enumerationComplete;
+            private bool enumerationComplete;
 
             /// <summary>
             /// Constructor.
             /// </summary>
             public SingleDictionaryEntryEnumerator(DictionaryEntry value)
             {
-                _value = value;
-                _enumerationComplete = false;
+                this.value = value;
+                enumerationComplete = false;
             }
 
             /// <summary>
@@ -833,9 +833,9 @@ namespace Microsoft.Build.Collections
             {
                 get
                 {
-                    if (_enumerationComplete)
+                    if (enumerationComplete)
                     {
-                        return _value;
+                        return value;
                     }
 
                     throw new InvalidOperationException("Past end of enumeration");
@@ -854,9 +854,9 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public bool MoveNext()
             {
-                if (!_enumerationComplete)
+                if (!enumerationComplete)
                 {
-                    _enumerationComplete = true;
+                    enumerationComplete = true;
                     return true;
                 }
 
@@ -868,7 +868,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public void Reset()
             {
-                _enumerationComplete = false;
+                enumerationComplete = false;
             }
         }
 
@@ -882,14 +882,14 @@ namespace Microsoft.Build.Collections
             /// <summary>
             /// The value.
             /// </summary>
-            private IEnumerator<KeyValuePair<KK, VV>> _enumerator;
+            private IEnumerator<KeyValuePair<KK, VV>> enumerator;
 
             /// <summary>
             /// Constructor.
             /// </summary>
             public ListDictionaryEntryEnumerator(List<KeyValuePair<KK, VV>> list)
             {
-                _enumerator = list.GetEnumerator();
+                enumerator = list.GetEnumerator();
             }
 
             /// <summary>
@@ -897,7 +897,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public object Key
             {
-                get { return _enumerator.Current.Key; }
+                get { return enumerator.Current.Key; }
             }
 
             /// <summary>
@@ -905,7 +905,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public object Value
             {
-                get { return _enumerator.Current.Value; }
+                get { return enumerator.Current.Value; }
             }
 
             /// <summary>
@@ -921,7 +921,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public DictionaryEntry Entry
             {
-                get { return new DictionaryEntry(_enumerator.Current.Key, _enumerator.Current.Value); }
+                get { return new DictionaryEntry(enumerator.Current.Key, enumerator.Current.Value); }
             }
 
             /// <summary>
@@ -936,7 +936,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public bool MoveNext()
             {
-                return _enumerator.MoveNext();
+                return enumerator.MoveNext();
             }
 
             /// <summary>
@@ -944,7 +944,7 @@ namespace Microsoft.Build.Collections
             /// </summary>
             public void Reset()
             {
-                _enumerator.Reset();
+                enumerator.Reset();
             }
         }
     }

--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -48,29 +48,29 @@ namespace Microsoft.Build.Collections
         /// This is necessary to prevent, e.g., someone from reading the comparer (through GetHashCode when setting 
         /// a property, for example) at the same time that someone else is writing to it. 
         /// </summary>
-        private Object _lockObject = new Object();
+        private Object lockObject = new Object();
 
         /// <summary>
         /// String to be constrained. 
         /// If null, comparer is unconstrained.
         /// If empty string, comparer is unconstrained and immutable.
         /// </summary>
-        private string _constraintString;
+        private string constraintString;
 
         /// <summary>
         /// Start of constraint
         /// </summary>
-        private int _startIndex;
+        private int startIndex;
 
         /// <summary>
         /// End of constraint
         /// </summary>
-        private int _endIndex;
+        private int endIndex;
 
         /// <summary>
         /// True if the comparer is immutable; false otherwise.
         /// </summary>
-        private bool _immutable;
+        private bool immutable;
 
         /// <summary>
         /// We need a static constructor to retrieve the running ProcessorArchitecture that way we can
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         private MSBuildNameIgnoreCaseComparer(bool immutable)
         {
-            _immutable = immutable;
+            this.immutable = immutable;
         }
 
         /// <summary>
@@ -176,7 +176,7 @@ namespace Microsoft.Build.Collections
         public T GetValueWithConstraints<T>(IDictionary<string, T> dictionary, string key, int startIndex, int endIndex)
             where T : class
         {
-            if (_immutable)
+            if (immutable)
             {
                 ErrorUtilities.ThrowInternalError("immutable");
             }
@@ -200,11 +200,11 @@ namespace Microsoft.Build.Collections
             }
 
             T returnValue;
-            lock (_lockObject)
+            lock (lockObject)
             {
-                _constraintString = key;
-                _startIndex = startIndex;
-                _endIndex = endIndex;
+                constraintString = key;
+                this.startIndex = startIndex;
+                this.endIndex = endIndex;
 
                 try
                 {
@@ -213,9 +213,9 @@ namespace Microsoft.Build.Collections
                 finally
                 {
                     // Make sure we always reset the constraint
-                    _constraintString = null;
-                    _startIndex = 0;
-                    _endIndex = 0;
+                    constraintString = null;
+                    this.startIndex = 0;
+                    this.endIndex = 0;
                 }
             }
 
@@ -258,7 +258,7 @@ namespace Microsoft.Build.Collections
             int start;
             int lengthToCompare;
 
-            if (_immutable)
+            if (immutable)
             {
                 // by definition we don't have a constraint
                 if (Object.ReferenceEquals(x, y))
@@ -273,12 +273,12 @@ namespace Microsoft.Build.Collections
             }
             else
             {
-                lock (_lockObject)
+                lock (lockObject)
                 {
-                    if (_constraintString != null)
+                    if (constraintString != null)
                     {
-                        bool constraintInX = Object.ReferenceEquals(x, _constraintString);
-                        bool constraintInY = Object.ReferenceEquals(y, _constraintString);
+                        bool constraintInX = Object.ReferenceEquals(x, constraintString);
+                        bool constraintInY = Object.ReferenceEquals(y, constraintString);
 
                         if (!constraintInX && !constraintInY)
                         {
@@ -289,8 +289,8 @@ namespace Microsoft.Build.Collections
                         compareToString = constraintInX ? y : x;
                         constrainedString = constraintInY ? y : x;
 
-                        start = _startIndex;
-                        lengthToCompare = _endIndex - _startIndex + 1;
+                        start = startIndex;
+                        lengthToCompare = endIndex - startIndex + 1;
                     }
                     else
                     {
@@ -337,14 +337,14 @@ namespace Microsoft.Build.Collections
             int start = 0;
             int length = obj.Length;
 
-            if (!_immutable)
+            if (!immutable)
             {
-                lock (_lockObject)
+                lock (lockObject)
                 {
-                    if (_constraintString != null && Object.ReferenceEquals(obj, _constraintString))
+                    if (constraintString != null && Object.ReferenceEquals(obj, constraintString))
                     {
-                        start = _startIndex;
-                        length = _endIndex - _startIndex + 1;
+                        start = startIndex;
+                        length = endIndex - startIndex + 1;
                     }
                 }
             }
@@ -411,7 +411,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal void SetConstraintsForUnitTestingOnly(string constraintString, int startIndex, int endIndex)
         {
-            if (_immutable)
+            if (immutable)
             {
                 ErrorUtilities.ThrowInternalError("immutable");
             }
@@ -426,11 +426,11 @@ namespace Microsoft.Build.Collections
                 ErrorUtilities.ThrowInternalError("Invalid end index '{0}' {1} {2}", constraintString, startIndex, endIndex);
             }
 
-            lock (_lockObject)
+            lock (lockObject)
             {
-                _constraintString = constraintString;
-                _startIndex = startIndex;
-                _endIndex = endIndex;
+                this.constraintString = constraintString;
+                this.startIndex = startIndex;
+                this.endIndex = endIndex;
             }
         }
 
@@ -439,16 +439,16 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal void RemoveConstraintsForUnitTestingOnly()
         {
-            if (_immutable)
+            if (immutable)
             {
                 ErrorUtilities.ThrowInternalError("immutable");
             }
 
-            lock (_lockObject)
+            lock (lockObject)
             {
-                _constraintString = null;
-                _startIndex = 0;
-                _endIndex = 0;
+                constraintString = null;
+                startIndex = 0;
+                endIndex = 0;
             }
         }
     }

--- a/src/XMakeBuildEngine/ElementLocation/ElementLocation.cs
+++ b/src/XMakeBuildEngine/ElementLocation/ElementLocation.cs
@@ -238,17 +238,17 @@ namespace Microsoft.Build.Construction
             /// <summary>
             /// The source file.
             /// </summary>
-            private string _file;
+            private string file;
 
             /// <summary>
             /// The source line.
             /// </summary>
-            private int _line;
+            private int line;
 
             /// <summary>
             /// The source column.
             /// </summary>
-            private int _column;
+            private int column;
 
             /// <summary>
             /// Constructor for the case where we have most or all information.
@@ -260,9 +260,9 @@ namespace Microsoft.Build.Construction
                 ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(file, "file");
                 ErrorUtilities.VerifyThrow(line > -1 && column > -1, "Use zero for unknown");
 
-                _file = file ?? String.Empty;
-                _line = line;
-                _column = column;
+                this.file = file ?? String.Empty;
+                this.line = line;
+                this.column = column;
             }
 
             /// <summary>
@@ -274,7 +274,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override string File
             {
-                get { return _file; }
+                get { return file; }
             }
 
             /// <summary>
@@ -285,7 +285,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override int Line
             {
-                get { return _line; }
+                get { return line; }
             }
 
             /// <summary>
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override int Column
             {
-                get { return _column; }
+                get { return column; }
             }
         }
 
@@ -314,17 +314,17 @@ namespace Microsoft.Build.Construction
             /// <summary>
             /// The source file.
             /// </summary>
-            private string _file;
+            private string file;
 
             /// <summary>
             /// The source line.
             /// </summary>
-            private ushort _line;
+            private ushort line;
 
             /// <summary>
             /// The source column.
             /// </summary>
-            private ushort _column;
+            private ushort column;
 
             /// <summary>
             /// Constructor for the case where we have most or all information.
@@ -337,9 +337,9 @@ namespace Microsoft.Build.Construction
                 ErrorUtilities.VerifyThrow(line > -1 && column > -1, "Use zero for unknown");
                 ErrorUtilities.VerifyThrow(line <= 65535 && column <= 65535, "Use ElementLocation instead");
 
-                _file = file ?? String.Empty;
-                _line = Convert.ToUInt16(line);
-                _column = Convert.ToUInt16(column);
+                this.file = file ?? String.Empty;
+                this.line = Convert.ToUInt16(line);
+                this.column = Convert.ToUInt16(column);
             }
 
             /// <summary>
@@ -351,7 +351,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override string File
             {
-                get { return _file; }
+                get { return file; }
             }
 
             /// <summary>
@@ -362,7 +362,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override int Line
             {
-                get { return (int)_line; }
+                get { return (int)line; }
             }
 
             /// <summary>
@@ -373,7 +373,7 @@ namespace Microsoft.Build.Construction
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             public override int Column
             {
-                get { return (int)_column; }
+                get { return (int)column; }
             }
         }
     }

--- a/src/XMakeBuildEngine/ElementLocation/RegistryLocation.cs
+++ b/src/XMakeBuildEngine/ElementLocation/RegistryLocation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// The location.
         /// </summary>
-        private string _registryPath;
+        private string registryPath;
 
         /// <summary>
         /// Constructor taking the registry location.
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Construction
         {
             ErrorUtilities.VerifyThrowInternalLength(registryPath, "registryPath");
 
-            _registryPath = registryPath;
+            this.registryPath = registryPath;
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public string LocationString
         {
-            get { return _registryPath; }
+            get { return registryPath; }
         }
 
         #region INodePacketTranslatable Members
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public void Translate(INodePacketTranslator translator)
         {
-            translator.Translate(ref _registryPath);
+            translator.Translate(ref registryPath);
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Errors/InternalLoggerException.cs
+++ b/src/XMakeBuildEngine/Errors/InternalLoggerException.cs
@@ -93,10 +93,10 @@ namespace Microsoft.Build.Exceptions
             ErrorUtilities.VerifyThrow((errorCode != null) && (errorCode.Length > 0), "Must specify the error message code.");
             ErrorUtilities.VerifyThrow((helpKeyword != null) && (helpKeyword.Length > 0), "Must specify the help keyword for the IDE.");
 
-            _e = e;
-            _errorCode = errorCode;
-            _helpKeyword = helpKeyword;
-            _initializationException = initializationException;
+            this.e = e;
+            this.errorCode = errorCode;
+            this.helpKeyword = helpKeyword;
+            this.initializationException = initializationException;
         }
 
         #region Serialization (update when adding new class members)
@@ -110,10 +110,10 @@ namespace Microsoft.Build.Exceptions
         private InternalLoggerException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            _e = (BuildEventArgs)info.GetValue("e", typeof(BuildEventArgs));
-            _errorCode = info.GetString("errorCode");
-            _helpKeyword = info.GetString("helpKeyword");
-            _initializationException = info.GetBoolean("initializationException");
+            e = (BuildEventArgs)info.GetValue("e", typeof(BuildEventArgs));
+            errorCode = info.GetString("errorCode");
+            helpKeyword = info.GetString("helpKeyword");
+            initializationException = info.GetBoolean("initializationException");
         }
 
         /// <summary>
@@ -127,10 +127,10 @@ namespace Microsoft.Build.Exceptions
         {
             base.GetObjectData(info, context);
 
-            info.AddValue("e", _e);
-            info.AddValue("errorCode", _errorCode);
-            info.AddValue("helpKeyword", _helpKeyword);
-            info.AddValue("initializationException", _initializationException);
+            info.AddValue("e", e);
+            info.AddValue("errorCode", errorCode);
+            info.AddValue("helpKeyword", helpKeyword);
+            info.AddValue("initializationException", initializationException);
         }
 
         /// <summary>
@@ -139,11 +139,11 @@ namespace Microsoft.Build.Exceptions
         [OnDeserializing] // Will happen before the object is deserialized
         private void SetDefaultsBeforeSerialization(StreamingContext sc)
         {
-            _initializationException = false;
+            initializationException = false;
         }
 
         /// <summary>
-        /// Dont actually have anything to do in the method, but the method is required when implementing an optional field
+        /// Don't actually have anything to do in the method, but the method is required when implementing an optional field
         /// </summary>
         [OnDeserialized]
         private void SetValueAfterDeserialization(StreamingContext sx)
@@ -162,7 +162,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _e;
+                return e;
             }
         }
 
@@ -174,7 +174,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _errorCode;
+                return errorCode;
             }
         }
 
@@ -186,18 +186,18 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _helpKeyword;
+                return helpKeyword;
             }
         }
 
         /// <summary>
-        /// True if the exception occured during logger initialization
+        /// True if the exception occurred during logger initialization
         /// </summary>
         public bool InitializationException
         {
             get
             {
-                return _initializationException;
+                return initializationException;
             }
         }
 
@@ -229,14 +229,14 @@ namespace Microsoft.Build.Exceptions
         }
 
         // the event that was being logged when a logger failed (can be null)
-        private BuildEventArgs _e;
+        private BuildEventArgs e;
         // the error code for this exception's message (not the inner exception)
-        private string _errorCode;
+        private string errorCode;
         // the F1-help keyword for the host IDE
-        private string _helpKeyword;
+        private string helpKeyword;
 
         // This flag is set to indicate that the exception occured during logger initialization
         [OptionalField(VersionAdded = 2)]
-        private bool _initializationException;
+        private bool initializationException;
     }
 }

--- a/src/XMakeBuildEngine/Errors/InvalidProjectFileException.cs
+++ b/src/XMakeBuildEngine/Errors/InvalidProjectFileException.cs
@@ -88,15 +88,15 @@ namespace Microsoft.Build.Exceptions
         private InvalidProjectFileException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            _file = info.GetString("projectFile");
-            _lineNumber = info.GetInt32("lineNumber");
-            _columnNumber = info.GetInt32("columnNumber");
-            _endLineNumber = info.GetInt32("endLineNumber");
-            _endColumnNumber = info.GetInt32("endColumnNumber");
-            _errorSubcategory = info.GetString("errorSubcategory");
-            _errorCode = info.GetString("errorCode");
-            _helpKeyword = info.GetString("helpKeyword");
-            _hasBeenLogged = info.GetBoolean("hasBeenLogged");
+            file = info.GetString("projectFile");
+            lineNumber = info.GetInt32("lineNumber");
+            columnNumber = info.GetInt32("columnNumber");
+            endLineNumber = info.GetInt32("endLineNumber");
+            endColumnNumber = info.GetInt32("endColumnNumber");
+            errorSubcategory = info.GetString("errorSubcategory");
+            errorCode = info.GetString("errorCode");
+            helpKeyword = info.GetString("helpKeyword");
+            hasBeenLogged = info.GetBoolean("hasBeenLogged");
         }
 
         /// <summary>
@@ -110,15 +110,15 @@ namespace Microsoft.Build.Exceptions
         {
             base.GetObjectData(info, context);
 
-            info.AddValue("projectFile", _file);
-            info.AddValue("lineNumber", _lineNumber);
-            info.AddValue("columnNumber", _columnNumber);
-            info.AddValue("endLineNumber", _endLineNumber);
-            info.AddValue("endColumnNumber", _endColumnNumber);
-            info.AddValue("errorSubcategory", _errorSubcategory);
-            info.AddValue("errorCode", _errorCode);
-            info.AddValue("helpKeyword", _helpKeyword);
-            info.AddValue("hasBeenLogged", _hasBeenLogged);
+            info.AddValue("projectFile", file);
+            info.AddValue("lineNumber", lineNumber);
+            info.AddValue("columnNumber", columnNumber);
+            info.AddValue("endLineNumber", endLineNumber);
+            info.AddValue("endColumnNumber", endColumnNumber);
+            info.AddValue("errorSubcategory", errorSubcategory);
+            info.AddValue("errorCode", errorCode);
+            info.AddValue("helpKeyword", helpKeyword);
+            info.AddValue("hasBeenLogged", hasBeenLogged);
         }
 
         #endregion
@@ -195,14 +195,14 @@ namespace Microsoft.Build.Exceptions
                 projectFile = (fullPath == null) ? projectFile : fullPath;
             }
 
-            _file = projectFile;
-            _lineNumber = lineNumber;
-            _columnNumber = columnNumber;
-            _endLineNumber = endLineNumber;
-            _endColumnNumber = endColumnNumber;
-            _errorSubcategory = errorSubcategory;
-            _errorCode = errorCode;
-            _helpKeyword = helpKeyword;
+            file = projectFile;
+            this.lineNumber = lineNumber;
+            this.columnNumber = columnNumber;
+            this.endLineNumber = endLineNumber;
+            this.endColumnNumber = endColumnNumber;
+            this.errorSubcategory = errorSubcategory;
+            this.errorCode = errorCode;
+            this.helpKeyword = helpKeyword;
         }
 
         #endregion
@@ -248,7 +248,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _file;
+                return file;
             }
         }
 
@@ -260,7 +260,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _lineNumber;
+                return lineNumber;
             }
         }
 
@@ -272,7 +272,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _columnNumber;
+                return columnNumber;
             }
         }
 
@@ -284,7 +284,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _endLineNumber;
+                return endLineNumber;
             }
         }
 
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _endColumnNumber;
+                return endColumnNumber;
             }
         }
 
@@ -308,7 +308,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _errorSubcategory;
+                return errorSubcategory;
             }
         }
 
@@ -320,7 +320,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _errorCode;
+                return errorCode;
             }
         }
 
@@ -332,7 +332,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _helpKeyword;
+                return helpKeyword;
             }
         }
 
@@ -344,33 +344,33 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _hasBeenLogged;
+                return hasBeenLogged;
             }
             internal set
             {
-                _hasBeenLogged = value;
+                hasBeenLogged = value;
             }
         }
 
         #endregion
 
         // the project file that caused this exception
-        private string _file;
+        private string file;
         // the invalid line number in the project
-        private int _lineNumber;
+        private int lineNumber;
         // the invalid column number in the project
-        private int _columnNumber;
+        private int columnNumber;
         // the end of a range of invalid lines in the project
-        private int _endLineNumber;
+        private int endLineNumber;
         // the end of a range of invalid columns in the project
-        private int _endColumnNumber;
+        private int endColumnNumber;
         // the error sub-category that describes the type of this error
-        private string _errorSubcategory;
+        private string errorSubcategory;
         // the error code for the exception message
-        private string _errorCode;
+        private string errorCode;
         // the F1-help keyword for the host IDE
-        private string _helpKeyword;
+        private string helpKeyword;
         // Has this errors been sent to the loggers?
-        private bool _hasBeenLogged = false;
+        private bool hasBeenLogged = false;
     }
 }

--- a/src/XMakeBuildEngine/Errors/InvalidToolsetDefinitionException.cs
+++ b/src/XMakeBuildEngine/Errors/InvalidToolsetDefinitionException.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Exceptions
         /// <summary>
         /// The MSBuild error code corresponding with this exception.
         /// </summary>
-        private string _errorCode = null;
+        private string errorCode = null;
 
         /// <summary>
         /// Basic constructor.
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Exceptions
         {
             ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-            _errorCode = info.GetString("errorCode");
+            errorCode = info.GetString("errorCode");
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Exceptions
         public InvalidToolsetDefinitionException(string message, string errorCode)
             : base(message)
         {
-            _errorCode = errorCode;
+            this.errorCode = errorCode;
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Exceptions
         public InvalidToolsetDefinitionException(string message, string errorCode, Exception innerException)
             : base(message, innerException)
         {
-            _errorCode = errorCode;
+            this.errorCode = errorCode;
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Microsoft.Build.Exceptions
 
             base.GetObjectData(info, context);
 
-            info.AddValue("errorCode", _errorCode);
+            info.AddValue("errorCode", errorCode);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Microsoft.Build.Exceptions
         {
             get
             {
-                return _errorCode;
+                return errorCode;
             }
         }
 

--- a/src/XMakeCommandLine/CommandLineSwitchException.cs
+++ b/src/XMakeCommandLine/CommandLineSwitchException.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.CommandLine
         ) :
             this(message)
         {
-            _commandLineArg = commandLineArg;
+            this.commandLineArg = commandLineArg;
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Microsoft.Build.CommandLine
         {
             ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-            _commandLineArg = info.GetString("commandLineArg");
+            commandLineArg = info.GetString("commandLineArg");
         }
 
         /// <summary>
@@ -67,13 +67,13 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                if (_commandLineArg == null)
+                if (commandLineArg == null)
                 {
                     return base.Message;
                 }
                 else
                 {
-                    return base.Message + Environment.NewLine + ResourceUtilities.FormatResourceString("InvalidSwitchIndicator", _commandLineArg);
+                    return base.Message + Environment.NewLine + ResourceUtilities.FormatResourceString("InvalidSwitchIndicator", commandLineArg);
                 }
             }
         }
@@ -86,12 +86,12 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                return _commandLineArg;
+                return commandLineArg;
             }
         }
 
         // the invalid switch causing this exception
-        private string _commandLineArg;
+        private string commandLineArg;
 
         /// <summary>
         /// Serialize the contents of the class.
@@ -101,7 +101,7 @@ namespace Microsoft.Build.CommandLine
         {
             base.GetObjectData(info, context);
 
-            info.AddValue("commandLineArg", _commandLineArg, typeof(string));
+            info.AddValue("commandLineArg", commandLineArg, typeof(string));
         }
 
         /// <summary>

--- a/src/XMakeCommandLine/InitializationException.cs
+++ b/src/XMakeCommandLine/InitializationException.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.CommandLine
         ) :
             this(message)
         {
-            _invalidSwitch = invalidSwitch;
+            this.invalidSwitch = invalidSwitch;
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Microsoft.Build.CommandLine
         {
             ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-            _invalidSwitch = info.GetString("invalidSwitch");
+            invalidSwitch = info.GetString("invalidSwitch");
         }
 
         /// <summary>
@@ -80,19 +80,19 @@ namespace Microsoft.Build.CommandLine
         {
             get
             {
-                if (_invalidSwitch == null)
+                if (invalidSwitch == null)
                 {
                     return base.Message;
                 }
                 else
                 {
-                    return base.Message + Environment.NewLine + ResourceUtilities.FormatResourceString("InvalidSwitchIndicator", _invalidSwitch);
+                    return base.Message + Environment.NewLine + ResourceUtilities.FormatResourceString("InvalidSwitchIndicator", invalidSwitch);
                 }
             }
         }
 
         // the invalid switch causing this exception (can be null)
-        private string _invalidSwitch;
+        private string invalidSwitch;
 
         /// <summary>
         /// Serialize the contents of the class.
@@ -102,7 +102,7 @@ namespace Microsoft.Build.CommandLine
         {
             base.GetObjectData(info, context);
 
-            info.AddValue("invalidSwitch", _invalidSwitch, typeof(string));
+            info.AddValue("invalidSwitch", invalidSwitch, typeof(string));
         }
 
         /// <summary>

--- a/src/XMakeCommandLine/OutOfProcTaskAppDomainWrapperBase.cs
+++ b/src/XMakeCommandLine/OutOfProcTaskAppDomainWrapperBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// This is the actual user task whose instance we will create and invoke Execute
         /// </summary>
-        private ITask _wrappedTask;
+        private ITask wrappedTask;
 
         /// <summary>
         /// This is an appDomain instance if any is created for running this task
@@ -52,20 +52,20 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// Need to keep the build engine around in order to log from the task loader. 
         /// </summary>
-        private IBuildEngine _buildEngine;
+        private IBuildEngine buildEngine;
 
         /// <summary>
         /// Need to keep track of the task name also so that we can log valid information
         /// from the task loader. 
         /// </summary>
-        private string _taskName;
+        private string taskName;
 
         /// <summary>
         /// This is the actual user task whose instance we will create and invoke Execute
         /// </summary>
         public ITask WrappedTask
         {
-            get { return _wrappedTask; }
+            get { return wrappedTask; }
         }
 
         /// <summary>
@@ -107,11 +107,11 @@ namespace Microsoft.Build.CommandLine
                 IDictionary<string, TaskParameter> taskParams
             )
         {
-            _buildEngine = oopTaskHostNode;
-            _taskName = taskName;
+            buildEngine = oopTaskHostNode;
+            this.taskName = taskName;
 
             _taskAppDomain = null;
-            _wrappedTask = null;
+            wrappedTask = null;
 
             LoadedType taskType = null;
             try
@@ -170,7 +170,7 @@ namespace Microsoft.Build.CommandLine
             }
 
             TaskLoader.RemoveAssemblyResolver();
-            _wrappedTask = null;
+            wrappedTask = null;
         }
 
         /// <summary>
@@ -273,14 +273,14 @@ namespace Microsoft.Build.CommandLine
             )
         {
             _taskAppDomain = null;
-            _wrappedTask = null;
+            wrappedTask = null;
 
             try
             {
-                _wrappedTask = TaskLoader.CreateTask(taskType, taskName, taskFile, taskLine, taskColumn, new TaskLoader.LogError(LogErrorDelegate), appDomainSetup, true /* always out of proc */, out _taskAppDomain);
-                Type wrappedTaskType = _wrappedTask.GetType();
+                wrappedTask = TaskLoader.CreateTask(taskType, taskName, taskFile, taskLine, taskColumn, new TaskLoader.LogError(LogErrorDelegate), appDomainSetup, true /* always out of proc */, out _taskAppDomain);
+                Type wrappedTaskType = wrappedTask.GetType();
 
-                _wrappedTask.BuildEngine = oopTaskHostNode;
+                wrappedTask.BuildEngine = oopTaskHostNode;
             }
             catch (Exception e)
             {
@@ -311,8 +311,8 @@ namespace Microsoft.Build.CommandLine
             {
                 try
                 {
-                    PropertyInfo paramInfo = _wrappedTask.GetType().GetProperty(param.Key, BindingFlags.Instance | BindingFlags.Public);
-                    paramInfo.SetValue(_wrappedTask, (param.Value == null ? null : param.Value.WrappedParameter), null);
+                    PropertyInfo paramInfo = wrappedTask.GetType().GetProperty(param.Key, BindingFlags.Instance | BindingFlags.Public);
+                    paramInfo.SetValue(wrappedTask, (param.Value == null ? null : param.Value.WrappedParameter), null);
                 }
                 catch (Exception e)
                 {
@@ -349,7 +349,7 @@ namespace Microsoft.Build.CommandLine
                 }
 
                 // If it didn't crash and return before now, we're clear to go ahead and execute here. 
-                success = _wrappedTask.Execute();
+                success = wrappedTask.Execute();
             }
             catch (Exception e)
             {
@@ -361,7 +361,7 @@ namespace Microsoft.Build.CommandLine
                 return new OutOfProcTaskHostTaskResult(TaskCompleteType.CrashedDuringExecution, e);
             }
 
-            PropertyInfo[] finalPropertyValues = _wrappedTask.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
+            PropertyInfo[] finalPropertyValues = wrappedTask.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
 
             IDictionary<string, Object> finalParameterValues = new Dictionary<string, Object>(StringComparer.OrdinalIgnoreCase);
             foreach (PropertyInfo value in finalPropertyValues)
@@ -371,7 +371,7 @@ namespace Microsoft.Build.CommandLine
                 {
                     try
                     {
-                        finalParameterValues[value.Name] = value.GetValue(_wrappedTask, null);
+                        finalParameterValues[value.Name] = value.GetValue(wrappedTask, null);
                     }
                     catch (Exception e)
                     {
@@ -396,7 +396,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         private void LogErrorDelegate(string taskLocation, int taskLine, int taskColumn, string message, params object[] messageArgs)
         {
-            _buildEngine.LogErrorEvent(new BuildErrorEventArgs(
+            buildEngine.LogErrorEvent(new BuildErrorEventArgs(
                                                     null,
                                                     null,
                                                     taskLocation,
@@ -406,7 +406,7 @@ namespace Microsoft.Build.CommandLine
                                                     0,
                                                     ResourceUtilities.FormatString(AssemblyResources.GetString(message), messageArgs),
                                                     null,
-                                                    _taskName
+                                                    taskName
                                                 )
                                             );
         }

--- a/src/XMakeTasks/AppConfig/AppConfigException.cs
+++ b/src/XMakeTasks/AppConfig/AppConfigException.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The name of the app.config file.
         /// </summary>
-        private string _fileName = String.Empty;
+        private string fileName = String.Empty;
         internal string FileName
         {
             get
             {
-                return _fileName;
+                return fileName;
             }
         }
 
@@ -28,24 +28,24 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The line number with the error. Is initialized to zero
         /// </summary>
-        private int _line;
+        private int line;
         internal int Line
         {
             get
             {
-                return _line;
+                return line;
             }
         }
 
         /// <summary>
         /// The column with the error. Is initialized to zero
         /// </summary>
-        private int _column;
+        private int column;
         internal int Column
         {
             get
             {
-                return _column;
+                return column;
             }
         }
 
@@ -60,9 +60,9 @@ namespace Microsoft.Build.Tasks
         /// <param name="inner"></param>
         public AppConfigException(string message, string fileName, int line, int column, System.Exception inner) : base(message, inner)
         {
-            _fileName = fileName;
-            _line = line;
-            _column = column;
+            this.fileName = fileName;
+            this.line = line;
+            this.column = column;
         }
 
         /// <summary>

--- a/src/XMakeTasks/AssemblyDependency/InvalidReferenceAssemblyNameException.cs
+++ b/src/XMakeTasks/AssemblyDependency/InvalidReferenceAssemblyNameException.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Tasks
     [Serializable]
     internal sealed class InvalidReferenceAssemblyNameException : Exception
     {
-        private string _sourceItemSpec;
+        private string sourceItemSpec;
 
         /// <summary>
         /// Don't allow default construction.
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal InvalidReferenceAssemblyNameException(string sourceItemSpec)
         {
-            _sourceItemSpec = sourceItemSpec;
+            this.sourceItemSpec = sourceItemSpec;
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal string SourceItemSpec
         {
-            get { return _sourceItemSpec; }
+            get { return sourceItemSpec; }
         }
     }
 }

--- a/src/XMakeTasks/DependencyFile.cs
+++ b/src/XMakeTasks/DependencyFile.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Build.Tasks
     internal class DependencyFile
     {
         // Filename
-        private string _filename;
+        private string filename;
 
         // Date and time the file was last modified           
-        private DateTime _lastModified;
+        private DateTime lastModified;
 
         // Whether the file exists or not.
-        private bool _exists = false;
+        private bool exists = false;
 
         /// <summary>
         /// The name of the file.
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Tasks
         /// <value></value>
         internal string FileName
         {
-            get { return _filename; }
+            get { return filename; }
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Tasks
         /// <value></value>
         internal DateTime LastModified
         {
-            get { return _lastModified; }
+            get { return lastModified; }
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Tasks
         /// <value></value>
         internal bool Exists
         {
-            get { return _exists; }
+            get { return exists; }
         }
 
         /// <summary>
@@ -66,16 +66,16 @@ namespace Microsoft.Build.Tasks
         /// <param name="filename">The file name.</param>
         internal DependencyFile(string filename)
         {
-            _filename = filename;
+            this.filename = filename;
 
             if (File.Exists(FileName))
             {
-                _lastModified = File.GetLastWriteTime(FileName);
-                _exists = true;
+                lastModified = File.GetLastWriteTime(FileName);
+                exists = true;
             }
             else
             {
-                _exists = false;
+                exists = false;
             }
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal bool HasFileChanged()
         {
-            FileInfo info = FileUtilities.GetFileInfoNoThrow(_filename);
+            FileInfo info = FileUtilities.GetFileInfoNoThrow(filename);
 
             // Obviously if the file no longer exists then we are not up to date.
             if (info == null || !info.Exists)
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Tasks
             // Check the saved timestamp against the current timestamp.
             // If they are different then obviously we are out of date.
             DateTime curLastModified = info.LastWriteTime;
-            if (curLastModified != _lastModified)
+            if (curLastModified != lastModified)
             {
                 return true;
             }

--- a/src/XMakeTasks/GenerateResource.cs
+++ b/src/XMakeTasks/GenerateResource.cs
@@ -3546,9 +3546,9 @@ namespace Microsoft.Build.Tasks
         [Serializable]
         internal sealed class TextFileException : Exception
         {
-            private String _fileName;
-            private int _lineNumber;
-            private int _column;
+            private String fileName;
+            private int lineNumber;
+            private int column;
 
             /// <summary>
             /// Fxcop want to have the correct basic exception constructors implemented
@@ -3561,24 +3561,24 @@ namespace Microsoft.Build.Tasks
             internal TextFileException(String message, String fileName, int lineNumber, int linePosition)
                 : base(message)
             {
-                _fileName = fileName;
-                _lineNumber = lineNumber;
-                _column = linePosition;
+                this.fileName = fileName;
+                this.lineNumber = lineNumber;
+                column = linePosition;
             }
 
             internal String FileName
             {
-                get { return _fileName; }
+                get { return fileName; }
             }
 
             internal int LineNumber
             {
-                get { return _lineNumber; }
+                get { return lineNumber; }
             }
 
             internal int LinePosition
             {
-                get { return _column; }
+                get { return column; }
             }
         }
 

--- a/src/XMakeTasks/InvalidParameterValueException.cs
+++ b/src/XMakeTasks/InvalidParameterValueException.cs
@@ -56,26 +56,26 @@ namespace Microsoft.Build.Tasks
         {
         }
 
-        private string _paramName;
+        private string paramName;
 
         /// <summary>
         /// The name of the parameter.
         /// </summary>
         public string ParamName
         {
-            get { return _paramName; }
-            set { _paramName = value; }
+            get { return paramName; }
+            set { paramName = value; }
         }
 
-        private string _actualValue;
+        private string actualValue;
 
         /// <summary>
         /// The value supplied, that was bad.
         /// </summary>
         public string ActualValue
         {
-            get { return _actualValue; }
-            set { _actualValue = value; }
+            get { return actualValue; }
+            set { actualValue = value; }
         }
     }
 }

--- a/src/XMakeTasks/SystemState.cs
+++ b/src/XMakeTasks/SystemState.cs
@@ -29,21 +29,21 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// State information for cached files kept at the SystemState instance level.
         /// </summary>
-        private Hashtable _instanceLocalFileStateCache = new Hashtable();
+        private Hashtable instanceLocalFileStateCache = new Hashtable();
 
         /// <summary>
         /// FileExists information is purely instance-local. It doesn't make sense to
         /// cache this for long periods of time since there's no way (without actually 
         /// calling File.Exists) to tell whether the cache is out-of-date.
         /// </summary>
-        private Hashtable _instanceLocalFileExists = new Hashtable();
+        private Hashtable instanceLocalFileExists = new Hashtable();
 
         /// <summary>
         /// GetDirectories information is also purely instance-local. This information
         /// is only considered good for the lifetime of the task (or whatever) that owns 
         /// this instance.
         /// </summary>
-        private Hashtable _instanceLocalDirectories = new Hashtable();
+        private Hashtable instanceLocalDirectories = new Hashtable();
 
         /// <summary>
         /// Additional level of caching kept at the process level.
@@ -53,42 +53,42 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// XML tables of installed assemblies.
         /// </summary>
-        private RedistList _redistList = null;
+        private RedistList redistList = null;
 
         /// <summary>
         /// True if the contents have changed.
         /// </summary>
-        private bool _isDirty = false;
+        private bool isDirty = false;
 
         /// <summary>
         /// Delegate used internally.
         /// </summary>
-        private GetLastWriteTime _getLastWriteTime = null;
+        private GetLastWriteTime getLastWriteTime = null;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private GetAssemblyName _getAssemblyName = null;
+        private GetAssemblyName getAssemblyName = null;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private GetAssemblyMetadata _getAssemblyMetadata = null;
+        private GetAssemblyMetadata getAssemblyMetadata = null;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private FileExists _fileExists = null;
+        private FileExists fileExists = null;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private GetDirectories _getDirectories = null;
+        private GetDirectories getDirectories = null;
 
         /// <summary>
         /// Cached delegate
         /// </summary>
-        private GetAssemblyRuntimeVersion _getAssemblyRuntimeVersion = null;
+        private GetAssemblyRuntimeVersion getAssemblyRuntimeVersion = null;
 
         /// <summary>
         /// Class that holds the current file state.
@@ -99,12 +99,12 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// The last modified time for this file.
             /// </summary>
-            private DateTime _lastModified;
+            private DateTime lastModified;
 
             /// <summary>
             /// The fusion name of this file.
             /// </summary>
-            private AssemblyNameExtension _assemblyName = null;
+            private AssemblyNameExtension assemblyName = null;
 
             /// <summary>
             /// The assemblies that this file depends on.
@@ -140,8 +140,8 @@ namespace Microsoft.Build.Tasks
             {
                 ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-                _lastModified = info.GetDateTime("lastModified");
-                _assemblyName = (AssemblyNameExtension)info.GetValue("assemblyName", typeof(AssemblyNameExtension));
+                lastModified = info.GetDateTime("lastModified");
+                assemblyName = (AssemblyNameExtension)info.GetValue("assemblyName", typeof(AssemblyNameExtension));
                 dependencies = (AssemblyNameExtension[])info.GetValue("dependencies", typeof(AssemblyNameExtension[]));
                 scatterFiles = (string[])info.GetValue("scatterFiles", typeof(string[]));
                 runtimeVersion = (string)info.GetValue("runtimeVersion", typeof(string));
@@ -156,8 +156,8 @@ namespace Microsoft.Build.Tasks
             {
                 ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-                info.AddValue("lastModified", _lastModified);
-                info.AddValue("assemblyName", _assemblyName);
+                info.AddValue("lastModified", lastModified);
+                info.AddValue("assemblyName", assemblyName);
                 info.AddValue("dependencies", dependencies);
                 info.AddValue("scatterFiles", scatterFiles);
                 info.AddValue("runtimeVersion", runtimeVersion);
@@ -170,8 +170,8 @@ namespace Microsoft.Build.Tasks
             /// <value></value>
             internal DateTime LastModified
             {
-                get { return _lastModified; }
-                set { _lastModified = value; }
+                get { return lastModified; }
+                set { lastModified = value; }
             }
 
             /// <summary>
@@ -180,8 +180,8 @@ namespace Microsoft.Build.Tasks
             /// <value></value>
             internal AssemblyNameExtension Assembly
             {
-                get { return _assemblyName; }
-                set { _assemblyName = value; }
+                get { return assemblyName; }
+                set { assemblyName = value; }
             }
 
             /// <summary>
@@ -219,8 +219,8 @@ namespace Microsoft.Build.Tasks
         {
             ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-            _instanceLocalFileStateCache = (Hashtable)info.GetValue("fileState", typeof(Hashtable));
-            _isDirty = false;
+            instanceLocalFileStateCache = (Hashtable)info.GetValue("fileState", typeof(Hashtable));
+            isDirty = false;
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Microsoft.Build.Tasks
             AssemblyTableInfo[] installedAssemblyTableInfos
         )
         {
-            _redistList = RedistList.GetRedistList(installedAssemblyTableInfos);
+            redistList = RedistList.GetRedistList(installedAssemblyTableInfos);
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace Microsoft.Build.Tasks
         {
             ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-            info.AddValue("fileState", _instanceLocalFileStateCache);
+            info.AddValue("fileState", instanceLocalFileStateCache);
         }
 
         /// <summary>
@@ -255,7 +255,7 @@ namespace Microsoft.Build.Tasks
         /// <value></value>
         internal bool IsDirty
         {
-            get { return _isDirty; }
+            get { return isDirty; }
         }
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="getLastWriteTime">Delegate used to get the last write time.</param>
         internal void SetGetLastWriteTime(GetLastWriteTime getLastWriteTimeValue)
         {
-            _getLastWriteTime = getLastWriteTimeValue;
+            getLastWriteTime = getLastWriteTimeValue;
         }
 
         /// <summary>
@@ -274,7 +274,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Cached version of the delegate.</returns>
         internal GetAssemblyName CacheDelegate(GetAssemblyName getAssemblyNameValue)
         {
-            _getAssemblyName = getAssemblyNameValue;
+            getAssemblyName = getAssemblyNameValue;
             return new GetAssemblyName(this.GetAssemblyName);
         }
 
@@ -285,7 +285,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Cached version of the delegate.</returns>
         internal GetAssemblyMetadata CacheDelegate(GetAssemblyMetadata getAssemblyMetadataValue)
         {
-            _getAssemblyMetadata = getAssemblyMetadataValue;
+            getAssemblyMetadata = getAssemblyMetadataValue;
             return new GetAssemblyMetadata(this.GetAssemblyMetadata);
         }
 
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Cached version of the delegate.</returns>
         internal FileExists CacheDelegate(FileExists fileExistsValue)
         {
-            _fileExists = fileExistsValue;
+            fileExists = fileExistsValue;
             return new FileExists(this.FileExists);
         }
 
@@ -307,7 +307,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Cached version of the delegate.</returns>
         internal GetDirectories CacheDelegate(GetDirectories getDirectoriesValue)
         {
-            _getDirectories = getDirectoriesValue;
+            getDirectories = getDirectoriesValue;
             return new GetDirectories(this.GetDirectories);
         }
 
@@ -318,7 +318,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Cached version of the delegate.</returns>
         internal GetAssemblyRuntimeVersion CacheDelegate(GetAssemblyRuntimeVersion getAssemblyRuntimeVersion)
         {
-            _getAssemblyRuntimeVersion = getAssemblyRuntimeVersion;
+            this.getAssemblyRuntimeVersion = getAssemblyRuntimeVersion;
             return new GetAssemblyRuntimeVersion(this.GetRuntimeVersion);
         }
 
@@ -333,7 +333,7 @@ namespace Microsoft.Build.Tasks
             FileState cacheFileState = null;
             FileState processFileState = null;
             SystemState.s_processWideFileStateCache.TryGetValue(path, out processFileState);
-            FileState instanceLocalFileState = instanceLocalFileState = (FileState)_instanceLocalFileStateCache[path];
+            FileState instanceLocalFileState = instanceLocalFileState = (FileState)instanceLocalFileStateCache[path];
 
             // Sync the caches.
             if (processFileState == null && instanceLocalFileState != null)
@@ -344,14 +344,14 @@ namespace Microsoft.Build.Tasks
             else if (processFileState != null && instanceLocalFileState == null)
             {
                 cacheFileState = processFileState;
-                _instanceLocalFileStateCache[path] = processFileState;
+                instanceLocalFileStateCache[path] = processFileState;
             }
             else if (processFileState != null && instanceLocalFileState != null)
             {
                 if (processFileState.LastModified > instanceLocalFileState.LastModified)
                 {
                     cacheFileState = processFileState;
-                    _instanceLocalFileStateCache[path] = processFileState;
+                    instanceLocalFileStateCache[path] = processFileState;
                 }
                 else
                 {
@@ -364,22 +364,22 @@ namespace Microsoft.Build.Tasks
             if (cacheFileState == null) // Or check time stamp
             {
                 cacheFileState = new FileState();
-                cacheFileState.LastModified = _getLastWriteTime(path);
-                _instanceLocalFileStateCache[path] = cacheFileState;
+                cacheFileState.LastModified = getLastWriteTime(path);
+                instanceLocalFileStateCache[path] = cacheFileState;
                 SystemState.s_processWideFileStateCache.TryAdd(path, cacheFileState);
-                _isDirty = true;
+                isDirty = true;
             }
             else
             {
                 // If time stamps have changed, then purge.
-                DateTime lastModified = _getLastWriteTime(path);
+                DateTime lastModified = getLastWriteTime(path);
                 if (lastModified != cacheFileState.LastModified)
                 {
                     cacheFileState = new FileState();
-                    cacheFileState.LastModified = _getLastWriteTime(path);
-                    _instanceLocalFileStateCache[path] = cacheFileState;
+                    cacheFileState.LastModified = getLastWriteTime(path);
+                    instanceLocalFileStateCache[path] = cacheFileState;
                     SystemState.s_processWideFileStateCache.TryAdd(path, cacheFileState);
-                    _isDirty = true;
+                    isDirty = true;
                 }
             }
 
@@ -395,12 +395,12 @@ namespace Microsoft.Build.Tasks
         {
             // If the assembly is in an FX folder and its a well-known assembly
             // then we can short-circuit the File IO involved with GetAssemblyName()
-            if (_redistList != null)
+            if (redistList != null)
             {
                 string extension = Path.GetExtension(path);
                 if (String.Compare(extension, ".dll", StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    AssemblyEntry[] assemblyNames = _redistList.FindAssemblyNameFromSimpleName
+                    AssemblyEntry[] assemblyNames = redistList.FindAssemblyNameFromSimpleName
                         (
                             Path.GetFileNameWithoutExtension(path)
                         );
@@ -423,7 +423,7 @@ namespace Microsoft.Build.Tasks
             FileState fileState = GetFileState(path);
             if (fileState.Assembly == null)
             {
-                fileState.Assembly = _getAssemblyName(path);
+                fileState.Assembly = getAssemblyName(path);
 
                 // Certain assemblies, like mscorlib may not have metadata.
                 // Avoid continuously calling getAssemblyName on these files by 
@@ -432,7 +432,7 @@ namespace Microsoft.Build.Tasks
                 {
                     fileState.Assembly = AssemblyNameExtension.UnnamedAssembly;
                 }
-                _isDirty = true;
+                isDirty = true;
             }
 
             if (fileState.Assembly.IsUnnamedAssembly)
@@ -452,8 +452,8 @@ namespace Microsoft.Build.Tasks
             FileState fileState = GetFileState(path);
             if (String.IsNullOrEmpty(fileState.RuntimeVersion))
             {
-                fileState.RuntimeVersion = _getAssemblyRuntimeVersion(path);
-                _isDirty = true;
+                fileState.RuntimeVersion = getAssemblyRuntimeVersion(path);
+                isDirty = true;
             }
 
             return fileState.RuntimeVersion;
@@ -477,7 +477,7 @@ namespace Microsoft.Build.Tasks
             FileState fileState = GetFileState(path);
             if (fileState.dependencies == null)
             {
-                _getAssemblyMetadata
+                getAssemblyMetadata
                 (
                     path,
                     out fileState.dependencies,
@@ -485,7 +485,7 @@ namespace Microsoft.Build.Tasks
                     out fileState.frameworkName
                  );
 
-                _isDirty = true;
+                isDirty = true;
             }
 
             dependencies = fileState.dependencies;
@@ -506,11 +506,11 @@ namespace Microsoft.Build.Tasks
             // is a string-copy.
             if (pattern == "*.")
             {
-                object cached = _instanceLocalDirectories[path];
+                object cached = instanceLocalDirectories[path];
                 if (cached == null)
                 {
-                    string[] directories = _getDirectories(path, pattern);
-                    _instanceLocalDirectories[path] = directories;
+                    string[] directories = getDirectories(path, pattern);
+                    instanceLocalDirectories[path] = directories;
                     return directories;
                 }
                 return (string[])cached;
@@ -520,7 +520,7 @@ namespace Microsoft.Build.Tasks
             // that this is an unoptimized path.
             Debug.Assert(false, "Using slow-path in SystemState.GetDirectories, was this intentional?");
 
-            return _getDirectories(path, pattern);
+            return getDirectories(path, pattern);
         }
 
         /// <summary>
@@ -533,7 +533,7 @@ namespace Microsoft.Build.Tasks
             /////////////////////////////////////////////////////////////////////////////////////////////
             // FIRST -- Look in the primary cache for this path.
             /////////////////////////////////////////////////////////////////////////////////////////////
-            object flag = _instanceLocalFileExists[path];
+            object flag = instanceLocalFileExists[path];
             if (flag != null)
             {
                 return (bool)flag;
@@ -542,8 +542,8 @@ namespace Microsoft.Build.Tasks
             /////////////////////////////////////////////////////////////////////////////////////////////
             // SECOND -- fall back to plain old File.Exists and cache the result.
             /////////////////////////////////////////////////////////////////////////////////////////////
-            bool exists = _fileExists(path);
-            _instanceLocalFileExists[path] = exists;
+            bool exists = fileExists(path);
+            instanceLocalFileExists[path] = exists;
             return exists;
         }
     }

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -8203,7 +8203,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <summary>
         /// Simulate a CreateProject resolution. This is primarily for IO monitoring.
         /// </summary>
-        public void SimulateCreateProjectAgainstWhidbey(string fxfolder)
+        public void SimulateCreateProjectAgainstWhidbeyInternal(string fxfolder)
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
             // times out the object used for remoting console writes.  Adding a write in the middle of
@@ -8248,7 +8248,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void SimulateCreateProjectAgainstWhidbey()
         {
-            SimulateCreateProjectAgainstWhidbey(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version45));
+            SimulateCreateProjectAgainstWhidbeyInternal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version45));
         }
 
         /// <summary>
@@ -8257,7 +8257,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void SimulateCreateProjectAgainstWhidbeyWithTrailingSlash()
         {
-            SimulateCreateProjectAgainstWhidbey(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version45) + @"\");
+            SimulateCreateProjectAgainstWhidbeyInternal(ToolLocationHelper.GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version45) + @"\");
         }
 
 


### PR DESCRIPTION
This should undo all the private field name changes made by CodeFormatter on all the classes that are [Serializable]. I think the cases that would have been affected by this would be pretty rare, but we can't ship Update 1 with changes that could break compatibility. Reverting these should mitigate some of that risk.

I made the changes manually (resharper rename field searching for _ in files that contained [Serializable]).