### PR TITLE
Unify default ToolsetDefinitionLocation

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The location of the toolset definitions.
         /// </summary>
-        private ToolsetDefinitionLocations _toolsetDefinitionLocations = ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry;
+        private ToolsetDefinitionLocations _toolsetDefinitionLocations = ToolsetDefinitionLocations.Default;
 
         /// <summary>
         /// The UI culture.

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -57,7 +57,18 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Read toolset information from the current exe path
         /// </summary>
-        Local = 4
+        Local = 4,
+
+        Default = None
+#if FEATURE_SYSTEM_CONFIGURATION
+                | ConfigurationFile
+#endif
+#if FEATURE_REGISTRY_TOOLSETS
+                | Registry
+#endif
+#if !FEATURE_SYSTEM_CONFIGURATION && !FEATURE_REGISTRY_TOOLSETS
+                | Local
+#endif
     }
 
     /// <summary>
@@ -222,7 +233,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="globalProperties">The default global properties to use. May be null.</param>
         public ProjectCollection(IDictionary<string, string> globalProperties)
-            : this(globalProperties, null, ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry)
+            : this(globalProperties, null, ToolsetDefinitionLocations.Default)
         {
         }
 
@@ -1364,7 +1375,7 @@ namespace Microsoft.Build.Evaluation
             GC.SuppressFinalize(this);
         }
 
-        #region IBuildComponent Members
+#region IBuildComponent Members
 
         /// <summary>
         /// Initializes the component with the component host.
@@ -1383,7 +1394,7 @@ namespace Microsoft.Build.Evaluation
             _host = null;
         }
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Unloads a project XML root element from the cache entirely, if it is not
@@ -1791,7 +1802,7 @@ namespace Microsoft.Build.Evaluation
                 _originalLogger = originalLogger;
             }
 
-            #region IEventSource Members
+#region IEventSource Members
 
             /// <summary>
             /// The Message logging event
@@ -1863,9 +1874,9 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public event AnyEventHandler AnyEventRaised;
 
-            #endregion
+#endregion
 
-            #region ILogger Members
+#region ILogger Members
 
             /// <summary>
             /// The logger verbosity
@@ -1957,7 +1968,7 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            #endregion
+#endregion
 
             /// <summary>
             /// Registers for all of the events on the specified event source.

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/MSBuild_Tests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Build.UnitTests
             string projectContents = @"
                 <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <MSBuild Projects=` @(empty) ` />
+                        <MSBuild Projects=` @(empty) ` />
                     </Target>
                 </Project>
                 ";
@@ -197,7 +197,7 @@ namespace Microsoft.Build.UnitTests
                 "SkipNonexistentProjectsMain.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <MSBuild Projects=`this_project_does_not_exist.csproj` />
+                        <MSBuild Projects=`this_project_does_not_exist.csproj` />
                     </Target>
                 </Project>
                 ");
@@ -218,7 +218,7 @@ namespace Microsoft.Build.UnitTests
                 "SkipNonexistentProjectsMain.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <MSBuild Projects=`this_project_does_not_exist.csproj` BuildInParallel=`true`/>
+                        <MSBuild Projects=`this_project_does_not_exist.csproj` BuildInParallel=`true`/>
                     </Target>
                 </Project>
                 ");
@@ -241,7 +241,7 @@ namespace Microsoft.Build.UnitTests
                 "SkipNonexistentProjectsMain.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <MSBuild Projects=`this_project_does_not_exist.csproj;foo.csproj` SkipNonexistentProjects=`true` />
+                        <MSBuild Projects=`this_project_does_not_exist.csproj;foo.csproj` SkipNonexistentProjects=`true` />
                     </Target>
                 </Project>
                 ");
@@ -250,7 +250,7 @@ namespace Microsoft.Build.UnitTests
                 "foo.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <Message Text=`Hello from foo.csproj`/>
+                        <Message Text=`Hello from foo.csproj`/>
                     </Target>
                 </Project>
                 ");
@@ -278,7 +278,7 @@ namespace Microsoft.Build.UnitTests
                 "SkipNonexistentProjectsMain.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <MSBuild Projects=`this_project_does_not_exist.csproj;foo.csproj` SkipNonexistentProjects=`true` BuildInParallel=`true` />
+                        <MSBuild Projects=`this_project_does_not_exist.csproj;foo.csproj` SkipNonexistentProjects=`true` BuildInParallel=`true` />
                     </Target>
                 </Project>
                 ");
@@ -287,7 +287,7 @@ namespace Microsoft.Build.UnitTests
                 "foo.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <Message Text=`Hello from foo.csproj`/>
+                        <Message Text=`Hello from foo.csproj`/>
                     </Target>
                 </Project>
                 ");
@@ -311,7 +311,7 @@ namespace Microsoft.Build.UnitTests
                 "BuildingVCProjMain.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <MSBuild Projects=`blah.vcproj;foo.csproj` StopOnFirstFailure=`false` />
+                        <MSBuild Projects=`blah.vcproj;foo.csproj` StopOnFirstFailure=`false` />
                     </Target>
                 </Project>
                 ");
@@ -320,7 +320,7 @@ namespace Microsoft.Build.UnitTests
                 "foo.csproj",
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <Target Name=`t` >
-	                    <Message Text=`Hello from foo.csproj`/>
+                        <Message Text=`Hello from foo.csproj`/>
                     </Target>
                 </Project>
                 ");
@@ -330,7 +330,7 @@ namespace Microsoft.Build.UnitTests
                 @"<Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
                     <NotWellFormedMSBuildFormatTag />
                     <Target Name=`t` >
-	                    <Message Text=`Hello from blah.vcproj`/>
+                        <Message Text=`Hello from blah.vcproj`/>
                     </Target>
                 </Project>
                 ");
@@ -1209,7 +1209,7 @@ namespace Microsoft.Build.UnitTests
                         </Project>";
 
                     MockLogger logger = new MockLogger();
-                    ProjectCollection pc = new ProjectCollection(null, new List<ILogger> { logger }, null, ToolsetDefinitionLocations.Registry | ToolsetDefinitionLocations.ConfigurationFile, 2, false);
+                    ProjectCollection pc = new ProjectCollection(null, new List<ILogger> { logger }, null, ToolsetDefinitionLocations.Default, 2, false);
                     Project p = ObjectModelHelpers.CreateInMemoryProject(pc, parentProjectContents, logger);
                     bool success = p.Build();
                     switch (i)
@@ -1303,7 +1303,7 @@ namespace Microsoft.Build.UnitTests
                 </Project>";
 
                 MockLogger logger = new MockLogger();
-                ProjectCollection pc = new ProjectCollection(null, new List<ILogger> { logger }, null, ToolsetDefinitionLocations.Registry | ToolsetDefinitionLocations.ConfigurationFile, 2, false);
+                ProjectCollection pc = new ProjectCollection(null, new List<ILogger> { logger }, null, ToolsetDefinitionLocations.Default, 2, false);
                 Project p = ObjectModelHelpers.CreateInMemoryProject(pc, parentProjectContents, logger);
                 bool success = p.Build();
 

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
@@ -1045,7 +1045,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             // Verifications
@@ -1388,7 +1388,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal(1, values.Count);
@@ -2002,7 +2002,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal(1, values.Count);
@@ -2048,7 +2048,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal(1, values.Count);
@@ -2098,7 +2098,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal(1, values.Count);
@@ -2183,7 +2183,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal(1, values.Count);
@@ -2215,7 +2215,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal(1, values.Count);
@@ -2240,7 +2240,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             // Should either be the last-ditch 2.0 toolset, or if 2.0 is not installed, then the last-last-ditch of 4.0
@@ -2283,7 +2283,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                            new ProjectCollection().EnvironmentProperties,
                                new PropertyDictionary<ProjectPropertyInstance>(),
-                               ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                               ToolsetDefinitionLocations.Default
                            );
             }
            );
@@ -2324,7 +2324,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                                new PropertyDictionary<ProjectPropertyInstance>(),
-                                                               ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                               ToolsetDefinitionLocations.Default
                                                            );
             });
         }
@@ -2375,7 +2375,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("5.0", defaultToolsVersion);
@@ -2420,7 +2420,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("4.0", defaultToolsVersion);
@@ -2470,7 +2470,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("4.0", defaultToolsVersion);
@@ -2519,7 +2519,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("13.0", values["4.0"].DefaultOverrideToolsVersion);
@@ -2559,7 +2559,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
 
@@ -2601,7 +2601,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
 
@@ -2643,7 +2643,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("5.0", defaultToolsVersion);
@@ -2685,7 +2685,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new PropertyDictionary<ProjectPropertyInstance>(),
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             string expectedDefault = "2.0";
@@ -2733,7 +2733,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new ProjectCollection().GlobalPropertiesCollection,
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("v1", values["4.0"].Properties["p1"].EvaluatedValue);
@@ -2783,7 +2783,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            new ProjectCollection().EnvironmentProperties,
                                                            new ProjectCollection().GlobalPropertiesCollection,
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("Microsoft.NET", values["4.0"].Properties["p1"].EvaluatedValue);
@@ -2835,7 +2835,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
                                                            e.EnvironmentProperties,
                                                            e.GlobalPropertiesCollection,
-                                                           ToolsetDefinitionLocations.ConfigurationFile | ToolsetDefinitionLocations.Registry
+                                                           ToolsetDefinitionLocations.Default
                                                        );
 
             Assert.Equal("gv1", values["4.0"].Properties["p1"].EvaluatedValue);

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// Verify Exist condition used in Import or ImportGroup elements will succeed when in-memory project is available inside projectCollection. 
         /// </summary>
         [Fact]
-        public void VerifyExistsInMemoryProjecs()
+        public void VerifyExistsInMemoryProjects()
         {
-            string fooPath = NativeMethodsShared.IsWindows ? "c:\temp\foo.import" : "/temp/foo.import";
-            string barPath = NativeMethodsShared.IsWindows ? "c:\temp\bar.import" : "/temp/bar.import";
+            string fooPath = NativeMethodsShared.IsWindows ? @"c:\temp\foo.import" : "/temp/foo.import";
+            string barPath = NativeMethodsShared.IsWindows ? @"c:\temp\bar.import" : "/temp/bar.import";
             string projXml = ObjectModelHelpers.CleanupFileContents(@"
                                 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns='msbuildnamespace' >
                                     <Import Project=""" + fooPath + @""" Condition=""Exists('" + fooPath + @"')""/>

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -956,16 +956,7 @@ namespace Microsoft.Build.CommandLine
                     }
                 }
 
-                ToolsetDefinitionLocations toolsetDefinitionLocations = ToolsetDefinitionLocations.None;
-#if FEATURE_SYSTEM_CONFIGURATION
-                toolsetDefinitionLocations |= ToolsetDefinitionLocations.ConfigurationFile;
-#endif
-#if FEATURE_REGISTRY_TOOLSETS
-                toolsetDefinitionLocations |= ToolsetDefinitionLocations.Registry;
-#endif
-#if !FEATURE_SYSTEM_CONFIGURATION && !FEATURE_REGISTRY_TOOLSETS
-                toolsetDefinitionLocations |= ToolsetDefinitionLocations.Local;
-#endif
+                ToolsetDefinitionLocations toolsetDefinitionLocations = ToolsetDefinitionLocations.Default;
 
                 projectCollection = new ProjectCollection
                         (


### PR DESCRIPTION
Previously, the "default" ToolsetDefinitionLocation settings were scattered across the tree as Registry | ConfigurationFile (or vice-versa).  Unifying those into a build-in enum member gives us a nice way to centralize changes . . .

Which we want to do for netcore, because netcore does not support reading from the registry (doesn't exist cross-platform) or the configuration file (netcore doesn't support those APIs).  This was aready done in xmake.cs, but that change didn't affect unit tests, many of which were failing because they couldn't find the current toolset version (14.1) in the registry--where they didn't need to be looking!