### PR TITLE
Port various tasks to .NET Core

### DIFF
--- a/Samples/NetCoreCompileTest/NetCoreCompileTest.csproj
+++ b/Samples/NetCoreCompileTest/NetCoreCompileTest.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"                       AssemblyFile="Microsoft.Build.Tasks.CodeAnalysis.dll" />
-  <Target Name="Build">
+  <!--<Import Project="$(MSBuildToolsPath)\Microsoft.Common.tasks" />-->
+  <!--<Target Name="Build">
     <Message Text="Hello World!"/>
-    <!-- UseSharedCompilation="true" - requires System.Security.Cryptography.Hashing.Algorithms, and updates to BuildClient.CheckPipeConnectionOwnership in Roslyn tasks -->
+    --><!-- UseSharedCompilation="true" - requires System.Security.Cryptography.Hashing.Algorithms, and updates to BuildClient.CheckPipeConnectionOwnership in Roslyn tasks --><!--
     <Csc
       Sources="@(Compile)"
       />
-  </Target>
-  <!--<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />-->
+  </Target>-->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -57,7 +57,7 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
-  <!--<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />-->
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Samples/PortableTask/project.json
+++ b/Samples/PortableTask/project.json
@@ -7,9 +7,11 @@
     "net46": { },
     "dnxcore50": {
       "dependencies": {
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "Microsoft.NETCore": "5.0.0",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.0"
-      }
+      },
+      "imports": "portable-net451+win81"
     }
   }
 }

--- a/Samples/PortableTask/project.lock.json
+++ b/Samples/PortableTask/project.lock.json
@@ -3,26 +3,28 @@
   "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5.1": {},
+    ".NETFramework,Version=v4.5.1/win7-x86": {},
     ".NETFramework,Version=v4.6": {},
+    ".NETFramework,Version=v4.6/win7-x86": {},
     "DNXCore,Version=v5.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -34,6 +36,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -58,8 +61,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -86,8 +89,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -129,29 +131,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -162,30 +164,30 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {},
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -208,13 +210,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -247,15 +249,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -266,13 +268,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -284,12 +286,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -311,16 +313,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -332,9 +334,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -346,15 +348,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -387,25 +389,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -416,8 +418,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -439,13 +441,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -467,20 +469,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -502,8 +504,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -514,11 +516,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -542,15 +544,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -561,14 +563,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -579,19 +581,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -613,13 +615,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -630,10 +632,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -645,21 +647,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -670,16 +672,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -690,13 +692,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -707,21 +709,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -751,9 +753,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -765,10 +767,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -780,25 +782,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -817,9 +819,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -830,13 +832,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -848,11 +850,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -863,9 +865,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -876,8 +878,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -886,28 +888,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -923,8 +912,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -935,9 +924,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -981,9 +970,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -995,8 +984,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -1007,9 +996,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1021,14 +1010,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1039,11 +1028,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -1065,10 +1054,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1104,10 +1093,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1155,17 +1144,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1176,14 +1165,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -1228,20 +1217,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1252,17 +1241,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1273,16 +1262,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1293,15 +1282,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -1312,16 +1301,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -1331,27 +1320,25 @@
         }
       }
     },
-    ".NETFramework,Version=v4.5.1/win7-x86": {},
-    ".NETFramework,Version=v4.6/win7-x86": {},
     "DNXCore,Version=v5.0/win7-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -1363,6 +1350,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -1387,8 +1375,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -1415,8 +1403,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -1458,29 +1445,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1500,8 +1487,8 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
@@ -1514,8 +1501,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1578,13 +1565,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1638,22 +1625,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -1676,13 +1663,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -1715,15 +1702,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1734,13 +1721,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -1752,12 +1739,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1779,16 +1766,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1800,9 +1787,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -1814,15 +1801,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -1855,25 +1842,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -1884,8 +1871,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -1907,13 +1894,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -1935,20 +1922,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -1970,8 +1957,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -1982,11 +1969,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2010,15 +1997,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -2034,14 +2021,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2052,19 +2039,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2086,13 +2073,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2103,10 +2090,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2118,21 +2105,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2143,16 +2130,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -2163,13 +2150,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -2180,21 +2167,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -2227,9 +2214,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2241,10 +2228,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2256,25 +2243,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -2293,9 +2280,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2306,13 +2293,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2324,11 +2311,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2339,9 +2326,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2353,9 +2340,9 @@
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
           "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2366,8 +2353,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -2376,28 +2363,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2413,8 +2387,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2425,9 +2399,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -2471,9 +2445,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -2485,8 +2459,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -2497,9 +2471,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2511,14 +2485,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2529,11 +2503,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -2555,10 +2529,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2594,10 +2568,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2645,17 +2619,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -2666,14 +2640,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -2718,20 +2692,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -2742,17 +2716,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -2763,16 +2737,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -2783,15 +2757,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -2802,16 +2776,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -2827,83 +2801,71 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.CSharp.nuspec",
         "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
-        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "Microsoft.CSharp.nuspec",
+        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
         "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
-        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
+        "_._",
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
-        "_._",
-        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp",
-        "[Content_Types].xml"
+        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
-        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
-        "lib/netcore50/System.Net.dll",
-        "lib/netcore50/System.Numerics.dll",
-        "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
-        "lib/netcore50/System.ServiceModel.Web.dll",
-        "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
-        "lib/netcore50/System.Xml.Linq.dll",
-        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.dll",
@@ -2917,9 +2879,23 @@
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "lib/netcore50/System.Core.dll",
+        "lib/netcore50/System.dll",
+        "lib/netcore50/System.Net.dll",
+        "lib/netcore50/System.Numerics.dll",
+        "lib/netcore50/System.Runtime.Serialization.dll",
+        "lib/netcore50/System.ServiceModel.dll",
+        "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.Windows.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.Xml.Linq.dll",
+        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
+        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
         "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
@@ -2933,21 +2909,7 @@
         "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
-        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
-        "runtimes/aot/lib/netcore50/System.Net.dll",
-        "runtimes/aot/lib/netcore50/System.Numerics.dll",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
-        "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -2961,85 +2923,100 @@
         "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/aot/lib/netcore50/mscorlib.dll",
+        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "runtimes/aot/lib/netcore50/System.Core.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/System.Net.dll",
+        "runtimes/aot/lib/netcore50/System.Numerics.dll",
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.Windows.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
+        "ref/dotnet/_._",
+        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
         "runtimes/win7-x86/native/dbgshim.dll",
         "runtimes/win7-x86/native/mscordaccore.dll",
         "runtimes/win7-x86/native/mscordbi.dll",
         "runtimes/win7-x86/native/mscorrc.debug.dll",
-        "runtimes/win7-x86/native/mscorrc.dll",
-        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
-        "ref/dotnet/_._",
-        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/4.9.0": {
       "sha512": "32pNFQTn/nVB15hYIztKn1Ij05ibGn8C9CfOiENbc+GbzxWWQQztDyWhS/vGzUcrFFZpcXbJ0yGHem2syNHMwQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/49a06ab6e27f4682b9b0c258f69b4fe2.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {
       "sha512": "hLIFc0enPvCCOt1pXl3etWtkhvB+lb8qcjxWM39Jk9n8UTLvIH4lwzFbTv6Tij3LYmNbToTKEPKYmx3TfjUevw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
-        "runtimes/win7-x86/native/CoreRun.exe",
         "package/services/metadata/core-properties/71ad7e2008a84dfdb75618cb7527719a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
+        "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -3102,13 +3079,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -3158,6 +3135,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -3172,8 +3157,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -3183,2407 +3168,2395 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
-        "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
-        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "Microsoft.VisualBasic.nuspec",
+        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
-        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
-        "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
-        "[Content_Types].xml"
+        "ref/win8/_._",
+        "ref/wpa81/_._"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
-        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "Microsoft.Win32.Primitives.nuspec",
+        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
-        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.Win32.Registry/4.0.0-beta-23123": {
       "sha512": "uDHpWnfXuynO2QyCsQbUjK3u6WZGXiiMOfHtFJ83Mkt/M3EtMeA6z3N/eHMnR9qBdfTAFon9yelVmwRBXXU1nQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Registry.nuspec",
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "Microsoft.Win32.Registry.nuspec",
+        "package/services/metadata/core-properties/a3c99102d20347a1b22da1fd42a907b4.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
         "ref/dotnet/fr/Microsoft.Win32.Registry.xml",
         "ref/dotnet/it/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ja/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ru/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
-        "ref/net46/Microsoft.Win32.Registry.dll",
-        "package/services/metadata/core-properties/a3c99102d20347a1b22da1fd42a907b4.psmdcp",
-        "[Content_Types].xml"
+        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.AppContext.nuspec",
-        "lib/netcore50/System.AppContext.dll",
         "lib/DNXCore50/System.AppContext.dll",
-        "lib/net46/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
-        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
         "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
         "ref/dotnet/it/System.AppContext.xml",
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
-        "ref/dotnet/es/System.AppContext.xml",
-        "ref/net46/System.AppContext.dll",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
-        "[Content_Types].xml"
+        "System.AppContext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.nuspec",
-        "lib/netcore50/System.Collections.dll",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
-        "ref/dotnet/zh-hant/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
         "ref/dotnet/it/System.Collections.xml",
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
-        "ref/dotnet/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
         "ref/dotnet/it/System.Collections.Concurrent.xml",
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
-        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
-        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
         "ref/dotnet/it/System.Collections.NonGeneric.xml",
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet/es/System.Collections.NonGeneric.xml",
-        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
         "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
         "ref/dotnet/it/System.ComponentModel.xml",
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
-        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.ComponentModel.dll",
         "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
         "ref/dotnet/it/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.Annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
     "System.Console/4.0.0-beta-23123": {
       "sha512": "fPglodP4GQV7HBBDhmCZaCD8fzBvhtHmBmiN/8yWiJz0NNnA55YUNBh3myvR2DP/6IOHJ75/tTRkvwdpX3BWXA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
-        "lib/net46/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
-        "ref/dotnet/zh-hant/System.Console.xml",
+        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
         "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
         "ref/dotnet/it/System.Console.xml",
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
-        "ref/dotnet/es/System.Console.xml",
-        "ref/net46/System.Console.dll",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
-        "[Content_Types].xml"
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Contracts.nuspec",
-        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
         "ref/dotnet/it/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Contracts.dll",
         "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
-        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
         "ref/dotnet/it/System.Diagnostics.Debug.xml",
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
-        "ref/dotnet/es/System.Diagnostics.Debug.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
     "System.Diagnostics.Process/4.0.0-beta-23123": {
       "sha512": "EUeT1XD9Nmnn4gIhEu1tA7/7RtWlQOIt7ZdETDScQoAYbLUtcY1Zc5Qy6B7+YbKnyqS8TIdGe/fxDEa0EDTsjA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Process.nuspec",
         "lib/DNXCore50/System.Diagnostics.Process.dll",
-        "lib/net46/System.Diagnostics.Process.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Process.dll",
-        "ref/dotnet/System.Diagnostics.Process.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
+        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Process.xml",
+        "ref/dotnet/es/System.Diagnostics.Process.xml",
         "ref/dotnet/fr/System.Diagnostics.Process.xml",
         "ref/dotnet/it/System.Diagnostics.Process.xml",
         "ref/dotnet/ja/System.Diagnostics.Process.xml",
         "ref/dotnet/ko/System.Diagnostics.Process.xml",
         "ref/dotnet/ru/System.Diagnostics.Process.xml",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/dotnet/System.Diagnostics.Process.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Process.xml",
-        "ref/dotnet/es/System.Diagnostics.Process.xml",
-        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.Process.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
-        "lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "lib/net46/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
+        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/it/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
         "ref/dotnet/it/System.Diagnostics.Tools.xml",
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
-        "ref/dotnet/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
         "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
       "sha512": "MZxMo9Skg9oZrJYwGpRfeOfrTfHxmTPWhj8XIXdIryfArzwG1FjZgzOrkWWcON0PdV9OywZYGly09nUCs/JdhA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.TraceSource.nuspec",
         "lib/DNXCore50/System.Diagnostics.TraceSource.dll",
         "lib/net46/System.Diagnostics.TraceSource.dll",
+        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
         "ref/dotnet/System.Diagnostics.TraceSource.dll",
         "ref/net46/System.Diagnostics.TraceSource.dll",
-        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.TraceSource.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tracing.nuspec",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
         "ref/dotnet/it/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Dynamic.Runtime.nuspec",
-        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
         "ref/dotnet/it/System.Dynamic.Runtime.xml",
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
-        "ref/dotnet/es/System.Dynamic.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "System.Dynamic.Runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.nuspec",
-        "lib/netcore50/System.Globalization.dll",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
-        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
         "ref/dotnet/it/System.Globalization.xml",
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
-        "ref/dotnet/es/System.Globalization.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Calendars.nuspec",
-        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
-        "lib/net46/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
         "ref/dotnet/it/System.Globalization.Calendars.xml",
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet/es/System.Globalization.Calendars.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
-        "lib/net46/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
         "ref/dotnet/it/System.Globalization.Extensions.xml",
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet/es/System.Globalization.Extensions.xml",
-        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
-        "[Content_Types].xml"
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.nuspec",
-        "lib/netcore50/System.IO.dll",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
-        "ref/dotnet/zh-hant/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
         "ref/dotnet/it/System.IO.xml",
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
-        "ref/dotnet/es/System.IO.xml",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
         "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
         "ref/dotnet/it/System.IO.Compression.xml",
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
-        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.clrcompression-x86.nuspec",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "runtimes/win10-x86/native/ClrCompression.dll",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win10-x86/native/ClrCompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "System.IO.Compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
-        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
-        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.ZipFile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
-        "lib/netcore50/System.IO.FileSystem.dll",
-        "lib/net46/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
         "ref/dotnet/it/System.IO.FileSystem.xml",
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
-        "ref/dotnet/es/System.IO.FileSystem.xml",
-        "ref/net46/System.IO.FileSystem.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
-        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
-        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
         "ref/dotnet/it/System.Linq.xml",
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.dll",
         "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Expressions.nuspec",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
-        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
         "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
         "ref/dotnet/it/System.Linq.Expressions.xml",
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
-        "ref/dotnet/es/System.Linq.Expressions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
         "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
         "ref/dotnet/it/System.Linq.Parallel.xml",
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
-        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
-        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
         "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
         "ref/dotnet/it/System.Linq.Queryable.xml",
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
-        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Queryable.dll",
         "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Http.nuspec",
-        "lib/netcore50/System.Net.Http.dll",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
-        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
         "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
         "ref/dotnet/it/System.Net.Http.xml",
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
-        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Http.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
-        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.10-beta-23123": {
       "sha512": "NkKpsUm2MLoxT+YlSwexidAw2jGFIJuc6i4H9pT3nU3TQj7MZVursD/ohWj3nyBxthy7i00XLWkRZAwGao/zsg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Primitives.nuspec",
-        "lib/netcore50/System.Net.Primitives.dll",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
         "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
         "ref/dotnet/it/System.Net.Primitives.xml",
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
-        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Primitives.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Numerics.Vectors.nuspec",
         "lib/dotnet/System.Numerics.Vectors.dll",
-        "lib/net46/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
         "ref/dotnet/System.Numerics.Vectors.dll",
-        "ref/net46/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "[Content_Types].xml"
+        "System.Numerics.Vectors.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
-        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
         "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
         "ref/dotnet/it/System.ObjectModel.xml",
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
-        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
-        "[Content_Types].xml"
+        "System.ObjectModel.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Networking.nuspec",
-        "lib/netcore50/System.Private.Networking.dll",
         "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Networking.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Uri.nuspec",
-        "lib/netcore50/System.Private.Uri.dll",
         "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.nuspec",
-        "lib/netcore50/System.Reflection.dll",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
-        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
         "ref/dotnet/it/System.Reflection.xml",
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
-        "ref/dotnet/es/System.Reflection.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.DispatchProxy.nuspec",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
-        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
         "ref/dotnet/it/System.Reflection.Emit.xml",
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
-        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
-        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
-        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Extensions.nuspec",
-        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
         "ref/dotnet/it/System.Reflection.Extensions.xml",
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
-        "ref/dotnet/es/System.Reflection.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Extensions.dll",
         "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Metadata.nuspec",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Primitives.nuspec",
-        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
         "ref/dotnet/it/System.Reflection.Primitives.xml",
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
-        "ref/dotnet/es/System.Reflection.Primitives.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.TypeExtensions.nuspec",
-        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
-        "lib/net46/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Resources.ResourceManager.nuspec",
-        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
-        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
         "ref/dotnet/it/System.Resources.ResourceManager.xml",
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
-        "ref/dotnet/es/System.Resources.ResourceManager.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Resources.ResourceManager.dll",
         "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.nuspec",
-        "lib/netcore50/System.Runtime.dll",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
         "ref/dotnet/it/System.Runtime.xml",
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
-        "ref/dotnet/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Extensions.nuspec",
-        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
         "ref/dotnet/it/System.Runtime.Extensions.xml",
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
-        "ref/dotnet/es/System.Runtime.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
-        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
         "ref/dotnet/it/System.Runtime.Handles.xml",
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
-        "ref/dotnet/es/System.Runtime.Handles.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
-        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
-        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
         "ref/dotnet/it/System.Runtime.InteropServices.xml",
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
-        "ref/dotnet/es/System.Runtime.InteropServices.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
       "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
         "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
         "ref/dotnet/it/System.Runtime.Numerics.xml",
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
-        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.Numerics.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/net46/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
         "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
         "ref/dotnet/it/System.Security.Claims.xml",
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/net46/System.Security.Claims.dll",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Claims.nuspec"
       ]
     },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Cryptography.Encryption.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
-        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
-        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
+        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
         "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/it/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
-        "ref/net46/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encryption.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Cryptography.Encryption.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
-        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
         "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
         "ref/dotnet/it/System.Security.Principal.xml",
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
-        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Principal.nuspec"
       ]
     },
     "System.Security.SecureString/4.0.0-beta-23123": {
       "sha512": "T35YL/7zWBYOLJCcntF+bQgZBgOy5qc6oPn4GWL1phv0borJawTL60iwk4MO2ReYYSK89JmJ7/yqKahqYNw72g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.SecureString.nuspec",
         "lib/DNXCore50/System.Security.SecureString.dll",
-        "lib/net46/System.Security.SecureString.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.SecureString.dll",
-        "ref/dotnet/System.Security.SecureString.xml",
-        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
         "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
         "ref/dotnet/fr/System.Security.SecureString.xml",
         "ref/dotnet/it/System.Security.SecureString.xml",
         "ref/dotnet/ja/System.Security.SecureString.xml",
         "ref/dotnet/ko/System.Security.SecureString.xml",
         "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/zh-hans/System.Security.SecureString.xml",
-        "ref/dotnet/es/System.Security.SecureString.xml",
-        "ref/net46/System.Security.SecureString.dll",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.nuspec",
-        "lib/netcore50/System.Text.Encoding.dll",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
         "ref/dotnet/it/System.Text.Encoding.xml",
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
-        "ref/dotnet/es/System.Text.Encoding.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.Extensions.nuspec",
-        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
-        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
         "ref/dotnet/it/System.Text.RegularExpressions.xml",
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
-        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
-        "[Content_Types].xml"
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
-        "lib/netcore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
-        "ref/dotnet/zh-hant/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
         "ref/dotnet/it/System.Threading.xml",
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
-        "ref/dotnet/es/System.Threading.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Overlapped.nuspec",
-        "lib/netcore50/System.Threading.Overlapped.dll",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
-        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
         "ref/dotnet/it/System.Threading.Overlapped.xml",
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
-        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.nuspec",
-        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
         "ref/dotnet/it/System.Threading.Tasks.xml",
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
-        "ref/dotnet/es/System.Threading.Tasks.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
     "System.Threading.Thread/4.0.0-beta-23123": {
       "sha512": "qu18HhV/xvNSqh3KjY5olJnVN4dJI2FoPB/BQ7vyDbvSJUEhemUmwuNGAx4TpyO4aBdbGCcLxVkWQIo30yxbeQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Thread.nuspec",
         "lib/DNXCore50/System.Threading.Thread.dll",
-        "lib/net46/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.xml",
-        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
+        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
         "ref/dotnet/de/System.Threading.Thread.xml",
+        "ref/dotnet/es/System.Threading.Thread.xml",
         "ref/dotnet/fr/System.Threading.Thread.xml",
         "ref/dotnet/it/System.Threading.Thread.xml",
         "ref/dotnet/ja/System.Threading.Thread.xml",
         "ref/dotnet/ko/System.Threading.Thread.xml",
         "ref/dotnet/ru/System.Threading.Thread.xml",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/dotnet/System.Threading.Thread.xml",
         "ref/dotnet/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet/es/System.Threading.Thread.xml",
-        "ref/net46/System.Threading.Thread.dll",
+        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Thread.nuspec"
       ]
     },
     "System.Threading.ThreadPool/4.0.10-beta-23123": {
       "sha512": "v3gETuR6Z96CPmZrM7260+MK2eFP8wVm4VcaSH3HDEqIHCByWDWOfY7C80TUdtXshnITcUeIoSU/C6rLwKoiVg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.ThreadPool.nuspec",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/dotnet/System.Threading.ThreadPool.xml",
-        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
         "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
         "ref/dotnet/fr/System.Threading.ThreadPool.xml",
         "ref/dotnet/it/System.Threading.ThreadPool.xml",
         "ref/dotnet/ja/System.Threading.ThreadPool.xml",
         "ref/dotnet/ko/System.Threading.ThreadPool.xml",
         "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet/es/System.Threading.ThreadPool.xml",
-        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Timer.nuspec",
-        "lib/netcore50/System.Threading.Timer.dll",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
-        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
         "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
         "ref/dotnet/it/System.Threading.Timer.xml",
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
-        "ref/dotnet/es/System.Threading.Timer.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
-        "ref/win81/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
         "ref/dotnet/it/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XDocument.nuspec",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
         "ref/dotnet/it/System.Xml.XDocument.xml",
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XDocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XmlDocument.dll",
-        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XmlDocument.xml",
-        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XmlDocument.nuspec"
       ]
     },
     "System.Xml.XPath/4.0.0": {
       "sha512": "jalVwhZSwErcW28NZOE3Dqb6B1XA4DAsL15JvykYIKXtXYQU8PI5GXssjF5G0bLm8/6Gko2e1SOjRs/MoeAKrw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.nuspec",
         "lib/dotnet/System.Xml.XPath.dll",
-        "lib/net46/System.Xml.XPath.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XPath.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.dll",
-        "ref/dotnet/System.Xml.XPath.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
+        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.xml",
+        "ref/dotnet/es/System.Xml.XPath.xml",
         "ref/dotnet/fr/System.Xml.XPath.xml",
         "ref/dotnet/it/System.Xml.XPath.xml",
         "ref/dotnet/ja/System.Xml.XPath.xml",
         "ref/dotnet/ko/System.Xml.XPath.xml",
         "ref/dotnet/ru/System.Xml.XPath.xml",
+        "ref/dotnet/System.Xml.XPath.dll",
+        "ref/dotnet/System.Xml.XPath.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.xml",
-        "ref/dotnet/es/System.Xml.XPath.xml",
-        "ref/net46/System.Xml.XPath.dll",
+        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XPath.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.nuspec"
       ]
     },
     "System.Xml.XPath.XmlDocument/4.0.0": {
       "sha512": "toGFsezsdAJ3Fkau0l386iGBg3qfYauQrM4haX1nWPYnUOWb0hXfAEVIi47/Ke4ET3gl9h9ZppKiws8QWeJVyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XPath.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
+        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.XmlDocument.nuspec"
       ]
     }
   },
@@ -5593,7 +5566,8 @@
     ".NETFramework,Version=v4.6": [],
     "DNXCore,Version=v5.0": [
       "Microsoft.NETCore >= 5.0.0",
-      "Microsoft.NETCore.Portable.Compatibility >= 1.0.0"
+      "Microsoft.NETCore.Portable.Compatibility >= 1.0.0",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014"
     ]
   }
 }

--- a/dir.props
+++ b/dir.props
@@ -154,6 +154,10 @@
     <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
     <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
     <NetCoreSurface>true</NetCoreSurface>
+
+    <!-- Setting this to false stops the AppX targets, which aren't supported on .NET Core, from beeing imported -->
+    <WindowsAppContainer>false</WindowsAppContainer>
+    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreSurface)' != 'true'">
@@ -189,6 +193,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PARALLEL_BUILD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PERFORMANCE_COUNTERS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_PFX_SIGNING</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REFLECTION_EMIT_DEBUG_INFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRY_TOOLSETS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRYHIVE_DYNDATA</DefineConstants>

--- a/dir.props
+++ b/dir.props
@@ -178,6 +178,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_ENCODING_DEFAULT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ENVIRONMENT_SYSTEMDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_FILE_TRACKER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_FUSION_COMPAREASSEMBLYIDENTITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_GAC</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_GET_COMMANDLINE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HANDLE_SAFEWAITHANDLE</DefineConstants>

--- a/src/Framework/UnitTests/project.json
+++ b/src/Framework/UnitTests/project.json
@@ -20,6 +20,7 @@
         "Microsoft.NETCore": "5.0.0",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
         "System.Console": "4.0.0-beta-23123",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Runtime": "4.0.20",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
         "Microsoft.NETCore.Runtime": "1.0.0",

--- a/src/Framework/UnitTests/project.lock.json
+++ b/src/Framework/UnitTests/project.lock.json
@@ -1029,28 +1029,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2494,28 +2481,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -4767,17 +4741,16 @@
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
         "System.Reflection.Metadata.nuspec"
       ]
     },
@@ -5669,6 +5642,7 @@
       "Microsoft.NETCore.Runtime >= 1.0.0",
       "Microsoft.NETCore.TestHost >= 1.0.0-beta-23318",
       "System.Console >= 4.0.0-beta-23123",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
       "System.Runtime >= 4.0.20",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "xunit.console.netcore >= 1.0.2-prerelease-00096"

--- a/src/Framework/project.json
+++ b/src/Framework/project.json
@@ -13,6 +13,7 @@
         "Microsoft.NETCore": "5.0.0",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
         "System.Console": "4.0.0-beta-23123",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Threading.Thread": "4.0.0-beta-23109",
         "Microsoft.NETCore.Runtime": "1.0.0",
         "Microsoft.NETCore.TestHost-x86": "1.0.0-beta-23123"

--- a/src/Framework/project.lock.json
+++ b/src/Framework/project.lock.json
@@ -3,26 +3,28 @@
   "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5.1": {},
+    ".NETFramework,Version=v4.5.1/win7-x86": {},
     ".NETFramework,Version=v4.6": {},
+    ".NETFramework,Version=v4.6/win7-x86": {},
     "DNXCore,Version=v5.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -34,6 +36,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -58,8 +61,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -86,8 +89,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -128,30 +130,30 @@
       "Microsoft.NETCore.Runtime/1.0.0": {},
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {},
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -196,15 +198,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -215,13 +217,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -233,12 +235,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -260,16 +262,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -281,9 +283,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -295,15 +297,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -347,20 +349,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -382,8 +384,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -394,11 +396,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -422,15 +424,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -441,14 +443,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -459,19 +461,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -493,13 +495,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -510,10 +512,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -525,21 +527,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -550,16 +552,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -570,13 +572,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -587,21 +589,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -631,9 +633,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -645,10 +647,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -660,25 +662,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -697,9 +699,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -710,13 +712,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -728,11 +730,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -743,9 +745,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -756,8 +758,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -766,28 +768,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -803,8 +792,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -815,9 +804,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -861,9 +850,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -875,9 +864,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -889,14 +878,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -941,10 +930,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -992,17 +981,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1013,14 +1002,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -1053,20 +1042,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1077,17 +1066,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1097,27 +1086,25 @@
         }
       }
     },
-    ".NETFramework,Version=v4.5.1/win7-x86": {},
-    ".NETFramework,Version=v4.6/win7-x86": {},
     "DNXCore,Version=v5.0/win7-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -1129,6 +1116,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -1153,8 +1141,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -1181,8 +1169,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -1224,29 +1211,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1266,8 +1253,8 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
@@ -1280,8 +1267,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1344,13 +1331,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1404,22 +1391,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -1464,15 +1451,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1483,13 +1470,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -1501,12 +1488,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1528,16 +1515,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1549,9 +1536,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -1563,15 +1550,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -1604,8 +1591,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -1638,20 +1625,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -1673,8 +1660,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -1685,11 +1672,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -1713,15 +1700,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -1737,14 +1724,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -1755,19 +1742,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -1789,13 +1776,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -1806,10 +1793,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1821,21 +1808,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -1846,16 +1833,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -1866,13 +1853,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -1883,21 +1870,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -1930,9 +1917,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1944,10 +1931,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1959,25 +1946,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1996,9 +1983,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2009,13 +1996,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2027,11 +2014,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2042,9 +2029,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2056,9 +2043,9 @@
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
           "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2069,8 +2056,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -2079,28 +2066,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2116,8 +2090,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2128,9 +2102,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -2174,9 +2148,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -2188,9 +2162,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2202,14 +2176,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2254,10 +2228,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2305,17 +2279,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -2326,14 +2300,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -2366,20 +2340,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -2390,17 +2364,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -2416,83 +2390,71 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.CSharp.nuspec",
         "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
-        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "Microsoft.CSharp.nuspec",
+        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
         "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
-        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
+        "_._",
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
-        "_._",
-        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp",
-        "[Content_Types].xml"
+        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
-        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
-        "lib/netcore50/System.Net.dll",
-        "lib/netcore50/System.Numerics.dll",
-        "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
-        "lib/netcore50/System.ServiceModel.Web.dll",
-        "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
-        "lib/netcore50/System.Xml.Linq.dll",
-        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.dll",
@@ -2506,9 +2468,23 @@
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "lib/netcore50/System.Core.dll",
+        "lib/netcore50/System.dll",
+        "lib/netcore50/System.Net.dll",
+        "lib/netcore50/System.Numerics.dll",
+        "lib/netcore50/System.Runtime.Serialization.dll",
+        "lib/netcore50/System.ServiceModel.dll",
+        "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.Windows.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.Xml.Linq.dll",
+        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
+        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
         "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
@@ -2522,21 +2498,7 @@
         "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
-        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
-        "runtimes/aot/lib/netcore50/System.Net.dll",
-        "runtimes/aot/lib/netcore50/System.Numerics.dll",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
-        "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -2550,85 +2512,100 @@
         "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/aot/lib/netcore50/mscorlib.dll",
+        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "runtimes/aot/lib/netcore50/System.Core.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/System.Net.dll",
+        "runtimes/aot/lib/netcore50/System.Numerics.dll",
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.Windows.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
+        "ref/dotnet/_._",
+        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
         "runtimes/win7-x86/native/dbgshim.dll",
         "runtimes/win7-x86/native/mscordaccore.dll",
         "runtimes/win7-x86/native/mscordbi.dll",
         "runtimes/win7-x86/native/mscorrc.debug.dll",
-        "runtimes/win7-x86/native/mscorrc.dll",
-        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
-        "ref/dotnet/_._",
-        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/4.9.0": {
       "sha512": "32pNFQTn/nVB15hYIztKn1Ij05ibGn8C9CfOiENbc+GbzxWWQQztDyWhS/vGzUcrFFZpcXbJ0yGHem2syNHMwQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/49a06ab6e27f4682b9b0c258f69b4fe2.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {
       "sha512": "hLIFc0enPvCCOt1pXl3etWtkhvB+lb8qcjxWM39Jk9n8UTLvIH4lwzFbTv6Tij3LYmNbToTKEPKYmx3TfjUevw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
-        "runtimes/win7-x86/native/CoreRun.exe",
         "package/services/metadata/core-properties/71ad7e2008a84dfdb75618cb7527719a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
+        "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -2691,13 +2668,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -2747,6 +2724,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -2761,8 +2746,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -2772,2119 +2757,2107 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
-        "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
-        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "Microsoft.VisualBasic.nuspec",
+        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
-        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
-        "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
-        "[Content_Types].xml"
+        "ref/win8/_._",
+        "ref/wpa81/_._"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
-        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "Microsoft.Win32.Primitives.nuspec",
+        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
-        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.AppContext.nuspec",
-        "lib/netcore50/System.AppContext.dll",
         "lib/DNXCore50/System.AppContext.dll",
-        "lib/net46/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
-        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
         "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
         "ref/dotnet/it/System.AppContext.xml",
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
-        "ref/dotnet/es/System.AppContext.xml",
-        "ref/net46/System.AppContext.dll",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
-        "[Content_Types].xml"
+        "System.AppContext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.nuspec",
-        "lib/netcore50/System.Collections.dll",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
-        "ref/dotnet/zh-hant/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
         "ref/dotnet/it/System.Collections.xml",
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
-        "ref/dotnet/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
         "ref/dotnet/it/System.Collections.Concurrent.xml",
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
-        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
-        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
         "ref/dotnet/it/System.Collections.NonGeneric.xml",
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet/es/System.Collections.NonGeneric.xml",
-        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
         "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
         "ref/dotnet/it/System.ComponentModel.xml",
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
-        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.ComponentModel.dll",
         "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
         "ref/dotnet/it/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.Annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
     "System.Console/4.0.0-beta-23123": {
       "sha512": "fPglodP4GQV7HBBDhmCZaCD8fzBvhtHmBmiN/8yWiJz0NNnA55YUNBh3myvR2DP/6IOHJ75/tTRkvwdpX3BWXA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
-        "lib/net46/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
-        "ref/dotnet/zh-hant/System.Console.xml",
+        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
         "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
         "ref/dotnet/it/System.Console.xml",
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
-        "ref/dotnet/es/System.Console.xml",
-        "ref/net46/System.Console.dll",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
-        "[Content_Types].xml"
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Contracts.nuspec",
-        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
         "ref/dotnet/it/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Contracts.dll",
         "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
-        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
         "ref/dotnet/it/System.Diagnostics.Debug.xml",
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
-        "ref/dotnet/es/System.Diagnostics.Debug.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
-        "lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "lib/net46/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
+        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/it/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
         "ref/dotnet/it/System.Diagnostics.Tools.xml",
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
-        "ref/dotnet/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
         "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tracing.nuspec",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
         "ref/dotnet/it/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Dynamic.Runtime.nuspec",
-        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
         "ref/dotnet/it/System.Dynamic.Runtime.xml",
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
-        "ref/dotnet/es/System.Dynamic.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "System.Dynamic.Runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.nuspec",
-        "lib/netcore50/System.Globalization.dll",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
-        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
         "ref/dotnet/it/System.Globalization.xml",
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
-        "ref/dotnet/es/System.Globalization.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Calendars.nuspec",
-        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
-        "lib/net46/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
         "ref/dotnet/it/System.Globalization.Calendars.xml",
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet/es/System.Globalization.Calendars.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
-        "lib/net46/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
         "ref/dotnet/it/System.Globalization.Extensions.xml",
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet/es/System.Globalization.Extensions.xml",
-        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
-        "[Content_Types].xml"
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.nuspec",
-        "lib/netcore50/System.IO.dll",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
-        "ref/dotnet/zh-hant/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
         "ref/dotnet/it/System.IO.xml",
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
-        "ref/dotnet/es/System.IO.xml",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
         "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
         "ref/dotnet/it/System.IO.Compression.xml",
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
-        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.clrcompression-x86.nuspec",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "runtimes/win10-x86/native/ClrCompression.dll",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win10-x86/native/ClrCompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "System.IO.Compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
-        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
-        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.ZipFile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
-        "lib/netcore50/System.IO.FileSystem.dll",
-        "lib/net46/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
         "ref/dotnet/it/System.IO.FileSystem.xml",
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
-        "ref/dotnet/es/System.IO.FileSystem.xml",
-        "ref/net46/System.IO.FileSystem.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
-        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
-        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
         "ref/dotnet/it/System.Linq.xml",
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.dll",
         "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Expressions.nuspec",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
-        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
         "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
         "ref/dotnet/it/System.Linq.Expressions.xml",
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
-        "ref/dotnet/es/System.Linq.Expressions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
         "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
         "ref/dotnet/it/System.Linq.Parallel.xml",
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
-        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
-        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
         "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
         "ref/dotnet/it/System.Linq.Queryable.xml",
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
-        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Queryable.dll",
         "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Http.nuspec",
-        "lib/netcore50/System.Net.Http.dll",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
-        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
         "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
         "ref/dotnet/it/System.Net.Http.xml",
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
-        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Http.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
-        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.10-beta-23123": {
       "sha512": "NkKpsUm2MLoxT+YlSwexidAw2jGFIJuc6i4H9pT3nU3TQj7MZVursD/ohWj3nyBxthy7i00XLWkRZAwGao/zsg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Primitives.nuspec",
-        "lib/netcore50/System.Net.Primitives.dll",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
         "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
         "ref/dotnet/it/System.Net.Primitives.xml",
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
-        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Primitives.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Numerics.Vectors.nuspec",
         "lib/dotnet/System.Numerics.Vectors.dll",
-        "lib/net46/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
         "ref/dotnet/System.Numerics.Vectors.dll",
-        "ref/net46/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "[Content_Types].xml"
+        "System.Numerics.Vectors.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
-        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
         "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
         "ref/dotnet/it/System.ObjectModel.xml",
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
-        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
-        "[Content_Types].xml"
+        "System.ObjectModel.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Networking.nuspec",
-        "lib/netcore50/System.Private.Networking.dll",
         "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Networking.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Uri.nuspec",
-        "lib/netcore50/System.Private.Uri.dll",
         "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.nuspec",
-        "lib/netcore50/System.Reflection.dll",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
-        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
         "ref/dotnet/it/System.Reflection.xml",
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
-        "ref/dotnet/es/System.Reflection.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.DispatchProxy.nuspec",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
-        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
         "ref/dotnet/it/System.Reflection.Emit.xml",
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
-        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
-        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
-        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Extensions.nuspec",
-        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
         "ref/dotnet/it/System.Reflection.Extensions.xml",
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
-        "ref/dotnet/es/System.Reflection.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Extensions.dll",
         "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Metadata.nuspec",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Primitives.nuspec",
-        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
         "ref/dotnet/it/System.Reflection.Primitives.xml",
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
-        "ref/dotnet/es/System.Reflection.Primitives.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.TypeExtensions.nuspec",
-        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
-        "lib/net46/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Resources.ResourceManager.nuspec",
-        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
-        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
         "ref/dotnet/it/System.Resources.ResourceManager.xml",
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
-        "ref/dotnet/es/System.Resources.ResourceManager.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Resources.ResourceManager.dll",
         "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.nuspec",
-        "lib/netcore50/System.Runtime.dll",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
         "ref/dotnet/it/System.Runtime.xml",
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
-        "ref/dotnet/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Extensions.nuspec",
-        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
         "ref/dotnet/it/System.Runtime.Extensions.xml",
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
-        "ref/dotnet/es/System.Runtime.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
-        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
         "ref/dotnet/it/System.Runtime.Handles.xml",
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
-        "ref/dotnet/es/System.Runtime.Handles.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
-        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
-        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
         "ref/dotnet/it/System.Runtime.InteropServices.xml",
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
-        "ref/dotnet/es/System.Runtime.InteropServices.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
         "ref/dotnet/it/System.Runtime.Numerics.xml",
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
-        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.Numerics.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/net46/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
         "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
         "ref/dotnet/it/System.Security.Claims.xml",
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/net46/System.Security.Claims.dll",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Claims.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
-        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
         "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
         "ref/dotnet/it/System.Security.Principal.xml",
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
-        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Principal.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.nuspec",
-        "lib/netcore50/System.Text.Encoding.dll",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
         "ref/dotnet/it/System.Text.Encoding.xml",
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
-        "ref/dotnet/es/System.Text.Encoding.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.Extensions.nuspec",
-        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
-        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
         "ref/dotnet/it/System.Text.RegularExpressions.xml",
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
-        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
-        "[Content_Types].xml"
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
-        "lib/netcore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
-        "ref/dotnet/zh-hant/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
         "ref/dotnet/it/System.Threading.xml",
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
-        "ref/dotnet/es/System.Threading.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Overlapped.nuspec",
-        "lib/netcore50/System.Threading.Overlapped.dll",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
-        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
         "ref/dotnet/it/System.Threading.Overlapped.xml",
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
-        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.nuspec",
-        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
         "ref/dotnet/it/System.Threading.Tasks.xml",
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
-        "ref/dotnet/es/System.Threading.Tasks.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
     "System.Threading.Thread/4.0.0-beta-23109": {
       "sha512": "pOob5Fz4cRJ/bfBs2+ehmS99VGCN5Ei2mf7bl17STagcDGHUZBAzVLz8Kamq0hwQGX2pCFkuUZH+2Ycdts2PSQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Thread.nuspec",
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/net46/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.xml",
-        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
+        "package/services/metadata/core-properties/ba9a9919e2744245be86e42f4f3b93d1.psmdcp",
         "ref/dotnet/de/System.Threading.Thread.xml",
+        "ref/dotnet/es/System.Threading.Thread.xml",
         "ref/dotnet/fr/System.Threading.Thread.xml",
         "ref/dotnet/it/System.Threading.Thread.xml",
         "ref/dotnet/ja/System.Threading.Thread.xml",
         "ref/dotnet/ko/System.Threading.Thread.xml",
         "ref/dotnet/ru/System.Threading.Thread.xml",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/dotnet/System.Threading.Thread.xml",
         "ref/dotnet/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet/es/System.Threading.Thread.xml",
+        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
         "ref/net46/System.Threading.Thread.dll",
-        "package/services/metadata/core-properties/ba9a9919e2744245be86e42f4f3b93d1.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Thread.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Timer.nuspec",
-        "lib/netcore50/System.Threading.Timer.dll",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
-        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
         "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
         "ref/dotnet/it/System.Threading.Timer.xml",
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
-        "ref/dotnet/es/System.Threading.Timer.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
-        "ref/win81/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
         "ref/dotnet/it/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XDocument.nuspec",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
         "ref/dotnet/it/System.Xml.XDocument.xml",
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XDocument.nuspec"
       ]
     }
   },
@@ -4895,10 +4868,11 @@
     "DNXCore,Version=v5.0": [
       "Microsoft.NETCore >= 5.0.0",
       "Microsoft.NETCore.Portable.Compatibility >= 1.0.0",
-      "System.Console >= 4.0.0-beta-23123",
-      "System.Threading.Thread >= 4.0.0-beta-23109",
       "Microsoft.NETCore.Runtime >= 1.0.0",
-      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123"
+      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
+      "System.Console >= 4.0.0-beta-23123",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
+      "System.Threading.Thread >= 4.0.0-beta-23109"
     ]
   }
 }

--- a/src/Shared/Compat/TypeExtensions.cs
+++ b/src/Shared/Compat/TypeExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace System.Reflection
 {
@@ -7,6 +11,625 @@ namespace System.Reflection
         public static bool IsEquivalentTo(this Type type, Type other)
         {
             return type.Equals(other);
+        }
+
+        public static object InvokeMember(this Type type, string name, BindingFlags bindingFlags, object target, object[] providedArgs,
+            ParameterModifier[] modifiers, CultureInfo culture, string[] namedParams)
+        {
+            return new InvokeMemberHelper(type).InvokeMember(name, bindingFlags, target, providedArgs, modifiers, culture, namedParams);
+        }
+
+
+        class InvokeMemberHelper
+        {
+            public Type TargetType { get; private set; }
+
+            public InvokeMemberHelper(Type targetType)
+            {
+                TargetType = targetType;
+
+            }
+
+            bool IsGenericParameter { get { return TargetType.IsGenericParameter; } }
+
+            private const BindingFlags MemberBindingMask = (BindingFlags)0x000000FF;
+            private const BindingFlags InvocationMask = (BindingFlags)0x0000FF00;
+
+            //  InvokeMember code copied and modified from: https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/mscorlib/system/rttype.cs#L4562
+            //[Diagnostics.DebuggerHidden]
+            internal Object InvokeMember(
+                String name, BindingFlags bindingFlags, Object target,
+                Object[] providedArgs, ParameterModifier[] modifiers, CultureInfo culture, String[] namedParams)
+            {
+                if (IsGenericParameter)
+                    throw new InvalidOperationException("Arg_GenericParameter");
+                Contract.EndContractBlock();
+
+                #region Preconditions
+                //if ((bindingFlags & InvocationMask) == 0)
+                //    // "Must specify binding flags describing the invoke operation required."
+                //    throw new ArgumentException("Arg_NoAccessSpec", "bindingFlags");
+
+                // Provide a default binding mask if none is provided 
+                if ((bindingFlags & MemberBindingMask) == 0)
+                {
+                    bindingFlags |= BindingFlags.Instance | BindingFlags.Public;
+
+                    //if ((bindingFlags & BindingFlags.CreateInstance) == 0)
+                    bindingFlags |= BindingFlags.Static;
+                }
+
+                // There must not be more named parameters than provided arguments
+                if (namedParams != null)
+                {
+                    if (providedArgs != null)
+                    {
+                        if (namedParams.Length > providedArgs.Length)
+                            // "Named parameter array can not be bigger than argument array."
+                            throw new ArgumentException("Arg_NamedParamTooBig", "namedParams");
+                    }
+                    else
+                    {
+                        if (namedParams.Length != 0)
+                            // "Named parameter array can not be bigger than argument array."
+                            throw new ArgumentException("Arg_NamedParamTooBig", "namedParams");
+                    }
+                }
+                #endregion
+
+                #region COM Interop
+#if FEATURE_COMINTEROP && FEATURE_USE_LCID
+            if (target != null && target.GetType().IsCOMObject)
+            {
+                #region Preconditions
+                if ((bindingFlags & ClassicBindingMask) == 0)
+                    throw new ArgumentException(Environment.GetResourceString("Arg_COMAccess"), "bindingFlags");
+
+                if ((bindingFlags & BindingFlags.GetProperty) != 0 && (bindingFlags & ClassicBindingMask & ~(BindingFlags.GetProperty | BindingFlags.InvokeMethod)) != 0)
+                    throw new ArgumentException(Environment.GetResourceString("Arg_PropSetGet"), "bindingFlags");
+
+                if ((bindingFlags & BindingFlags.InvokeMethod) != 0 && (bindingFlags & ClassicBindingMask & ~(BindingFlags.GetProperty | BindingFlags.InvokeMethod)) != 0)
+                    throw new ArgumentException(Environment.GetResourceString("Arg_PropSetInvoke"), "bindingFlags");
+
+                if ((bindingFlags & BindingFlags.SetProperty) != 0 && (bindingFlags & ClassicBindingMask & ~BindingFlags.SetProperty) != 0)
+                    throw new ArgumentException(Environment.GetResourceString("Arg_COMPropSetPut"), "bindingFlags");
+
+                if ((bindingFlags & BindingFlags.PutDispProperty) != 0 && (bindingFlags & ClassicBindingMask & ~BindingFlags.PutDispProperty) != 0)
+                    throw new ArgumentException(Environment.GetResourceString("Arg_COMPropSetPut"), "bindingFlags");
+
+                if ((bindingFlags & BindingFlags.PutRefDispProperty) != 0 && (bindingFlags & ClassicBindingMask & ~BindingFlags.PutRefDispProperty) != 0)
+                    throw new ArgumentException(Environment.GetResourceString("Arg_COMPropSetPut"), "bindingFlags");
+                #endregion
+
+#if FEATURE_REMOTING
+                if(!RemotingServices.IsTransparentProxy(target))
+#endif
+                {
+                #region Non-TransparentProxy case
+                    if (name == null)
+                        throw new ArgumentNullException("name");
+
+                    bool[] isByRef = modifiers == null ? null : modifiers[0].IsByRefArray;
+                    
+                    // pass LCID_ENGLISH_US if no explicit culture is specified to match the behavior of VB
+                    int lcid = (culture == null ? 0x0409 : culture.LCID);
+
+                    return InvokeDispMethod(name, bindingFlags, target, providedArgs, isByRef, lcid, namedParams);
+                #endregion
+                }
+#if FEATURE_REMOTING
+                else
+                {
+                #region TransparentProxy case
+                    return ((MarshalByRefObject)target).InvokeMember(name, bindingFlags, binder, providedArgs, modifiers, culture, namedParams);
+                #endregion
+                }
+#endif // FEATURE_REMOTING
+            }
+#endif // FEATURE_COMINTEROP && FEATURE_USE_LCID
+                #endregion
+
+                #region Check that any named paramters are not null
+                if (namedParams != null && Array.IndexOf(namedParams, null) != -1)
+                    // "Named parameter value must not be null."
+                    throw new ArgumentException("Arg_NamedParamNull", "namedParams");
+                #endregion
+
+                int argCnt = (providedArgs != null) ? providedArgs.Length : 0;
+
+                //#region Get a Binder
+                //if (binder == null)
+                //    binder = DefaultBinder;
+
+                //bool bDefaultBinder = (binder == DefaultBinder);
+                //#endregion
+
+                //#region Delegate to Activator.CreateInstance
+                //if ((bindingFlags & BindingFlags.CreateInstance) != 0)
+                //{
+                //    if ((bindingFlags & BindingFlags.CreateInstance) != 0 && (bindingFlags & BinderNonCreateInstance) != 0)
+                //        // "Can not specify both CreateInstance and another access type."
+                //        throw new ArgumentException(Environment.GetResourceString("Arg_CreatInstAccess"), "bindingFlags");
+
+                //    return Activator.CreateInstance(this, bindingFlags, binder, providedArgs, culture);
+                //}
+                //#endregion
+
+                //// PutDispProperty and\or PutRefDispProperty ==> SetProperty.
+                //if ((bindingFlags & (BindingFlags.PutDispProperty | BindingFlags.PutRefDispProperty)) != 0)
+                //    bindingFlags |= BindingFlags.SetProperty;
+
+                #region Name
+                if (name == null)
+                    throw new ArgumentNullException("name");
+
+                if (name.Length == 0 || name.Equals(@"[DISPID=0]"))
+                {
+                    //name = GetDefaultMemberName();
+
+                    if (name == null)
+                    {
+                        // in InvokeMember we always pretend there is a default member if none is provided and we make it ToString
+                        name = "ToString";
+                    }
+                }
+                #endregion
+
+                //#region GetField or SetField
+                //bool IsGetField = (bindingFlags & BindingFlags.GetField) != 0;
+                //bool IsSetField = (bindingFlags & BindingFlags.SetField) != 0;
+
+                //if (IsGetField || IsSetField)
+                //{
+                //    #region Preconditions
+                //    if (IsGetField)
+                //    {
+                //        if (IsSetField)
+                //            // "Can not specify both Get and Set on a field."
+                //            throw new ArgumentException(Environment.GetResourceString("Arg_FldSetGet"), "bindingFlags");
+
+                //        if ((bindingFlags & BindingFlags.SetProperty) != 0)
+                //            // "Can not specify both GetField and SetProperty."
+                //            throw new ArgumentException(Environment.GetResourceString("Arg_FldGetPropSet"), "bindingFlags");
+                //    }
+                //    else
+                //    {
+                //        Contract.Assert(IsSetField);
+
+                //        if (providedArgs == null)
+                //            throw new ArgumentNullException("providedArgs");
+
+                //        if ((bindingFlags & BindingFlags.GetProperty) != 0)
+                //            // "Can not specify both SetField and GetProperty."
+                //            throw new ArgumentException(Environment.GetResourceString("Arg_FldSetPropGet"), "bindingFlags");
+
+                //        if ((bindingFlags & BindingFlags.InvokeMethod) != 0)
+                //            // "Can not specify Set on a Field and Invoke on a method."
+                //            throw new ArgumentException(Environment.GetResourceString("Arg_FldSetInvoke"), "bindingFlags");
+                //    }
+                //    #endregion
+
+                //    #region Lookup Field
+                //    FieldInfo selFld = null;
+                //    FieldInfo[] flds = GetMember(name, MemberTypes.Field, bindingFlags) as FieldInfo[];
+
+                //    Contract.Assert(flds != null);
+
+                //    if (flds.Length == 1)
+                //    {
+                //        selFld = flds[0];
+                //    }
+                //    else if (flds.Length > 0)
+                //    {
+                //        selFld = binder.BindToField(bindingFlags, flds, IsGetField ? Empty.Value : providedArgs[0], culture);
+                //    }
+                //    #endregion
+
+                //    if (selFld != null)
+                //    {
+                //        #region Invocation on a field
+                //        if (selFld.FieldType.IsArray || Object.ReferenceEquals(selFld.FieldType, typeof(System.Array)))
+                //        {
+                //            #region Invocation of an array Field
+                //            int idxCnt;
+
+                //            if ((bindingFlags & BindingFlags.GetField) != 0)
+                //            {
+                //                idxCnt = argCnt;
+                //            }
+                //            else
+                //            {
+                //                idxCnt = argCnt - 1;
+                //            }
+
+                //            if (idxCnt > 0)
+                //            {
+                //                // Verify that all of the index values are ints
+                //                int[] idx = new int[idxCnt];
+                //                for (int i = 0; i < idxCnt; i++)
+                //                {
+                //                    try
+                //                    {
+                //                        idx[i] = ((IConvertible)providedArgs[i]).ToInt32(null);
+                //                    }
+                //                    catch (InvalidCastException)
+                //                    {
+                //                        throw new ArgumentException(Environment.GetResourceString("Arg_IndexMustBeInt"));
+                //                    }
+                //                }
+
+                //                // Set or get the value...
+                //                Array a = (Array)selFld.GetValue(target);
+
+                //                // Set or get the value in the array
+                //                if ((bindingFlags & BindingFlags.GetField) != 0)
+                //                {
+                //                    return a.GetValue(idx);
+                //                }
+                //                else
+                //                {
+                //                    a.SetValue(providedArgs[idxCnt], idx);
+                //                    return null;
+                //                }
+                //            }
+                //            #endregion
+                //        }
+
+                //        if (IsGetField)
+                //        {
+                //            #region Get the field value
+                //            if (argCnt != 0)
+                //                throw new ArgumentException(Environment.GetResourceString("Arg_FldGetArgErr"), "bindingFlags");
+
+                //            return selFld.GetValue(target);
+                //            #endregion
+                //        }
+                //        else
+                //        {
+                //            #region Set the field Value
+                //            if (argCnt != 1)
+                //                throw new ArgumentException(Environment.GetResourceString("Arg_FldSetArgErr"), "bindingFlags");
+
+                //            selFld.SetValue(target, providedArgs[0], bindingFlags, binder, culture);
+
+                //            return null;
+                //            #endregion
+                //        }
+                //        #endregion
+                //    }
+
+                //    if ((bindingFlags & BinderNonFieldGetSet) == 0)
+                //        throw new MissingFieldException(FullName, name);
+                //}
+                //#endregion
+
+                #region Caching Logic
+                /*
+                bool useCache = false;
+                // Note that when we add something to the cache, we are careful to ensure
+                // that the actual providedArgs matches the parameters of the method.  Otherwise,
+                // some default argument processing has occurred.  We don't want anyone
+                // else with the same (insufficient) number of actual arguments to get a
+                // cache hit because then they would bypass the default argument processing
+                // and the invocation would fail.
+                if (bDefaultBinder && namedParams == null && argCnt < 6)
+                    useCache = true;
+                if (useCache)
+                {
+                    MethodBase invokeMethod = GetMethodFromCache (name, bindingFlags, argCnt, providedArgs);
+                    if (invokeMethod != null)
+                        return ((MethodInfo) invokeMethod).Invoke(target, bindingFlags, binder, providedArgs, culture);
+                }
+                */
+                #endregion
+
+                //#region Property PreConditions
+                //// @Legacy - This is RTM behavior
+                //bool isGetProperty = (bindingFlags & BindingFlags.GetProperty) != 0;
+                //bool isSetProperty = (bindingFlags & BindingFlags.SetProperty) != 0;
+
+                //if (isGetProperty || isSetProperty)
+                //{
+                //    #region Preconditions
+                //    if (isGetProperty)
+                //    {
+                //        Contract.Assert(!IsSetField);
+
+                //        if (isSetProperty)
+                //            throw new ArgumentException(Environment.GetResourceString("Arg_PropSetGet"), "bindingFlags");
+                //    }
+                //    else
+                //    {
+                //        Contract.Assert(isSetProperty);
+
+                //        Contract.Assert(!IsGetField);
+
+                //        if ((bindingFlags & BindingFlags.InvokeMethod) != 0)
+                //            throw new ArgumentException(Environment.GetResourceString("Arg_PropSetInvoke"), "bindingFlags");
+                //    }
+                //    #endregion
+                //}
+                //#endregion
+
+                MethodInfo[] finalists = null;
+                MethodInfo finalist = null;
+
+                #region BindingFlags.InvokeMethod
+                //if ((bindingFlags & BindingFlags.InvokeMethod) != 0)
+                {
+                    #region Lookup Methods
+                    //MethodInfo[] semiFinalists = GetMember(name, MemberTypes.Method, bindingFlags) as MethodInfo[];
+                    MethodInfo[] semiFinalists = TargetType.GetMethods(bindingFlags).Where(mi => mi.Name == name).ToArray();
+                    List<MethodInfo> results = null;
+
+                    for (int i = 0; i < semiFinalists.Length; i++)
+                    {
+                        MethodInfo semiFinalist = semiFinalists[i];
+                        Contract.Assert(semiFinalist != null);
+
+                        if (!FilterApplyMethodBase(semiFinalist, bindingFlags, bindingFlags, CallingConventions.Any, new Type[argCnt]))
+                            continue;
+
+                        if (finalist == null)
+                        {
+                            finalist = semiFinalist;
+                        }
+                        else
+                        {
+                            if (results == null)
+                            {
+                                results = new List<MethodInfo>(semiFinalists.Length);
+                                results.Add(finalist);
+                            }
+
+                            results.Add(semiFinalist);
+                        }
+                    }
+
+                    if (results != null)
+                    {
+                        Contract.Assert(results.Count > 1);
+                        finalists = new MethodInfo[results.Count];
+                        results.CopyTo(finalists);
+                    }
+                    #endregion
+                }
+                #endregion
+
+                Contract.Assert(finalists == null || finalist != null);
+
+                //#region BindingFlags.GetProperty or BindingFlags.SetProperty
+                //if (finalist == null && isGetProperty || isSetProperty)
+                //{
+                //    #region Lookup Property
+                //    PropertyInfo[] semiFinalists = GetMember(name, MemberTypes.Property, bindingFlags) as PropertyInfo[];
+                //    List<MethodInfo> results = null;
+
+                //    for (int i = 0; i < semiFinalists.Length; i++)
+                //    {
+                //        MethodInfo semiFinalist = null;
+
+                //        if (isSetProperty)
+                //        {
+                //            semiFinalist = semiFinalists[i].GetSetMethod(true);
+                //        }
+                //        else
+                //        {
+                //            semiFinalist = semiFinalists[i].GetGetMethod(true);
+                //        }
+
+                //        if (semiFinalist == null)
+                //            continue;
+
+                //        if (!FilterApplyMethodInfo((RuntimeMethodInfo)semiFinalist, bindingFlags, CallingConventions.Any, new Type[argCnt]))
+                //            continue;
+
+                //        if (finalist == null)
+                //        {
+                //            finalist = semiFinalist;
+                //        }
+                //        else
+                //        {
+                //            if (results == null)
+                //            {
+                //                results = new List<MethodInfo>(semiFinalists.Length);
+                //                results.Add(finalist);
+                //            }
+
+                //            results.Add(semiFinalist);
+                //        }
+                //    }
+
+                //    if (results != null)
+                //    {
+                //        Contract.Assert(results.Count > 1);
+                //        finalists = new MethodInfo[results.Count];
+                //        results.CopyTo(finalists);
+                //    }
+                //    #endregion
+                //}
+                //#endregion
+
+                if (finalist != null)
+                {
+                    #region Invoke
+                    if (finalists == null &&
+                        argCnt == 0 &&
+                        finalist.GetParameters().Length == 0 
+                        //&& (bindingFlags & BindingFlags.OptionalParamBinding) == 0
+                        )
+                    {
+                        //if (useCache && argCnt == props[0].GetParameters().Length)
+                        //    AddMethodToCache(name, bindingFlags, argCnt, providedArgs, props[0]);
+
+                        //return finalist.Invoke(target, bindingFlags, binder, providedArgs, culture);
+                        return finalist.Invoke(target, providedArgs);
+                    }
+
+                    if (finalists == null)
+                        finalists = new MethodInfo[] { finalist };
+
+                    if (providedArgs == null)
+                        providedArgs = Array.Empty<object>();
+
+                    Object state = null;
+
+
+                    MethodBase invokeMethod = null;
+
+                    try { invokeMethod = DefaultBinder.BindToMethod(bindingFlags, finalists, ref providedArgs, modifiers, culture, namedParams, out state); }
+                    catch (MissingMethodException) { }
+
+                    if (invokeMethod == null)
+                        throw new MissingMethodException(TargetType.FullName + "." + name);
+
+                    //if (useCache && argCnt == invokeMethod.GetParameters().Length)
+                    //    AddMethodToCache(name, bindingFlags, argCnt, providedArgs, invokeMethod);
+
+                    //Object result = ((MethodInfo)invokeMethod).Invoke(target, bindingFlags, binder, providedArgs, culture);
+                    Object result = ((MethodInfo)invokeMethod).Invoke(target, providedArgs);
+
+                    if (state != null)
+                        DefaultBinder.ReorderArgumentArray(ref providedArgs, state);
+
+                    return result;
+                    #endregion
+                }
+
+                throw new MissingMethodException(TargetType.FullName + "." + name);
+            }
+
+
+            //  FilterApplyMethodBase code copied from: https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/mscorlib/system/rttype.cs#L2514
+            private static bool FilterApplyMethodBase(
+                    MethodBase methodBase, BindingFlags methodFlags, BindingFlags bindingFlags, CallingConventions callConv, Type[] argumentTypes)
+            {
+                Contract.Requires(methodBase != null);
+
+                bindingFlags ^= BindingFlags.DeclaredOnly;
+
+                #region Apply Base Filter
+                if ((bindingFlags & methodFlags) != methodFlags)
+                    return false;
+                #endregion
+
+                #region Check CallingConvention
+                if ((callConv & CallingConventions.Any) == 0)
+                {
+                    if ((callConv & CallingConventions.VarArgs) != 0 &&
+                        (methodBase.CallingConvention & CallingConventions.VarArgs) == 0)
+                        return false;
+
+                    if ((callConv & CallingConventions.Standard) != 0 &&
+                        (methodBase.CallingConvention & CallingConventions.Standard) == 0)
+                        return false;
+                }
+                #endregion
+
+                #region If argumentTypes supplied
+                if (argumentTypes != null)
+                {
+                    ParameterInfo[] parameterInfos = methodBase.GetParameters();
+
+                    if (argumentTypes.Length != parameterInfos.Length)
+                    {
+                        #region Invoke Member, Get\Set & Create Instance specific case
+                        //// If the number of supplied arguments differs than the number in the signature AND
+                        //// we are not filtering for a dynamic call -- InvokeMethod or CreateInstance -- filter out the method.
+                        //if ((bindingFlags &
+                        //    (BindingFlags.InvokeMethod | BindingFlags.CreateInstance | BindingFlags.GetProperty | BindingFlags.SetProperty)) == 0)
+                        //    return false;
+
+                        bool testForParamArray = false;
+                        bool excessSuppliedArguments = argumentTypes.Length > parameterInfos.Length;
+
+                        if (excessSuppliedArguments)
+                        { // more supplied arguments than parameters, additional arguments could be vararg
+                            #region Varargs
+                            // If method is not vararg, additional arguments can not be passed as vararg
+                            if ((methodBase.CallingConvention & CallingConventions.VarArgs) == 0)
+                            {
+                                testForParamArray = true;
+                            }
+                            else
+                            {
+                                // If Binding flags did not include varargs we would have filtered this vararg method.
+                                // This Invariant established during callConv check.
+                                Contract.Assert((callConv & CallingConventions.VarArgs) != 0);
+                            }
+                            #endregion
+                        }
+                        else
+                        {// fewer supplied arguments than parameters, missing arguments could be optional
+                            #region OptionalParamBinding
+                            //if ((bindingFlags & BindingFlags.OptionalParamBinding) == 0)
+                            if (true)
+                            {
+                                testForParamArray = true;
+                            }
+                            else
+                            {
+                                // From our existing code, our policy here is that if a parameterInfo 
+                                // is optional then all subsequent parameterInfos shall be optional. 
+
+                                // Thus, iff the first parameterInfo is not optional then this MethodInfo is no longer a canidate.
+                                if (!parameterInfos[argumentTypes.Length].IsOptional)
+                                    testForParamArray = true;
+                            }
+                            #endregion
+                        }
+
+                        #region ParamArray
+                        if (testForParamArray)
+                        {
+                            if (parameterInfos.Length == 0)
+                                return false;
+
+                            // The last argument of the signature could be a param array. 
+                            bool shortByMoreThanOneSuppliedArgument = argumentTypes.Length < parameterInfos.Length - 1;
+
+                            if (shortByMoreThanOneSuppliedArgument)
+                                return false;
+
+                            ParameterInfo lastParameter = parameterInfos[parameterInfos.Length - 1];
+
+                            if (!lastParameter.ParameterType.IsArray)
+                                return false;
+
+                            if (!lastParameter.IsDefined(typeof(ParamArrayAttribute), false))
+                                return false;
+                        }
+                        #endregion
+
+                        #endregion
+                    }
+                    else
+                    {
+                        //#region Exact Binding
+                        //if ((bindingFlags & BindingFlags.ExactBinding) != 0)
+                        //{
+                        //    // Legacy behavior is to ignore ExactBinding when InvokeMember is specified.
+                        //    // Why filter by InvokeMember? If the answer is we leave this to the binder then why not leave
+                        //    // all the rest of this  to the binder too? Further, what other semanitc would the binder
+                        //    // use for BindingFlags.ExactBinding besides this one? Further, why not include CreateInstance 
+                        //    // in this if statement? That's just InvokeMethod with a constructor, right?
+                        //    if ((bindingFlags & (BindingFlags.InvokeMethod)) == 0)
+                        //    {
+                        //        for (int i = 0; i < parameterInfos.Length; i++)
+                        //        {
+                        //            // a null argument type implies a null arg which is always a perfect match
+                        //            if ((object)argumentTypes[i] != null && !Object.ReferenceEquals(parameterInfos[i].ParameterType, argumentTypes[i]))
+                        //                return false;
+                        //        }
+                        //    }
+                        //}
+                        //#endregion
+                    }
+                }
+                #endregion
+
+                return true;
+            }
         }
     }
 }

--- a/src/Shared/Compat/defaultbinder.cs
+++ b/src/Shared/Compat/defaultbinder.cs
@@ -1,0 +1,1216 @@
+// ==++==
+// 
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// 
+// ==--==
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+//
+// This class represents the Default COM+ binder.
+//
+//
+
+//  Copied from https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/mscorlib/system/defaultbinder.cs
+
+namespace System {
+
+    using System;
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+    using System.Runtime.Versioning;
+    using System.Diagnostics.Contracts;
+    using CultureInfo = System.Globalization.CultureInfo;
+    //Marked serializable even though it has no state.
+    [Serializable]
+    internal class DefaultBinder //: Binder
+    {
+        // This method is passed a set of methods and must choose the best
+        // fit.  The methods all have the same number of arguments and the object
+        // array args.  On exit, this method will choice the best fit method
+        // and coerce the args to match that method.  By match, we mean all primitive
+        // arguments are exact matchs and all object arguments are exact or subclasses
+        // of the target.  If the target OR is an interface, the object must implement
+        // that interface.  There are a couple of exceptions
+        // thrown when a method cannot be returned.  If no method matchs the args and
+        // ArgumentException is thrown.  If multiple methods match the args then 
+        // an AmbiguousMatchException is thrown.
+        // 
+        // The most specific match will be selected.  
+        // 
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public static MethodBase BindToMethod(
+            BindingFlags bindingAttr, MethodBase[] match, ref Object[] args, 
+            ParameterModifier[] modifiers, CultureInfo cultureInfo, String[] names, out Object state)
+        {
+            if (match == null || match.Length == 0)
+                throw new ArgumentException("Arg_EmptyArray", "match");
+            Contract.EndContractBlock();
+
+            MethodBase[] candidates = (MethodBase[]) match.Clone();
+
+            int i;
+            int j;
+        
+            state = null;
+
+            #region Map named parameters to candidate parameter postions
+            // We are creating an paramOrder array to act as a mapping
+            //  between the order of the args and the actual order of the
+            //  parameters in the method.  This order may differ because
+            //  named parameters (names) may change the order.  If names
+            //  is not provided, then we assume the default mapping (0,1,...)
+            int[][] paramOrder = new int[candidates.Length][];
+
+            for (i = 0; i < candidates.Length; i++) 
+            {
+                ParameterInfo[] par = candidates[i].GetParameters();
+
+                // args.Length + 1 takes into account the possibility of a last paramArray that can be omitted
+                paramOrder[i] = new int[(par.Length > args.Length) ? par.Length : args.Length];
+
+                if (names == null) 
+                {
+                    // Default mapping
+                    for (j = 0; j < args.Length; j++)
+                        paramOrder[i][j] = j;
+                }
+                else 
+                {
+                    // Named parameters, reorder the mapping.  If CreateParamOrder fails, it means that the method
+                    // doesn't have a name that matchs one of the named parameters so we don't consider it any further.
+                     if (!CreateParamOrder(paramOrder[i], par, names))
+                         candidates[i] = null;
+                }               
+            }
+            #endregion
+
+            Type[] paramArrayTypes = new Type[candidates.Length];
+            
+            Type[] argTypes = new Type[args.Length];
+
+            #region Cache the type of the provided arguments
+            // object that contain a null are treated as if they were typeless (but match either object 
+            // references or value classes).  We mark this condition by placing a null in the argTypes array.
+            for (i = 0; i < args.Length; i++) 
+            {
+                if (args[i] != null)
+                {
+                    argTypes[i] = args[i].GetType();
+                }
+            }
+            #endregion
+
+            
+            // Find the method that matches...
+            int CurIdx = 0;
+            //bool defaultValueBinding = ((bindingAttr & BindingFlags.OptionalParamBinding) != 0);
+            bool defaultValueBinding = false;
+
+            Type paramArrayType = null;
+
+            #region Filter methods by parameter count and type
+            for (i = 0; i < candidates.Length; i++) 
+            {
+                paramArrayType = null;
+
+                // If we have named parameters then we may have a hole in the candidates array.
+                if (candidates[i] == null)
+                    continue;
+                
+                // Validate the parameters.
+                ParameterInfo[] par = candidates[i].GetParameters();
+
+                #region Match method by parameter count
+                if (par.Length == 0) 
+                {
+                    #region No formal parameters
+                    if (args.Length != 0)
+                    {
+                        if ((candidates[i].CallingConvention & CallingConventions.VarArgs) == 0) 
+                            continue;
+                    }
+
+                    // This is a valid routine so we move it up the candidates list.
+                    paramOrder[CurIdx] = paramOrder[i];
+                    candidates[CurIdx++] = candidates[i];
+
+                    continue;
+                    #endregion
+                }
+                else if (par.Length > args.Length) 
+                {
+                    #region Shortage of provided parameters
+                    // If the number of parameters is greater than the number of args then 
+                    // we are in the situation were we may be using default values.
+                    for (j = args.Length; j < par.Length - 1; j++) 
+                    {
+                        //if (par[j].DefaultValue == System.DBNull.Value)
+                        if (!par[j].HasDefaultValue)
+                           break;
+                    }
+
+                    if (j != par.Length - 1)
+                        continue;       
+
+                    //if (par[j].DefaultValue == System.DBNull.Value) 
+                    if (!par[j].HasDefaultValue)
+                    {
+                        if (!par[j].ParameterType.IsArray) 
+                            continue;
+
+                        if (!par[j].IsDefined(typeof(ParamArrayAttribute), true)) 
+                            continue;
+
+                        paramArrayType = par[j].ParameterType.GetElementType();
+                    }
+                    #endregion
+                }
+                else if (par.Length < args.Length) 
+                {
+                    #region Excess provided parameters
+                    // test for the ParamArray case
+                    int lastArgPos = par.Length - 1;
+
+                    if (!par[lastArgPos].ParameterType.IsArray) 
+                        continue;
+
+                    if (!par[lastArgPos].IsDefined(typeof(ParamArrayAttribute), true)) 
+                        continue;
+
+                    if (paramOrder[i][lastArgPos] != lastArgPos)
+                        continue; 
+
+                    paramArrayType = par[lastArgPos].ParameterType.GetElementType();
+                    #endregion
+                }
+                else 
+                {
+                    #region Test for paramArray, save paramArray type
+                    int lastArgPos = par.Length - 1;
+
+                    if (par[lastArgPos].ParameterType.IsArray
+                        && par[lastArgPos].IsDefined(typeof(ParamArrayAttribute), true)
+                        && paramOrder[i][lastArgPos] == lastArgPos)
+                    {
+                        if (!par[lastArgPos].ParameterType.IsAssignableFrom(argTypes[lastArgPos]))
+                            paramArrayType = par[lastArgPos].ParameterType.GetElementType();
+                    }
+                    #endregion
+                }
+                #endregion
+
+                Type pCls = null;
+                int argsToCheck = (paramArrayType != null) ? par.Length - 1 : args.Length;
+
+                #region Match method by parameter type
+                for (j = 0; j < argsToCheck; j++) 
+                {
+                    #region Classic argument coersion checks
+                    // get the formal type
+                    pCls = par[j].ParameterType;
+
+                    if (pCls.IsByRef)
+                        pCls = pCls.GetElementType();
+
+                    // the type is the same
+                    if (pCls == argTypes[paramOrder[i][j]])
+                        continue;
+
+                    // a default value is available
+                    if (defaultValueBinding && args[paramOrder[i][j]] == Type.Missing)
+                        continue;   
+
+                    // the argument was null, so it matches with everything
+                    if (args[paramOrder[i][j]] == null)
+                        continue;
+
+                    // the type is Object, so it will match everything
+                    if (pCls == typeof(Object))
+                        continue;
+
+                    // now do a "classic" type check
+                    if (pCls.GetTypeInfo().IsPrimitive) 
+                    {
+                        if (argTypes[paramOrder[i][j]] == null || !CanConvertPrimitiveObjectToType(args[paramOrder[i][j]],pCls)) 
+                        {
+#if !FEATURE_COMINTEROP && false
+                            if (CanChangeType(args[paramOrder[i][j]],pCls,cultureInfo))
+                                continue;
+#endif 
+                            break;
+                        }
+                    }
+                    else 
+                    {
+                        if (argTypes[paramOrder[i][j]] == null)
+                            continue;
+
+                        if (!pCls.IsAssignableFrom(argTypes[paramOrder[i][j]])) 
+                        {
+#if false
+                            if (argTypes[paramOrder[i][j]].IsCOMObject) 
+                            {
+                                if (pCls.IsInstanceOfType(args[paramOrder[i][j]]))
+                                    continue;
+                            }
+#endif
+#if !FEATURE_COMINTEROP && false
+                            if (CanChangeType(args[paramOrder[i][j]],pCls,cultureInfo))
+                                continue;
+#endif
+                            break;
+                        }
+                    }
+#endregion
+                }
+
+                if (paramArrayType != null && j == par.Length - 1) 
+                {
+#region Check that excess arguments can be placed in the param array
+                    for (; j < args.Length; j++) 
+                    {
+                        if (paramArrayType.GetTypeInfo().IsPrimitive) 
+                        {
+                            if (argTypes[j] == null || !CanConvertPrimitiveObjectToType(args[j], paramArrayType))
+                                break;
+                        }
+                        else 
+                        {
+                            if (argTypes[j] == null)
+                                continue;
+
+                            if (!paramArrayType.IsAssignableFrom(argTypes[j])) 
+                            {
+#if false
+                                if (argTypes[j].IsCOMObject) 
+                                {
+                                    if (paramArrayType.IsInstanceOfType(args[j]))
+                                        continue;
+                                }
+#endif
+
+                                break;
+                            }
+                        }
+                    }
+#endregion
+                }
+#endregion
+
+                if (j == args.Length) 
+                {
+#region This is a valid routine so we move it up the candidates list
+                    paramOrder[CurIdx] = paramOrder[i];
+                    paramArrayTypes[CurIdx] = paramArrayType;
+                    candidates[CurIdx++] = candidates[i];
+#endregion
+                }
+            }
+#endregion
+
+            // If we didn't find a method 
+            if (CurIdx == 0)
+                throw new MissingMethodException("MissingMember");
+
+            if (CurIdx == 1) 
+            {
+#region Found only one method
+                if (names != null) 
+                {
+                    state = new BinderState((int[])paramOrder[0].Clone(), args.Length, paramArrayTypes[0] != null);
+                    ReorderParams(paramOrder[0],args);
+                }
+                
+                // If the parameters and the args are not the same length or there is a paramArray
+                //  then we need to create a argument array.
+                ParameterInfo[] parms = candidates[0].GetParameters();              
+
+                if (parms.Length == args.Length) 
+                {
+                    if (paramArrayTypes[0] != null) 
+                    {
+                        Object[] objs = new Object[parms.Length];
+                        int lastPos = parms.Length - 1;
+                        Array.Copy(args, 0, objs, 0, lastPos);
+                        objs[lastPos] = Array.CreateInstance(paramArrayTypes[0], 1); 
+                        ((Array)objs[lastPos]).SetValue(args[lastPos], 0);
+                        args = objs;
+                    }
+                }
+                else if (parms.Length > args.Length) 
+                {
+                    Object[] objs = new Object[parms.Length];
+
+                    for (i=0;i<args.Length;i++)
+                        objs[i] = args[i];
+
+                    for (;i<parms.Length - 1;i++)
+                        objs[i] = parms[i].DefaultValue;
+
+                    if (paramArrayTypes[0] != null)
+                        objs[i] = Array.CreateInstance(paramArrayTypes[0], 0); // create an empty array for the 
+
+                    else
+                        objs[i] = parms[i].DefaultValue;
+
+                    args = objs;
+                }
+                else 
+                {
+                    if ((candidates[0].CallingConvention & CallingConventions.VarArgs) == 0) 
+                    {
+                        Object[] objs = new Object[parms.Length];
+                        int paramArrayPos = parms.Length - 1;
+                        Array.Copy(args, 0, objs, 0, paramArrayPos);
+                        objs[paramArrayPos] = Array.CreateInstance(paramArrayTypes[0], args.Length - paramArrayPos); 
+                        Array.Copy(args, paramArrayPos, (System.Array)objs[paramArrayPos], 0, args.Length - paramArrayPos);
+                        args = objs;
+                    }
+                }
+#endregion
+
+                return candidates[0];
+            }
+            
+            int currentMin = 0;
+            bool ambig = false;
+            for (i = 1; i < CurIdx; i++) 
+            {
+#region Walk all of the methods looking the most specific method to invoke
+                int newMin = FindMostSpecificMethod(candidates[currentMin], paramOrder[currentMin], paramArrayTypes[currentMin],
+                                                    candidates[i], paramOrder[i], paramArrayTypes[i], argTypes, args);
+
+                if (newMin == 0)
+                {
+                    ambig = true;
+                }
+                else  if (newMin == 2) 
+                {
+                    currentMin = i;
+                    ambig = false;
+                }
+#endregion
+            }
+
+            if (ambig)
+                throw new AmbiguousMatchException("Arg_AmbiguousMatchException");
+
+            // Reorder (if needed)
+            if (names != null) {
+                state = new BinderState((int[])paramOrder[currentMin].Clone(), args.Length, paramArrayTypes[currentMin] != null);
+                ReorderParams(paramOrder[currentMin], args);
+            }
+                
+            // If the parameters and the args are not the same length or there is a paramArray
+            //  then we need to create a argument array.
+            ParameterInfo[] parameters = candidates[currentMin].GetParameters();
+            if (parameters.Length == args.Length) 
+            {
+                if (paramArrayTypes[currentMin] != null) 
+                {
+                    Object[] objs = new Object[parameters.Length];
+                    int lastPos = parameters.Length - 1;
+                    Array.Copy(args, 0, objs, 0, lastPos);
+                    objs[lastPos] = Array.CreateInstance(paramArrayTypes[currentMin], 1); 
+                    ((Array)objs[lastPos]).SetValue(args[lastPos], 0);
+                    args = objs;
+                }
+            }
+            else if (parameters.Length > args.Length) 
+            {
+                Object[] objs = new Object[parameters.Length];
+
+                for (i=0;i<args.Length;i++)
+                    objs[i] = args[i];
+
+                for (;i<parameters.Length - 1;i++)
+                    objs[i] = parameters[i].DefaultValue;
+
+                if (paramArrayTypes[currentMin] != null) 
+                {
+                    objs[i] = Array.CreateInstance(paramArrayTypes[currentMin], 0);
+                }
+                else
+                {
+                    objs[i] = parameters[i].DefaultValue;
+                }
+
+                args = objs;
+            }
+            else 
+            {
+                if ((candidates[currentMin].CallingConvention & CallingConventions.VarArgs) == 0) 
+                {
+                    Object[] objs = new Object[parameters.Length];
+                    int paramArrayPos = parameters.Length - 1;
+                    Array.Copy(args, 0, objs, 0, paramArrayPos);
+                    objs[paramArrayPos] = Array.CreateInstance(paramArrayTypes[currentMin], args.Length - paramArrayPos);
+                    Array.Copy(args, paramArrayPos, (System.Array)objs[paramArrayPos], 0, args.Length - paramArrayPos);
+                    args = objs;
+                }
+            }
+
+            return candidates[currentMin];
+        }
+
+#if false
+        // Given a set of fields that match the base criteria, select a field.
+        // if value is null then we have no way to select a field
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public override FieldInfo BindToField(BindingFlags bindingAttr,FieldInfo[] match, Object value,CultureInfo cultureInfo)
+        {
+            if (match == null) {
+                throw new ArgumentNullException("match");
+            }
+
+            int i;
+            // Find the method that match...
+            int CurIdx = 0;
+
+            Type valueType = null;
+
+            FieldInfo[] candidates = (FieldInfo[]) match.Clone();
+            
+            // If we are a FieldSet, then use the value's type to disambiguate
+            if ((bindingAttr & BindingFlags.SetField) != 0) {
+                valueType = value.GetType();
+                
+                for (i=0;i<candidates.Length;i++) {
+                    Type pCls = candidates[i].FieldType;
+                    if (pCls == valueType) {
+                        candidates[CurIdx++] = candidates[i];
+                        continue;
+                    }
+                    if (value == Empty.Value) {
+                        // the object passed in was null which would match any non primitive non value type
+                        if (pCls.IsClass) {
+                            candidates[CurIdx++] = candidates[i];
+                            continue;
+                        }
+                    }
+                    if (pCls == typeof(Object)) {
+                        candidates[CurIdx++] = candidates[i];
+                        continue;
+                    }
+                    if (pCls.IsPrimitive) {
+                        if (CanConvertPrimitiveObjectToType(value,(RuntimeType)pCls)) {
+                            candidates[CurIdx++] = candidates[i];
+                            continue;
+                        }
+                    }
+                    else {
+                        if (pCls.IsAssignableFrom(valueType)) {
+                            candidates[CurIdx++] = candidates[i];
+                            continue;
+                        }
+                    }
+                }
+                if (CurIdx == 0)
+                    throw new MissingFieldException(Environment.GetResourceString("MissingField"));
+                if (CurIdx == 1)
+                    return candidates[0];
+            }
+            
+            // Walk all of the methods looking the most specific method to invoke
+            int currentMin = 0;
+            bool ambig = false;
+            for (i=1;i<CurIdx;i++) {
+                int newMin = FindMostSpecificField(candidates[currentMin], candidates[i]);
+                if (newMin == 0)
+                    ambig = true;
+                else {
+                    if (newMin == 2) {
+                        currentMin = i;
+                        ambig = false;
+                    }
+                }
+            }
+            if (ambig)
+                throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+            return candidates[currentMin];
+        }
+        
+        // Given a set of methods that match the base criteria, select a method based
+        // upon an array of types.  This method should return null if no method matchs
+        // the criteria.
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public override MethodBase SelectMethod(BindingFlags bindingAttr,MethodBase[] match,Type[] types,ParameterModifier[] modifiers)
+        {
+            int i;
+            int j;
+            
+            Type[] realTypes = new Type[types.Length];
+            for (i=0;i<types.Length;i++) {
+                realTypes[i] = types[i].UnderlyingSystemType;
+                if (!(realTypes[i] is RuntimeType))
+                    throw new ArgumentException(Environment.GetResourceString("Arg_MustBeType"),"types");
+            }
+            types = realTypes;
+            
+            // We don't automatically jump out on exact match.
+            if (match == null || match.Length == 0)
+                throw new ArgumentException(Environment.GetResourceString("Arg_EmptyArray"), "match");
+
+            MethodBase[] candidates = (MethodBase[]) match.Clone();
+            
+            // Find all the methods that can be described by the types parameter. 
+            //  Remove all of them that cannot.
+            int CurIdx = 0;
+            for (i=0;i<candidates.Length;i++) {
+                ParameterInfo[] par = candidates[i].GetParametersNoCopy();
+                if (par.Length != types.Length)
+                    continue;
+                for (j=0;j<types.Length;j++) {
+                    Type pCls = par[j].ParameterType;
+                    if (pCls == types[j])
+                        continue;
+                    if (pCls == typeof(Object))
+                        continue;
+                    if (pCls.IsPrimitive) {
+                        if (!(types[j].UnderlyingSystemType is RuntimeType) ||
+                            !CanConvertPrimitive((RuntimeType)types[j].UnderlyingSystemType,(RuntimeType)pCls.UnderlyingSystemType))
+                            break;
+                    }
+                    else {
+                        if (!pCls.IsAssignableFrom(types[j]))
+                            break;
+                    }
+                }
+                if (j == types.Length)
+                    candidates[CurIdx++] = candidates[i];
+            }
+            if (CurIdx == 0)
+                return null;
+            if (CurIdx == 1)
+                return candidates[0];
+            
+            // Walk all of the methods looking the most specific method to invoke
+            int currentMin = 0;
+            bool ambig = false;
+            int[] paramOrder = new int[types.Length];
+            for (i=0;i<types.Length;i++)
+                paramOrder[i] = i;
+            for (i=1;i<CurIdx;i++) {
+                int newMin = FindMostSpecificMethod(candidates[currentMin], paramOrder, null, candidates[i], paramOrder, null, types, null);
+                if (newMin == 0)
+                    ambig = true;
+                else {
+                    if (newMin == 2) {
+                        currentMin = i;
+                        ambig = false;
+                        currentMin = i;
+                    }
+                }
+            }
+            if (ambig)
+                throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+            return candidates[currentMin];
+        }
+        
+        // Given a set of properties that match the base criteria, select one.
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public override PropertyInfo SelectProperty(BindingFlags bindingAttr,PropertyInfo[] match,Type returnType,
+                    Type[] indexes,ParameterModifier[] modifiers)
+        {
+            // Allow a null indexes array. But if it is not null, every element must be non-null as well.
+            if (indexes != null && !Contract.ForAll(indexes, delegate(Type t) { return t != null; }))
+            {
+                Exception e;  // Written this way to pass the Code Contracts style requirements.
+#if FEATURE_LEGACYNETCF
+                if (CompatibilitySwitches.IsAppEarlierThanWindowsPhone8)
+                    e = new NullReferenceException();
+                else
+#endif
+                    e = new ArgumentNullException("indexes");
+                throw e;
+            }
+            if (match == null || match.Length == 0)
+                throw new ArgumentException(Environment.GetResourceString("Arg_EmptyArray"), "match");
+            Contract.EndContractBlock();
+
+            PropertyInfo[] candidates = (PropertyInfo[]) match.Clone();
+
+            int i,j = 0;
+                
+            // Find all the properties that can be described by type indexes parameter
+            int CurIdx = 0;
+            int indexesLength = (indexes != null) ? indexes.Length : 0;
+            for (i=0;i<candidates.Length;i++) {
+
+                if (indexes != null)
+                {
+                    ParameterInfo[] par = candidates[i].GetIndexParameters();
+                    if (par.Length != indexesLength)
+                        continue;
+                        
+                    for (j=0;j<indexesLength;j++) {
+                        Type pCls = par[j]. ParameterType;
+                        
+                        // If the classes  exactly match continue
+                        if (pCls == indexes[j])
+                            continue;
+                        if (pCls == typeof(Object))
+                            continue;
+                        
+                        if (pCls.IsPrimitive) {
+                            if (!(indexes[j].UnderlyingSystemType is RuntimeType) ||
+                                !CanConvertPrimitive((RuntimeType)indexes[j].UnderlyingSystemType,(RuntimeType)pCls.UnderlyingSystemType))
+                                break;
+                        }
+                        else {
+                            if (!pCls.IsAssignableFrom(indexes[j]))
+                                break;
+                        }
+                    }
+                }
+                
+                if (j == indexesLength) {
+                    if (returnType != null) {
+                        if (candidates[i].PropertyType.IsPrimitive) {
+                            if (!(returnType.UnderlyingSystemType is RuntimeType) ||
+                                !CanConvertPrimitive((RuntimeType)returnType.UnderlyingSystemType,(RuntimeType)candidates[i].PropertyType.UnderlyingSystemType))
+                                continue;
+                        }
+                        else {
+                            if (!candidates[i].PropertyType.IsAssignableFrom(returnType))
+                                continue;
+                        }
+                    }
+                    candidates[CurIdx++] = candidates[i];
+                }
+            }
+            if (CurIdx == 0)
+                return null;
+            if (CurIdx == 1)
+                return candidates[0];
+                
+            // Walk all of the properties looking the most specific method to invoke
+            int currentMin = 0;
+            bool ambig = false;
+            int[] paramOrder = new int[indexesLength];
+            for (i=0;i<indexesLength;i++)
+                paramOrder[i] = i;
+            for (i=1;i<CurIdx;i++) {
+                int newMin = FindMostSpecificType(candidates[currentMin].PropertyType, candidates[i].PropertyType,returnType);
+                if (newMin == 0 && indexes != null)
+                    newMin = FindMostSpecific(candidates[currentMin].GetIndexParameters(),
+                                              paramOrder,
+                                              null,
+                                              candidates[i].GetIndexParameters(),
+                                              paramOrder,
+                                              null,
+                                              indexes, 
+                                              null);
+                if (newMin == 0)
+                {
+                    newMin = FindMostSpecificProperty(candidates[currentMin], candidates[i]);
+                    if (newMin == 0)
+                        ambig = true;
+                }
+                if (newMin == 2) {
+                    ambig = false;
+                    currentMin = i;
+                }
+            }
+
+            if (ambig)
+                throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+            return candidates[currentMin];
+        }
+        
+        // ChangeType
+        // The default binder doesn't support any change type functionality.
+        // This is because the default is built into the low level invoke code.
+        public override Object ChangeType(Object value,Type type,CultureInfo cultureInfo)
+        {
+            throw new NotSupportedException(Environment.GetResourceString("NotSupported_ChangeType"));
+        }
+#endif        
+
+        public static void ReorderArgumentArray(ref Object[] args, Object state)
+        {
+            BinderState binderState = (BinderState)state;
+            ReorderParams(binderState.m_argsMap, args);
+            if (binderState.m_isParamArray) {
+                int paramArrayPos = args.Length - 1;
+                if (args.Length == binderState.m_originalSize)
+                    args[paramArrayPos] = ((Object[])args[paramArrayPos])[0];
+                else {
+                    // must be args.Length < state.originalSize
+                    Object[] newArgs = new Object[args.Length];
+                    Array.Copy(args, 0, newArgs, 0, paramArrayPos);
+                    for (int i = paramArrayPos, j = 0; i < newArgs.Length; i++, j++) {
+                        newArgs[i] = ((Object[])args[paramArrayPos])[j];
+                    }
+                    args = newArgs;
+                }
+            }
+            else {
+                if (args.Length > binderState.m_originalSize) {
+                    Object[] newArgs = new Object[binderState.m_originalSize];
+                    Array.Copy(args, 0, newArgs, 0, binderState.m_originalSize);
+                    args = newArgs;
+                }
+            }
+        }
+
+#if false
+        // Return any exact bindings that may exist. (This method is not defined on the
+        //  Binder and is used by RuntimeType.)
+        public static MethodBase ExactBinding(MethodBase[] match,Type[] types,ParameterModifier[] modifiers)
+        {
+            if (match==null)
+                throw new ArgumentNullException("match");
+            Contract.EndContractBlock();
+            MethodBase[] aExactMatches = new MethodBase[match.Length];
+            int cExactMatches = 0;
+
+            for (int i=0;i<match.Length;i++) {
+                ParameterInfo[] par = match[i].GetParametersNoCopy();
+                if (par.Length == 0) {
+                    continue;
+                }
+                int j;
+                for (j=0;j<types.Length;j++) {
+                    Type pCls = par[j]. ParameterType;
+                    
+                    // If the classes  exactly match continue
+                    if (!pCls.Equals(types[j]))
+                        break;
+                }
+                if (j < types.Length)
+                    continue;
+
+                // Add the exact match to the array of exact matches.
+                aExactMatches[cExactMatches] = match[i];
+                cExactMatches++;
+            }
+
+            if (cExactMatches == 0)
+                return null;
+
+            if (cExactMatches == 1)
+                return aExactMatches[0];
+
+            return FindMostDerivedNewSlotMeth(aExactMatches, cExactMatches);
+        }
+        
+        // Return any exact bindings that may exist. (This method is not defined on the
+        //  Binder and is used by RuntimeType.)
+        public static PropertyInfo ExactPropertyBinding(PropertyInfo[] match,Type returnType,Type[] types,ParameterModifier[] modifiers)
+        {
+            if (match==null)
+                throw new ArgumentNullException("match");
+            Contract.EndContractBlock();
+
+            PropertyInfo bestMatch = null;
+            int typesLength = (types != null) ? types.Length : 0;
+            for (int i=0;i<match.Length;i++) {
+                ParameterInfo[] par = match[i].GetIndexParameters();
+                int j;
+                for (j=0;j<typesLength;j++) {
+                    Type pCls = par[j].ParameterType;
+                    
+                    // If the classes  exactly match continue
+                    if (pCls != types[j])
+                        break;
+                }
+                if (j < typesLength)
+                    continue;
+                if (returnType != null && returnType != match[i].PropertyType)
+                    continue;
+                
+                if (bestMatch != null)
+                    throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+
+                bestMatch = match[i];
+            }
+            return bestMatch;
+        }
+#endif
+
+        private static int FindMostSpecific(ParameterInfo[] p1, int[] paramOrder1, Type paramArrayType1,
+                                            ParameterInfo[] p2, int[] paramOrder2, Type paramArrayType2,
+                                            Type[] types, Object[] args)
+        {
+            // A method using params is always less specific than one not using params
+            if (paramArrayType1 != null && paramArrayType2 == null) return 2;
+            if (paramArrayType2 != null && paramArrayType1 == null) return 1;
+
+            // now either p1 and p2 both use params or neither does.
+
+            bool p1Less = false;
+            bool p2Less = false;
+
+            for (int i = 0; i < types.Length; i++)
+            {
+                if (args != null && args[i] == Type.Missing)
+                    continue;
+
+                Type c1, c2;
+
+                //  If a param array is present, then either
+                //      the user re-ordered the parameters in which case
+                //          the argument to the param array is either an array
+                //              in which case the params is conceptually ignored and so paramArrayType1 == null
+                //          or the argument to the param array is a single element
+                //              in which case paramOrder[i] == p1.Length - 1 for that element
+                //      or the user did not re-order the parameters in which case
+                //          the paramOrder array could contain indexes larger than p.Length - 1 (see VSW 577286)
+                //          so any index >= p.Length - 1 is being put in the param array
+
+                if (paramArrayType1 != null && paramOrder1[i] >= p1.Length - 1)
+                    c1 = paramArrayType1;
+                else
+                    c1 = p1[paramOrder1[i]].ParameterType;
+
+                if (paramArrayType2 != null && paramOrder2[i] >= p2.Length - 1)
+                    c2 = paramArrayType2;
+                else
+                    c2 = p2[paramOrder2[i]].ParameterType;
+
+                if (c1 == c2) continue;
+
+                switch (FindMostSpecificType(c1, c2, types[i])) {
+                    case 0: return 0;
+                    case 1: p1Less = true; break;
+                    case 2: p2Less = true; break;
+                }
+            }
+
+            // Two way p1Less and p2Less can be equal.  All the arguments are the
+            //  same they both equal false, otherwise there were things that both
+            //  were the most specific type on....
+            if (p1Less == p2Less)
+            {
+                // if we cannot tell which is a better match based on parameter types (p1Less == p2Less),
+                // let's see which one has the most matches without using the params array (the longer one wins).
+                if (!p1Less && args != null)
+                {
+                    if (p1.Length > p2.Length)
+                    {
+                        return 1;
+                    }
+                    else if (p2.Length > p1.Length)
+                    {
+                        return 2;
+                    }
+                }
+
+                return 0;
+            }
+            else
+            {
+                return (p1Less == true) ? 1 : 2;
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private static int FindMostSpecificType(Type c1, Type c2, Type t)
+        {
+            // If the two types are exact move on...
+            if (c1 == c2)
+                return 0;
+
+            if (c1 == t) 
+                return 1;
+            
+            if (c2 == t) 
+                return 2;         
+
+            bool c1FromC2;
+            bool c2FromC1;
+
+            if (c1.IsByRef || c2.IsByRef)
+            {
+                if (c1.IsByRef && c2.IsByRef)
+                {
+                    c1 = c1.GetElementType();
+                    c2 = c2.GetElementType();
+                }
+                else if (c1.IsByRef)
+                {
+                    if (c1.GetElementType() == c2)
+                        return 2;
+
+                    c1 = c1.GetElementType();
+                }
+                else 
+                {
+                    if (c2.GetElementType() == c1)
+                        return 1;
+
+                    c2 = c2.GetElementType();
+                }
+            }
+
+#if false
+            if (c1.GetTypeInfo().IsPrimitive && c2.GetTypeInfo().IsPrimitive) 
+            {
+                c1FromC2 = CanConvertPrimitive((RuntimeType)c2, (RuntimeType)c1);
+                c2FromC1 = CanConvertPrimitive((RuntimeType)c1, (RuntimeType)c2);
+            }
+            else
+#endif
+            {
+                c1FromC2 = c1.IsAssignableFrom(c2);
+                c2FromC1 = c2.IsAssignableFrom(c1);
+            }
+
+            if (c1FromC2 == c2FromC1)
+                return 0;
+
+            if (c1FromC2)
+            {
+                return 2;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+
+        private static int FindMostSpecificMethod(MethodBase m1, int[] paramOrder1, Type paramArrayType1,
+                                                  MethodBase m2, int[] paramOrder2, Type paramArrayType2,
+                                                  Type[] types, Object[] args)
+        {
+            // Find the most specific method based on the parameters.
+            int res = FindMostSpecific(m1.GetParameters(), paramOrder1, paramArrayType1,
+                                       m2.GetParameters(), paramOrder2, paramArrayType2, types, args);            
+
+            // If the match was not ambigous then return the result.
+            if (res != 0)
+                return res;
+
+            // Check to see if the methods have the exact same name and signature.
+            if (CompareMethodSigAndName(m1, m2))
+            {
+                // Determine the depth of the declaring types for both methods.
+                int hierarchyDepth1 = GetHierarchyDepth(m1.DeclaringType);
+                int hierarchyDepth2 = GetHierarchyDepth(m2.DeclaringType);
+
+                // The most derived method is the most specific one.
+                if (hierarchyDepth1 == hierarchyDepth2) 
+                {
+                    return 0; 
+                }
+                else if (hierarchyDepth1 < hierarchyDepth2) 
+                {
+                    return 2;
+                }
+                else
+                {
+                    return 1;
+                }
+            }
+
+            // The match is ambigous.
+            return 0;
+        }
+
+#if false
+        private static int FindMostSpecificField(FieldInfo cur1,FieldInfo cur2)
+        {
+            // Check to see if the fields have the same name.
+            if (cur1.Name == cur2.Name)
+            {
+                int hierarchyDepth1 = GetHierarchyDepth(cur1.DeclaringType);
+                int hierarchyDepth2 = GetHierarchyDepth(cur2.DeclaringType);
+
+                if (hierarchyDepth1 == hierarchyDepth2) {
+                    Contract.Assert(cur1.IsStatic != cur2.IsStatic, "hierarchyDepth1 == hierarchyDepth2");
+                    return 0; 
+                }
+                else if (hierarchyDepth1 < hierarchyDepth2) 
+                    return 2;
+                else
+                    return 1;
+            }
+
+            // The match is ambigous.
+            return 0;
+        }
+
+        private static int FindMostSpecificProperty(PropertyInfo cur1,PropertyInfo cur2)
+        {
+            // Check to see if the fields have the same name.
+            if (cur1.Name == cur2.Name)
+            {
+                int hierarchyDepth1 = GetHierarchyDepth(cur1.DeclaringType);
+                int hierarchyDepth2 = GetHierarchyDepth(cur2.DeclaringType);
+
+                if (hierarchyDepth1 == hierarchyDepth2) {
+                    return 0; 
+                }
+                else if (hierarchyDepth1 < hierarchyDepth2) 
+                    return 2;
+                else
+                    return 1;
+            }
+
+            // The match is ambigous.
+            return 0;
+        }
+#endif
+
+        internal static bool CompareMethodSigAndName(MethodBase m1, MethodBase m2)
+        {
+            ParameterInfo[] params1 = m1.GetParameters();
+            ParameterInfo[] params2 = m2.GetParameters();
+
+            if (params1.Length != params2.Length)
+                return false;
+
+            int numParams = params1.Length;
+            for (int i = 0; i < numParams; i++)
+            {
+                if (params1[i].ParameterType != params2[i].ParameterType)
+                    return false;
+            }
+
+            return true;
+        }
+
+        internal static int GetHierarchyDepth(Type t)
+        {
+            int depth = 0;
+
+            Type currentType = t;
+            do 
+            {
+                depth++;
+                currentType = currentType.GetTypeInfo().BaseType;
+            } while (currentType != null);
+
+            return depth;
+        }
+
+#if false
+        internal static MethodBase FindMostDerivedNewSlotMeth(MethodBase[] match, int cMatches)
+        {
+            int deepestHierarchy = 0;
+            MethodBase methWithDeepestHierarchy = null;
+
+            for (int i = 0; i < cMatches; i++)
+            {
+                // Calculate the depth of the hierarchy of the declaring type of the
+                // current method.
+                int currentHierarchyDepth = GetHierarchyDepth(match[i].DeclaringType);
+
+                // The two methods have the same name, signature, and hierarchy depth.
+                // This can only happen if at least one is vararg or generic.
+                if (currentHierarchyDepth == deepestHierarchy)
+                {
+                    throw new AmbiguousMatchException(Environment.GetResourceString("Arg_AmbiguousMatchException"));
+                }
+
+                // Check to see if this method is on the most derived class.
+                if (currentHierarchyDepth > deepestHierarchy)
+                {
+                    deepestHierarchy = currentHierarchyDepth;
+                    methWithDeepestHierarchy = match[i];
+                }
+            }
+
+            return methWithDeepestHierarchy;
+        }
+
+        // CanConvertPrimitive
+        // This will determine if the source can be converted to the target type
+        [System.Security.SecurityCritical]  // auto-generated
+        [ResourceExposure(ResourceScope.None)]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern bool CanConvertPrimitive(RuntimeType source,RuntimeType target);
+
+        // CanConvertPrimitiveObjectToType
+        // This method will determine if the primitive object can be converted
+        //  to a type.
+        [System.Security.SecurityCritical]  // auto-generated
+        [ResourceExposure(ResourceScope.None)]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        static internal extern bool CanConvertPrimitiveObjectToType(Object source,RuntimeType type);
+#else
+        static internal bool CanConvertPrimitiveObjectToType(Object source, Type type)
+        {
+            try
+            {
+                Convert.ChangeType(source, type);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+#endif
+
+        // This method will sort the vars array into the mapping order stored
+        //  in the paramOrder array.
+        private static void ReorderParams(int[] paramOrder,Object[] vars)
+        {
+            object[] varsCopy = new object[vars.Length];
+            for (int i = 0; i < vars.Length; i ++)
+                varsCopy[i] = vars[i];
+                    
+            for (int i = 0; i < vars.Length; i ++)
+                vars[i] = varsCopy[paramOrder[i]];
+        }
+
+        // This method will create the mapping between the Parameters and the underlying
+        //  data based upon the names array.  The names array is stored in the same order
+        //  as the values and maps to the parameters of the method.  We store the mapping
+        //  from the parameters to the names in the paramOrder array.  All parameters that
+        //  don't have matching names are then stored in the array in order.
+        private static bool CreateParamOrder(int[] paramOrder,ParameterInfo[] pars,String[] names)
+        {
+            bool[] used = new bool[pars.Length];
+            
+            // Mark which parameters have not been found in the names list
+            for (int i=0;i<pars.Length;i++)
+                paramOrder[i] = -1;
+            // Find the parameters with names. 
+            for (int i=0;i<names.Length;i++) {
+                int j;
+                for (j=0;j<pars.Length;j++) {
+                    if (names[i].Equals(pars[j].Name)) {
+                        paramOrder[j] = i;
+                        used[i] = true;
+                        break;
+                    }
+                }
+                // This is an error condition.  The name was not found.  This
+                //  method must not match what we sent.
+                if (j == pars.Length)
+                    return false;
+            }
+            
+            // Now we fill in the holes with the parameters that are unused.
+            int pos = 0;
+            for (int i=0;i<pars.Length;i++) {
+                if (paramOrder[i] == -1) {
+                    for (;pos<pars.Length;pos++) {
+                        if (!used[pos]) {
+                            paramOrder[i] = pos;
+                            pos++;
+                            break;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        internal class BinderState {
+          internal int[] m_argsMap;
+          internal int m_originalSize;
+          internal bool m_isParamArray;
+
+          internal BinderState(int[] argsMap, int originalSize, bool isParamArray) {
+              m_argsMap = argsMap;
+              m_originalSize = originalSize;
+              m_isParamArray = isParamArray;
+          }
+
+        }
+    }
+}

--- a/src/Shared/Compat/parametermodifier.cs
+++ b/src/Shared/Compat/parametermodifier.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics.Contracts;
+// ==++==
+// 
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// 
+// ==--==
+// <OWNER>[....]</OWNER>
+// 
+
+//  Copied from https://github.com/Microsoft/referencesource/blob/74706335e3b8c806f44fa0683dc1e18d3ed747c2/mscorlib/system/reflection/parametermodifier.cs
+
+namespace System.Reflection 
+{  
+    using System;
+
+    [Serializable]
+[System.Runtime.InteropServices.ComVisible(true)]
+    public struct ParameterModifier 
+    {
+        #region Private Data Members
+        private bool[] _byRef;
+        #endregion
+
+        #region Constructor
+        public ParameterModifier(int parameterCount) 
+        {
+            if (parameterCount <= 0)
+                throw new ArgumentException("Arg_ParmArraySize");
+            Contract.EndContractBlock();
+
+            _byRef = new bool[parameterCount];
+        }
+        #endregion
+
+        #region Internal Members
+        internal bool[] IsByRefArray { get { return _byRef; } }
+        #endregion
+
+        #region Public Members
+        public bool this[int index] 
+        {
+            get 
+            {
+                return _byRef[index]; 
+            }
+            set 
+            {
+                _byRef[index] = value;
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Utilities/UnitTests/project.json
+++ b/src/Utilities/UnitTests/project.json
@@ -25,6 +25,7 @@
         "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
         "System.Console": "4.0.0-beta-23123",
         "System.Diagnostics.Process": "4.0.0-beta-23123",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "Microsoft.NETCore.Runtime": "1.0.0",
         "Microsoft.NETCore.TestHost-x86": "1.0.0-beta-23123",
         "Microsoft.Win32.Registry": "4.0.0-beta-23127"

--- a/src/Utilities/UnitTests/project.lock.json
+++ b/src/Utilities/UnitTests/project.lock.json
@@ -11,6 +11,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -72,6 +91,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -131,6 +169,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -220,6 +277,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -3946,6 +4022,19 @@
         "System.Collections.Concurrent.nuspec"
       ]
     },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
+      ]
+    },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
@@ -6403,7 +6492,8 @@
       "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
       "Microsoft.Win32.Registry >= 4.0.0-beta-23127",
       "System.Console >= 4.0.0-beta-23123",
-      "System.Diagnostics.Process >= 4.0.0-beta-23123"
+      "System.Diagnostics.Process >= 4.0.0-beta-23123",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014"
     ]
   }
 }

--- a/src/Utilities/UnitTests/project.lock.json
+++ b/src/Utilities/UnitTests/project.lock.json
@@ -1450,6 +1450,24 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -1463,6 +1481,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -2187,6 +2233,68 @@
         },
         "runtime": {
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Globalization.Calendars": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Runtime.Numerics": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Cng": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Csp": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -3064,6 +3172,64 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -3077,6 +3243,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -3921,6 +4115,73 @@
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
         "ref/net46/Microsoft.Win32.Registry.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "IC7PgaDHuFUsCPW2zzuOA50NJIBDDvzh2JE83+y2hfL5A06aOZ/MegykcBEwfP0Dq6s7eT+2ZD19MJTMH/9QGw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/924fcc98aafd49cbac18eb8675970437.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "xbu5Wtp85oj6UviMDDyKuu+hNe2yNGvMXEpMBBHGq2WVzqSZE+ToYBrAoCHV5VbdBj3dS/bWQLxKwG0kCnbt4A==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/df8825162d064ad4bf2f5fc454e91be5.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "jh5U0VdyM8EUaqPEfYgVy1bVb8RKPgmn61YLIIyhCK6l1Fst8LmNwVC7Q3EzaQwCWIMh29CTQzihwkBVsoVXrw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/db47208018624b188fa7c43863463d75.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hant/System.Security.Cryptography.X509Certificates.xml"
       ]
     },
     "System.AppContext/4.0.0": {
@@ -5724,6 +5985,86 @@
         "System.Security.Claims.nuspec"
       ]
     },
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "25LZE9MSAs9/S2JxL3r0B7NmeGitGN++zCUvW/TAqsO5CMl/Ysse/q6F2783EHczGdCo+RJSkLgcxOJ6KGj1Qg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/20419424c30243f8aec61118e5d8eeaa.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Algorithms.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Algorithms.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+      "sha512": "Fwvz+VL5hCdJVxfLPnvFLhIKarGVED0iqouCLC7bHXL3fLTzb/B9a4Mcyv2Y8d+5J58ezRog0Gpl/fuNUPNDHg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Cng.dll",
+        "lib/net46/System.Security.Cryptography.Cng.dll",
+        "package/services/metadata/core-properties/9ab35fd122304d878e0a747255d00a93.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Cng.dll",
+        "ref/net46/System.Security.Cryptography.Cng.dll",
+        "System.Security.Cryptography.Cng.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+      "sha512": "m4VvZZSnZjZLoeDgif960VH0ghlMb/Id9hZNjFF2OHc0MiWXuWwD0Ii+CM+gyFonpCXIcDwVFCZMEZ+5sWMbJQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/648fed08d33f46959697f33a336f2d8d.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Csp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Csp.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "ko7c7fMmiWAk5/jBPxu/ne79AHCgEj7mVTKr9nT7tdyIF/XBEdFhBO4MnBOMdRMmKlGU5r8JIXSVTWogl52KUA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/96181ca5472843aab9f5d726a71879a6.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Encoding.nuspec"
+      ]
+    },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
@@ -5754,6 +6095,50 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Security.Cryptography.Encryption.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+      "sha512": "qfy2ZTRu7Xd0zlh/4dnpbPm38zZLcE8e1/e+Go3P9L9iPZARSOJWEja60ceIIrfSOS9wUGQwbdHetIjIq0rjkw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/6a1dc1f915064f9c9ba3c3aa7526d8e7.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Primitives.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "yes70JDjOIw9uDifXfXIq7RrnaPlnom1XcEjmeTN8TRdnIeckFUlYlvSkH2tztVYw8CY/Sy7/qlqIOIzBlpDag==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/a1c258831c694973aafeb648ffe94e76.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {

--- a/src/Utilities/UnitTests/project.lock.json
+++ b/src/Utilities/UnitTests/project.lock.json
@@ -1236,28 +1236,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2863,28 +2850,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -5327,17 +5301,16 @@
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
         "System.Reflection.Metadata.nuspec"
       ]
     },

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -13,6 +13,7 @@
         "System.Console": "4.0.0-beta-23123",
         "System.Diagnostics.Process": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
         "System.Threading.Thread": "4.0.0-beta-23123",
         "System.Threading.ThreadPool": "4.0.10-beta-23123",

--- a/src/Utilities/project.lock.json
+++ b/src/Utilities/project.lock.json
@@ -3,26 +3,28 @@
   "version": 1,
   "targets": {
     ".NETFramework,Version=v4.5.1": {},
+    ".NETFramework,Version=v4.5.1/win7-x86": {},
     ".NETFramework,Version=v4.6": {},
+    ".NETFramework,Version=v4.6/win7-x86": {},
     "DNXCore,Version=v5.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -34,6 +36,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -58,8 +61,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -86,8 +89,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -129,29 +131,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -162,30 +164,30 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {},
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -208,13 +210,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -247,15 +249,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -266,13 +268,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -284,12 +286,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -311,16 +313,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -332,9 +334,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -346,15 +348,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -387,25 +389,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -416,8 +418,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -439,13 +441,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -467,20 +469,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -502,8 +504,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -514,11 +516,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -542,15 +544,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -561,14 +563,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -579,19 +581,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -613,13 +615,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -630,10 +632,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -645,21 +647,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -670,16 +672,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -690,13 +692,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -707,21 +709,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -751,9 +753,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -765,10 +767,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -780,25 +782,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -817,9 +819,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -830,13 +832,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -848,11 +850,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -863,9 +865,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -876,8 +878,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -886,28 +888,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -923,8 +912,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -935,9 +924,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -981,9 +970,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -995,8 +984,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -1007,9 +996,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1021,14 +1010,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1039,11 +1028,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -1065,10 +1054,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1104,10 +1093,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1155,17 +1144,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1176,14 +1165,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -1228,20 +1217,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1252,17 +1241,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1273,16 +1262,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1293,15 +1282,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -1312,16 +1301,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -1331,27 +1320,25 @@
         }
       }
     },
-    ".NETFramework,Version=v4.5.1/win7-x86": {},
-    ".NETFramework,Version=v4.6/win7-x86": {},
     "DNXCore,Version=v5.0/win7-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -1363,6 +1350,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -1387,8 +1375,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -1415,8 +1403,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -1458,29 +1445,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1500,8 +1487,8 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
@@ -1514,8 +1501,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1578,13 +1565,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1638,22 +1625,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -1676,13 +1663,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -1715,15 +1702,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1734,13 +1721,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -1752,12 +1739,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1779,16 +1766,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1800,9 +1787,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -1814,15 +1801,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -1855,25 +1842,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -1884,8 +1871,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -1907,13 +1894,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -1935,20 +1922,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -1970,8 +1957,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -1982,11 +1969,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2010,15 +1997,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -2034,14 +2021,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2052,19 +2039,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2086,13 +2073,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2103,10 +2090,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2118,21 +2105,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2143,16 +2130,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -2163,13 +2150,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -2180,21 +2167,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -2227,9 +2214,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2241,10 +2228,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2256,25 +2243,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -2293,9 +2280,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2306,13 +2293,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2324,11 +2311,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2339,9 +2326,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2353,9 +2340,9 @@
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
           "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2366,8 +2353,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -2376,28 +2363,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2413,8 +2387,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2425,9 +2399,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -2471,9 +2445,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -2485,8 +2459,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -2497,9 +2471,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2511,14 +2485,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2529,11 +2503,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -2555,10 +2529,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2594,10 +2568,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2645,17 +2619,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -2666,14 +2640,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -2718,20 +2692,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -2742,17 +2716,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -2763,16 +2737,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -2783,15 +2757,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -2802,16 +2776,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -2827,83 +2801,71 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.CSharp.nuspec",
         "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
-        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "Microsoft.CSharp.nuspec",
+        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
         "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
-        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
+        "_._",
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
-        "_._",
-        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp",
-        "[Content_Types].xml"
+        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
-        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
-        "lib/netcore50/System.Net.dll",
-        "lib/netcore50/System.Numerics.dll",
-        "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
-        "lib/netcore50/System.ServiceModel.Web.dll",
-        "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
-        "lib/netcore50/System.Xml.Linq.dll",
-        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.dll",
@@ -2917,9 +2879,23 @@
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "lib/netcore50/System.Core.dll",
+        "lib/netcore50/System.dll",
+        "lib/netcore50/System.Net.dll",
+        "lib/netcore50/System.Numerics.dll",
+        "lib/netcore50/System.Runtime.Serialization.dll",
+        "lib/netcore50/System.ServiceModel.dll",
+        "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.Windows.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.Xml.Linq.dll",
+        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
+        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
         "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
@@ -2933,21 +2909,7 @@
         "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
-        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
-        "runtimes/aot/lib/netcore50/System.Net.dll",
-        "runtimes/aot/lib/netcore50/System.Numerics.dll",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
-        "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -2961,85 +2923,100 @@
         "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/aot/lib/netcore50/mscorlib.dll",
+        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "runtimes/aot/lib/netcore50/System.Core.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/System.Net.dll",
+        "runtimes/aot/lib/netcore50/System.Numerics.dll",
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.Windows.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
+        "ref/dotnet/_._",
+        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
         "runtimes/win7-x86/native/dbgshim.dll",
         "runtimes/win7-x86/native/mscordaccore.dll",
         "runtimes/win7-x86/native/mscordbi.dll",
         "runtimes/win7-x86/native/mscorrc.debug.dll",
-        "runtimes/win7-x86/native/mscorrc.dll",
-        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
-        "ref/dotnet/_._",
-        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/4.9.0": {
       "sha512": "32pNFQTn/nVB15hYIztKn1Ij05ibGn8C9CfOiENbc+GbzxWWQQztDyWhS/vGzUcrFFZpcXbJ0yGHem2syNHMwQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/49a06ab6e27f4682b9b0c258f69b4fe2.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {
       "sha512": "hLIFc0enPvCCOt1pXl3etWtkhvB+lb8qcjxWM39Jk9n8UTLvIH4lwzFbTv6Tij3LYmNbToTKEPKYmx3TfjUevw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
-        "runtimes/win7-x86/native/CoreRun.exe",
         "package/services/metadata/core-properties/71ad7e2008a84dfdb75618cb7527719a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
+        "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -3102,13 +3079,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -3158,6 +3135,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -3172,8 +3157,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -3183,2407 +3168,2395 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
-        "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
-        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "Microsoft.VisualBasic.nuspec",
+        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
-        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
-        "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
-        "[Content_Types].xml"
+        "ref/win8/_._",
+        "ref/wpa81/_._"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
-        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "Microsoft.Win32.Primitives.nuspec",
+        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
-        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.Win32.Registry/4.0.0-beta-23123": {
       "sha512": "uDHpWnfXuynO2QyCsQbUjK3u6WZGXiiMOfHtFJ83Mkt/M3EtMeA6z3N/eHMnR9qBdfTAFon9yelVmwRBXXU1nQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Registry.nuspec",
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "Microsoft.Win32.Registry.nuspec",
+        "package/services/metadata/core-properties/a3c99102d20347a1b22da1fd42a907b4.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
         "ref/dotnet/fr/Microsoft.Win32.Registry.xml",
         "ref/dotnet/it/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ja/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ru/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
-        "ref/net46/Microsoft.Win32.Registry.dll",
-        "package/services/metadata/core-properties/a3c99102d20347a1b22da1fd42a907b4.psmdcp",
-        "[Content_Types].xml"
+        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.AppContext.nuspec",
-        "lib/netcore50/System.AppContext.dll",
         "lib/DNXCore50/System.AppContext.dll",
-        "lib/net46/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
-        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
         "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
         "ref/dotnet/it/System.AppContext.xml",
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
-        "ref/dotnet/es/System.AppContext.xml",
-        "ref/net46/System.AppContext.dll",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
-        "[Content_Types].xml"
+        "System.AppContext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.nuspec",
-        "lib/netcore50/System.Collections.dll",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
-        "ref/dotnet/zh-hant/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
         "ref/dotnet/it/System.Collections.xml",
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
-        "ref/dotnet/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
         "ref/dotnet/it/System.Collections.Concurrent.xml",
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
-        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
-        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
         "ref/dotnet/it/System.Collections.NonGeneric.xml",
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet/es/System.Collections.NonGeneric.xml",
-        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
         "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
         "ref/dotnet/it/System.ComponentModel.xml",
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
-        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.ComponentModel.dll",
         "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
         "ref/dotnet/it/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.Annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
     "System.Console/4.0.0-beta-23123": {
       "sha512": "fPglodP4GQV7HBBDhmCZaCD8fzBvhtHmBmiN/8yWiJz0NNnA55YUNBh3myvR2DP/6IOHJ75/tTRkvwdpX3BWXA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
-        "lib/net46/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
-        "ref/dotnet/zh-hant/System.Console.xml",
+        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
         "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
         "ref/dotnet/it/System.Console.xml",
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
-        "ref/dotnet/es/System.Console.xml",
-        "ref/net46/System.Console.dll",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
-        "[Content_Types].xml"
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Contracts.nuspec",
-        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
         "ref/dotnet/it/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Contracts.dll",
         "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
-        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
         "ref/dotnet/it/System.Diagnostics.Debug.xml",
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
-        "ref/dotnet/es/System.Diagnostics.Debug.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
     "System.Diagnostics.Process/4.0.0-beta-23123": {
       "sha512": "EUeT1XD9Nmnn4gIhEu1tA7/7RtWlQOIt7ZdETDScQoAYbLUtcY1Zc5Qy6B7+YbKnyqS8TIdGe/fxDEa0EDTsjA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Process.nuspec",
         "lib/DNXCore50/System.Diagnostics.Process.dll",
-        "lib/net46/System.Diagnostics.Process.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Process.dll",
-        "ref/dotnet/System.Diagnostics.Process.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
+        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Process.xml",
+        "ref/dotnet/es/System.Diagnostics.Process.xml",
         "ref/dotnet/fr/System.Diagnostics.Process.xml",
         "ref/dotnet/it/System.Diagnostics.Process.xml",
         "ref/dotnet/ja/System.Diagnostics.Process.xml",
         "ref/dotnet/ko/System.Diagnostics.Process.xml",
         "ref/dotnet/ru/System.Diagnostics.Process.xml",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/dotnet/System.Diagnostics.Process.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Process.xml",
-        "ref/dotnet/es/System.Diagnostics.Process.xml",
-        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.Process.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
-        "lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "lib/net46/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
+        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/it/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
         "ref/dotnet/it/System.Diagnostics.Tools.xml",
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
-        "ref/dotnet/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
         "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
       "sha512": "MZxMo9Skg9oZrJYwGpRfeOfrTfHxmTPWhj8XIXdIryfArzwG1FjZgzOrkWWcON0PdV9OywZYGly09nUCs/JdhA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.TraceSource.nuspec",
         "lib/DNXCore50/System.Diagnostics.TraceSource.dll",
         "lib/net46/System.Diagnostics.TraceSource.dll",
+        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
         "ref/dotnet/System.Diagnostics.TraceSource.dll",
         "ref/net46/System.Diagnostics.TraceSource.dll",
-        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.TraceSource.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tracing.nuspec",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
         "ref/dotnet/it/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Dynamic.Runtime.nuspec",
-        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
         "ref/dotnet/it/System.Dynamic.Runtime.xml",
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
-        "ref/dotnet/es/System.Dynamic.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "System.Dynamic.Runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.nuspec",
-        "lib/netcore50/System.Globalization.dll",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
-        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
         "ref/dotnet/it/System.Globalization.xml",
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
-        "ref/dotnet/es/System.Globalization.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Calendars.nuspec",
-        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
-        "lib/net46/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
         "ref/dotnet/it/System.Globalization.Calendars.xml",
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet/es/System.Globalization.Calendars.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
-        "lib/net46/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
         "ref/dotnet/it/System.Globalization.Extensions.xml",
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet/es/System.Globalization.Extensions.xml",
-        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
-        "[Content_Types].xml"
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.nuspec",
-        "lib/netcore50/System.IO.dll",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
-        "ref/dotnet/zh-hant/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
         "ref/dotnet/it/System.IO.xml",
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
-        "ref/dotnet/es/System.IO.xml",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
         "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
         "ref/dotnet/it/System.IO.Compression.xml",
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
-        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.clrcompression-x86.nuspec",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "runtimes/win10-x86/native/ClrCompression.dll",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win10-x86/native/ClrCompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "System.IO.Compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
-        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
-        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.ZipFile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
-        "lib/netcore50/System.IO.FileSystem.dll",
-        "lib/net46/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
         "ref/dotnet/it/System.IO.FileSystem.xml",
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
-        "ref/dotnet/es/System.IO.FileSystem.xml",
-        "ref/net46/System.IO.FileSystem.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
-        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
-        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
         "ref/dotnet/it/System.Linq.xml",
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.dll",
         "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Expressions.nuspec",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
-        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
         "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
         "ref/dotnet/it/System.Linq.Expressions.xml",
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
-        "ref/dotnet/es/System.Linq.Expressions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
         "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
         "ref/dotnet/it/System.Linq.Parallel.xml",
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
-        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
-        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
         "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
         "ref/dotnet/it/System.Linq.Queryable.xml",
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
-        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Queryable.dll",
         "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Http.nuspec",
-        "lib/netcore50/System.Net.Http.dll",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
-        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
         "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
         "ref/dotnet/it/System.Net.Http.xml",
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
-        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Http.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
-        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.10-beta-23123": {
       "sha512": "NkKpsUm2MLoxT+YlSwexidAw2jGFIJuc6i4H9pT3nU3TQj7MZVursD/ohWj3nyBxthy7i00XLWkRZAwGao/zsg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Primitives.nuspec",
-        "lib/netcore50/System.Net.Primitives.dll",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
         "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
         "ref/dotnet/it/System.Net.Primitives.xml",
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
-        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Primitives.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Numerics.Vectors.nuspec",
         "lib/dotnet/System.Numerics.Vectors.dll",
-        "lib/net46/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
         "ref/dotnet/System.Numerics.Vectors.dll",
-        "ref/net46/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "[Content_Types].xml"
+        "System.Numerics.Vectors.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
-        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
         "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
         "ref/dotnet/it/System.ObjectModel.xml",
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
-        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
-        "[Content_Types].xml"
+        "System.ObjectModel.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Networking.nuspec",
-        "lib/netcore50/System.Private.Networking.dll",
         "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Networking.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Uri.nuspec",
-        "lib/netcore50/System.Private.Uri.dll",
         "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.nuspec",
-        "lib/netcore50/System.Reflection.dll",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
-        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
         "ref/dotnet/it/System.Reflection.xml",
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
-        "ref/dotnet/es/System.Reflection.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.DispatchProxy.nuspec",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
-        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
         "ref/dotnet/it/System.Reflection.Emit.xml",
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
-        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
-        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
-        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Extensions.nuspec",
-        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
         "ref/dotnet/it/System.Reflection.Extensions.xml",
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
-        "ref/dotnet/es/System.Reflection.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Extensions.dll",
         "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Metadata.nuspec",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Primitives.nuspec",
-        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
         "ref/dotnet/it/System.Reflection.Primitives.xml",
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
-        "ref/dotnet/es/System.Reflection.Primitives.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.TypeExtensions.nuspec",
-        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
-        "lib/net46/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Resources.ResourceManager.nuspec",
-        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
-        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
         "ref/dotnet/it/System.Resources.ResourceManager.xml",
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
-        "ref/dotnet/es/System.Resources.ResourceManager.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Resources.ResourceManager.dll",
         "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.nuspec",
-        "lib/netcore50/System.Runtime.dll",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
         "ref/dotnet/it/System.Runtime.xml",
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
-        "ref/dotnet/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Extensions.nuspec",
-        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
         "ref/dotnet/it/System.Runtime.Extensions.xml",
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
-        "ref/dotnet/es/System.Runtime.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
-        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
         "ref/dotnet/it/System.Runtime.Handles.xml",
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
-        "ref/dotnet/es/System.Runtime.Handles.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
-        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
-        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
         "ref/dotnet/it/System.Runtime.InteropServices.xml",
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
-        "ref/dotnet/es/System.Runtime.InteropServices.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
       "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
         "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
         "ref/dotnet/it/System.Runtime.Numerics.xml",
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
-        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.Numerics.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/net46/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
         "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
         "ref/dotnet/it/System.Security.Claims.xml",
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/net46/System.Security.Claims.dll",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Claims.nuspec"
       ]
     },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Cryptography.Encryption.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
-        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
-        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
+        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
         "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/it/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
-        "ref/net46/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encryption.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Cryptography.Encryption.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
-        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
         "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
         "ref/dotnet/it/System.Security.Principal.xml",
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
-        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Principal.nuspec"
       ]
     },
     "System.Security.SecureString/4.0.0-beta-23123": {
       "sha512": "T35YL/7zWBYOLJCcntF+bQgZBgOy5qc6oPn4GWL1phv0borJawTL60iwk4MO2ReYYSK89JmJ7/yqKahqYNw72g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.SecureString.nuspec",
         "lib/DNXCore50/System.Security.SecureString.dll",
-        "lib/net46/System.Security.SecureString.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.SecureString.dll",
-        "ref/dotnet/System.Security.SecureString.xml",
-        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
         "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
         "ref/dotnet/fr/System.Security.SecureString.xml",
         "ref/dotnet/it/System.Security.SecureString.xml",
         "ref/dotnet/ja/System.Security.SecureString.xml",
         "ref/dotnet/ko/System.Security.SecureString.xml",
         "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/zh-hans/System.Security.SecureString.xml",
-        "ref/dotnet/es/System.Security.SecureString.xml",
-        "ref/net46/System.Security.SecureString.dll",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.nuspec",
-        "lib/netcore50/System.Text.Encoding.dll",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
         "ref/dotnet/it/System.Text.Encoding.xml",
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
-        "ref/dotnet/es/System.Text.Encoding.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.Extensions.nuspec",
-        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
-        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
         "ref/dotnet/it/System.Text.RegularExpressions.xml",
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
-        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
-        "[Content_Types].xml"
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
-        "lib/netcore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
-        "ref/dotnet/zh-hant/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
         "ref/dotnet/it/System.Threading.xml",
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
-        "ref/dotnet/es/System.Threading.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Overlapped.nuspec",
-        "lib/netcore50/System.Threading.Overlapped.dll",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
-        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
         "ref/dotnet/it/System.Threading.Overlapped.xml",
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
-        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.nuspec",
-        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
         "ref/dotnet/it/System.Threading.Tasks.xml",
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
-        "ref/dotnet/es/System.Threading.Tasks.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
     "System.Threading.Thread/4.0.0-beta-23123": {
       "sha512": "qu18HhV/xvNSqh3KjY5olJnVN4dJI2FoPB/BQ7vyDbvSJUEhemUmwuNGAx4TpyO4aBdbGCcLxVkWQIo30yxbeQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Thread.nuspec",
         "lib/DNXCore50/System.Threading.Thread.dll",
-        "lib/net46/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.xml",
-        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
+        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
         "ref/dotnet/de/System.Threading.Thread.xml",
+        "ref/dotnet/es/System.Threading.Thread.xml",
         "ref/dotnet/fr/System.Threading.Thread.xml",
         "ref/dotnet/it/System.Threading.Thread.xml",
         "ref/dotnet/ja/System.Threading.Thread.xml",
         "ref/dotnet/ko/System.Threading.Thread.xml",
         "ref/dotnet/ru/System.Threading.Thread.xml",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/dotnet/System.Threading.Thread.xml",
         "ref/dotnet/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet/es/System.Threading.Thread.xml",
-        "ref/net46/System.Threading.Thread.dll",
+        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Thread.nuspec"
       ]
     },
     "System.Threading.ThreadPool/4.0.10-beta-23123": {
       "sha512": "v3gETuR6Z96CPmZrM7260+MK2eFP8wVm4VcaSH3HDEqIHCByWDWOfY7C80TUdtXshnITcUeIoSU/C6rLwKoiVg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.ThreadPool.nuspec",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/dotnet/System.Threading.ThreadPool.xml",
-        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
         "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
         "ref/dotnet/fr/System.Threading.ThreadPool.xml",
         "ref/dotnet/it/System.Threading.ThreadPool.xml",
         "ref/dotnet/ja/System.Threading.ThreadPool.xml",
         "ref/dotnet/ko/System.Threading.ThreadPool.xml",
         "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet/es/System.Threading.ThreadPool.xml",
-        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Timer.nuspec",
-        "lib/netcore50/System.Threading.Timer.dll",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
-        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
         "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
         "ref/dotnet/it/System.Threading.Timer.xml",
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
-        "ref/dotnet/es/System.Threading.Timer.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
-        "ref/win81/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
         "ref/dotnet/it/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XDocument.nuspec",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
         "ref/dotnet/it/System.Xml.XDocument.xml",
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XDocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XmlDocument.dll",
-        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XmlDocument.xml",
-        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XmlDocument.nuspec"
       ]
     },
     "System.Xml.XPath/4.0.0": {
       "sha512": "jalVwhZSwErcW28NZOE3Dqb6B1XA4DAsL15JvykYIKXtXYQU8PI5GXssjF5G0bLm8/6Gko2e1SOjRs/MoeAKrw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.nuspec",
         "lib/dotnet/System.Xml.XPath.dll",
-        "lib/net46/System.Xml.XPath.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XPath.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.dll",
-        "ref/dotnet/System.Xml.XPath.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
+        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.xml",
+        "ref/dotnet/es/System.Xml.XPath.xml",
         "ref/dotnet/fr/System.Xml.XPath.xml",
         "ref/dotnet/it/System.Xml.XPath.xml",
         "ref/dotnet/ja/System.Xml.XPath.xml",
         "ref/dotnet/ko/System.Xml.XPath.xml",
         "ref/dotnet/ru/System.Xml.XPath.xml",
+        "ref/dotnet/System.Xml.XPath.dll",
+        "ref/dotnet/System.Xml.XPath.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.xml",
-        "ref/dotnet/es/System.Xml.XPath.xml",
-        "ref/net46/System.Xml.XPath.dll",
+        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XPath.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.nuspec"
       ]
     },
     "System.Xml.XPath.XmlDocument/4.0.0": {
       "sha512": "toGFsezsdAJ3Fkau0l386iGBg3qfYauQrM4haX1nWPYnUOWb0hXfAEVIi47/Ke4ET3gl9h9ZppKiws8QWeJVyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XPath.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
+        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.XmlDocument.nuspec"
       ]
     }
   },
@@ -5594,15 +5567,16 @@
     "DNXCore,Version=v5.0": [
       "Microsoft.NETCore >= 5.0.0",
       "Microsoft.NETCore.Portable.Compatibility >= 1.0.0",
+      "Microsoft.NETCore.Runtime >= 1.0.0",
       "Microsoft.NETCore.Runtime.CoreCLR-x86 >= 1.0.0",
+      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
       "System.Console >= 4.0.0-beta-23123",
       "System.Diagnostics.Process >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Threading.Thread >= 4.0.0-beta-23123",
       "System.Threading.ThreadPool >= 4.0.10-beta-23123",
-      "Microsoft.NETCore.Runtime >= 1.0.0",
-      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
       "System.Xml.XmlDocument >= 4.0.0",
       "System.Xml.XPath.XmlDocument >= 4.0.0"
     ]

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" Condition="!$(Configuration.EndsWith('MONO'))"/>
@@ -68,6 +68,12 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\Compat\defaultbinder.cs">
+      <Link>SharedUtilities\Compat\defaultbinder.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\Compat\parametermodifier.cs">
+      <Link>SharedUtilities\Compat\parametermodifier.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\EnvironmentUtilities.cs">
       <Link>SharedUtilities\EnvironmentUtilities.cs</Link>
     </Compile>

--- a/src/XMakeBuildEngine/UnitTests/project.json
+++ b/src/XMakeBuildEngine/UnitTests/project.json
@@ -28,6 +28,7 @@
         "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23123",
         "System.Diagnostics.Process": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
         "System.Xml.XmlDocument": "4.0.0",
         "System.Xml.ReaderWriter": "4.0.10",

--- a/src/XMakeBuildEngine/UnitTests/project.lock.json
+++ b/src/XMakeBuildEngine/UnitTests/project.lock.json
@@ -1450,6 +1450,24 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -1463,6 +1481,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -2187,6 +2233,68 @@
         },
         "runtime": {
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Globalization.Calendars": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Runtime.Numerics": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Cng": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Csp": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -3064,6 +3172,64 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -3077,6 +3243,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -3921,6 +4115,73 @@
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
         "ref/net46/Microsoft.Win32.Registry.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "IC7PgaDHuFUsCPW2zzuOA50NJIBDDvzh2JE83+y2hfL5A06aOZ/MegykcBEwfP0Dq6s7eT+2ZD19MJTMH/9QGw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/924fcc98aafd49cbac18eb8675970437.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "xbu5Wtp85oj6UviMDDyKuu+hNe2yNGvMXEpMBBHGq2WVzqSZE+ToYBrAoCHV5VbdBj3dS/bWQLxKwG0kCnbt4A==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/df8825162d064ad4bf2f5fc454e91be5.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "jh5U0VdyM8EUaqPEfYgVy1bVb8RKPgmn61YLIIyhCK6l1Fst8LmNwVC7Q3EzaQwCWIMh29CTQzihwkBVsoVXrw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/db47208018624b188fa7c43863463d75.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hant/System.Security.Cryptography.X509Certificates.xml"
       ]
     },
     "System.AppContext/4.0.0": {
@@ -5724,6 +5985,86 @@
         "System.Security.Claims.nuspec"
       ]
     },
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "25LZE9MSAs9/S2JxL3r0B7NmeGitGN++zCUvW/TAqsO5CMl/Ysse/q6F2783EHczGdCo+RJSkLgcxOJ6KGj1Qg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/20419424c30243f8aec61118e5d8eeaa.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Algorithms.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Algorithms.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+      "sha512": "Fwvz+VL5hCdJVxfLPnvFLhIKarGVED0iqouCLC7bHXL3fLTzb/B9a4Mcyv2Y8d+5J58ezRog0Gpl/fuNUPNDHg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Cng.dll",
+        "lib/net46/System.Security.Cryptography.Cng.dll",
+        "package/services/metadata/core-properties/9ab35fd122304d878e0a747255d00a93.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Cng.dll",
+        "ref/net46/System.Security.Cryptography.Cng.dll",
+        "System.Security.Cryptography.Cng.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+      "sha512": "m4VvZZSnZjZLoeDgif960VH0ghlMb/Id9hZNjFF2OHc0MiWXuWwD0Ii+CM+gyFonpCXIcDwVFCZMEZ+5sWMbJQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/648fed08d33f46959697f33a336f2d8d.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Csp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Csp.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "ko7c7fMmiWAk5/jBPxu/ne79AHCgEj7mVTKr9nT7tdyIF/XBEdFhBO4MnBOMdRMmKlGU5r8JIXSVTWogl52KUA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/96181ca5472843aab9f5d726a71879a6.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Encoding.nuspec"
+      ]
+    },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
@@ -5754,6 +6095,50 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Security.Cryptography.Encryption.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+      "sha512": "qfy2ZTRu7Xd0zlh/4dnpbPm38zZLcE8e1/e+Go3P9L9iPZARSOJWEja60ceIIrfSOS9wUGQwbdHetIjIq0rjkw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/6a1dc1f915064f9c9ba3c3aa7526d8e7.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Primitives.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "yes70JDjOIw9uDifXfXIq7RrnaPlnom1XcEjmeTN8TRdnIeckFUlYlvSkH2tztVYw8CY/Sy7/qlqIOIzBlpDag==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/a1c258831c694973aafeb648ffe94e76.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {

--- a/src/XMakeBuildEngine/UnitTests/project.lock.json
+++ b/src/XMakeBuildEngine/UnitTests/project.lock.json
@@ -11,6 +11,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -72,6 +91,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -131,6 +169,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -220,6 +277,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -1236,28 +1312,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2863,28 +2926,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -3970,6 +4020,19 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Collections.Concurrent.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
@@ -5327,17 +5390,16 @@
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
         "System.Reflection.Metadata.nuspec"
       ]
     },
@@ -6434,6 +6496,7 @@
       "System.Diagnostics.FileVersionInfo >= 4.0.0-beta-23123",
       "System.Diagnostics.Process >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Xml.ReaderWriter >= 4.0.10",
       "System.Xml.XmlDocument >= 4.0.0"

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/project.lock.json
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/project.lock.json
@@ -11,6 +11,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -72,6 +91,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -131,6 +169,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -220,6 +277,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -317,6 +393,32 @@
         "License-Stable.rtf",
         "Microsoft.Tpl.Dataflow.nuspec",
         "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp"
+      ]
+    },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
+      ]
+    },
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-
+    "System.Reflection.Metadata": "1.1.0-alpha-00014"
   },
   "runtimes": {
     "win7-x86": { }
@@ -28,7 +28,6 @@
         "System.Diagnostics.Process": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
         "System.IO.Pipes": "4.0.0-beta-23123",
-        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Threading.Thread": "4.0.0-beta-23123",
         "System.Threading.ThreadPool": "4.0.10-beta-23123",
         "System.Xml.XmlDocument": "4.0.0",

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -28,6 +28,7 @@
         "System.Diagnostics.Process": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
         "System.IO.Pipes": "4.0.0-beta-23123",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Threading.Thread": "4.0.0-beta-23123",
         "System.Threading.ThreadPool": "4.0.10-beta-23123",
         "System.Xml.XmlDocument": "4.0.0",

--- a/src/XMakeBuildEngine/project.lock.json
+++ b/src/XMakeBuildEngine/project.lock.json
@@ -10,6 +10,25 @@
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
       }
     },
     ".NETFramework,Version=v4.5.1/win7-x86": {
@@ -20,6 +39,25 @@
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
       }
     },
     ".NETFramework,Version=v4.6": {
@@ -29,6 +67,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -67,6 +124,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -3490,6 +3566,19 @@
         "System.Collections.Concurrent.nuspec"
       ]
     },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
+      ]
+    },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
@@ -5750,7 +5839,9 @@
     }
   },
   "projectFileDependencyGroups": {
-    "": [],
+    "": [
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014"
+    ],
     ".NETFramework,Version=v4.5.1": [
       "Microsoft.Tpl.Dataflow >= 4.5.24"
     ],
@@ -5769,7 +5860,6 @@
       "System.Diagnostics.Process >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
       "System.IO.Pipes >= 4.0.0-beta-23123",
-      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Threading.Thread >= 4.0.0-beta-23123",
       "System.Threading.ThreadPool >= 4.0.10-beta-23123",

--- a/src/XMakeBuildEngine/project.lock.json
+++ b/src/XMakeBuildEngine/project.lock.json
@@ -12,6 +12,16 @@
         }
       }
     },
+    ".NETFramework,Version=v4.5.1/win7-x86": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      }
+    },
     ".NETFramework,Version=v4.6": {
       "Microsoft.Tpl.Dataflow/4.5.24": {
         "compile": {
@@ -39,8 +49,46 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6/win7-x86": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -53,22 +101,22 @@
     "DNXCore,Version=v5.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -80,6 +128,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -104,8 +153,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -132,8 +181,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -174,30 +222,30 @@
       "Microsoft.NETCore.Runtime/1.0.0": {},
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {},
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -220,13 +268,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -259,15 +307,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -278,13 +326,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -296,12 +344,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -323,16 +371,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -344,9 +392,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -358,15 +406,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -399,10 +447,10 @@
       },
       "System.Diagnostics.FileVersionInfo/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO.FileSystem": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.FileVersionInfo.dll": {}
@@ -413,25 +461,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -453,13 +501,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -481,20 +529,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -516,8 +564,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -528,11 +576,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -556,15 +604,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -575,14 +623,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -593,19 +641,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -627,18 +675,18 @@
       },
       "System.IO.Pipes/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Principal": "[4.0.0, )",
           "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Pipes.dll": {}
@@ -649,13 +697,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -666,10 +714,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -681,21 +729,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -706,16 +754,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -726,13 +774,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -743,21 +791,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -787,9 +835,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -801,10 +849,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -816,25 +864,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -853,9 +901,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -866,13 +914,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -884,11 +932,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -899,9 +947,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -912,8 +960,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -922,28 +970,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -959,8 +994,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -971,9 +1006,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -1017,9 +1052,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -1031,8 +1066,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -1043,9 +1078,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1057,14 +1092,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1075,11 +1110,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -1101,10 +1136,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1140,10 +1175,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1191,17 +1226,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1212,14 +1247,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -1264,20 +1299,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1288,17 +1323,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1309,16 +1344,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1329,15 +1364,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -1348,16 +1383,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -1367,73 +1402,25 @@
         }
       }
     },
-    ".NETFramework,Version=v4.5.1/win7-x86": {
-      "Microsoft.Tpl.Dataflow/4.5.24": {
-        "compile": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      }
-    },
-    ".NETFramework,Version=v4.6/win7-x86": {
-      "Microsoft.Tpl.Dataflow/4.5.24": {
-        "compile": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      },
-      "System.Resources.ResourceManager/4.0.0": {
-        "compile": {
-          "ref/net45/_._": {}
-        },
-        "runtime": {
-          "lib/net45/_._": {}
-        }
-      },
-      "System.Runtime/4.0.20": {
-        "compile": {
-          "ref/net46/_._": {}
-        },
-        "runtime": {
-          "lib/net46/_._": {}
-        }
-      },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
-        "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
-        }
-      }
-    },
     "DNXCore,Version=v5.0/win7-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -1445,6 +1432,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -1469,8 +1457,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -1497,8 +1485,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -1540,29 +1527,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1582,8 +1569,8 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
@@ -1596,8 +1583,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1660,13 +1647,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1720,22 +1707,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -1758,13 +1745,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -1797,15 +1784,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1816,13 +1803,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -1834,12 +1821,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1861,16 +1848,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1882,9 +1869,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -1896,15 +1883,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -1937,10 +1924,10 @@
       },
       "System.Diagnostics.FileVersionInfo/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO.FileSystem": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.FileVersionInfo.dll": {}
@@ -1951,25 +1938,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -1980,8 +1967,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -2003,13 +1990,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -2031,20 +2018,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -2066,8 +2053,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -2078,11 +2065,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2106,15 +2093,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -2130,14 +2117,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2148,19 +2135,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2182,18 +2169,18 @@
       },
       "System.IO.Pipes/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Principal": "[4.0.0, )",
           "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Pipes.dll": {}
@@ -2204,13 +2191,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2221,10 +2208,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2236,21 +2223,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2261,16 +2248,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -2281,13 +2268,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -2298,21 +2285,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -2345,9 +2332,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2359,10 +2346,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2374,25 +2361,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -2411,9 +2398,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2424,13 +2411,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2442,11 +2429,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2457,9 +2444,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2471,9 +2458,9 @@
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
           "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2484,8 +2471,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -2494,28 +2481,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2531,8 +2505,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2543,9 +2517,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -2589,9 +2563,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -2603,8 +2577,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -2615,9 +2589,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2629,14 +2603,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2647,11 +2621,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -2673,10 +2647,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2712,10 +2686,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2763,17 +2737,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -2784,14 +2758,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -2836,20 +2810,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -2860,17 +2834,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -2881,16 +2855,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -2901,15 +2875,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -2920,16 +2894,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -2945,83 +2919,71 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.CSharp.nuspec",
         "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
-        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "Microsoft.CSharp.nuspec",
+        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
         "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
-        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
+        "_._",
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
-        "_._",
-        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp",
-        "[Content_Types].xml"
+        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
-        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
-        "lib/netcore50/System.Net.dll",
-        "lib/netcore50/System.Numerics.dll",
-        "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
-        "lib/netcore50/System.ServiceModel.Web.dll",
-        "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
-        "lib/netcore50/System.Xml.Linq.dll",
-        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.dll",
@@ -3035,9 +2997,23 @@
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "lib/netcore50/System.Core.dll",
+        "lib/netcore50/System.dll",
+        "lib/netcore50/System.Net.dll",
+        "lib/netcore50/System.Numerics.dll",
+        "lib/netcore50/System.Runtime.Serialization.dll",
+        "lib/netcore50/System.ServiceModel.dll",
+        "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.Windows.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.Xml.Linq.dll",
+        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
+        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
         "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
@@ -3051,21 +3027,7 @@
         "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
-        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
-        "runtimes/aot/lib/netcore50/System.Net.dll",
-        "runtimes/aot/lib/netcore50/System.Numerics.dll",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
-        "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -3079,85 +3041,100 @@
         "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/aot/lib/netcore50/mscorlib.dll",
+        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "runtimes/aot/lib/netcore50/System.Core.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/System.Net.dll",
+        "runtimes/aot/lib/netcore50/System.Numerics.dll",
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.Windows.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
+        "ref/dotnet/_._",
+        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
         "runtimes/win7-x86/native/dbgshim.dll",
         "runtimes/win7-x86/native/mscordaccore.dll",
         "runtimes/win7-x86/native/mscordbi.dll",
         "runtimes/win7-x86/native/mscorrc.debug.dll",
-        "runtimes/win7-x86/native/mscorrc.dll",
-        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
-        "ref/dotnet/_._",
-        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/4.9.0": {
       "sha512": "32pNFQTn/nVB15hYIztKn1Ij05ibGn8C9CfOiENbc+GbzxWWQQztDyWhS/vGzUcrFFZpcXbJ0yGHem2syNHMwQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/49a06ab6e27f4682b9b0c258f69b4fe2.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {
       "sha512": "hLIFc0enPvCCOt1pXl3etWtkhvB+lb8qcjxWM39Jk9n8UTLvIH4lwzFbTv6Tij3LYmNbToTKEPKYmx3TfjUevw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
-        "runtimes/win7-x86/native/CoreRun.exe",
         "package/services/metadata/core-properties/71ad7e2008a84dfdb75618cb7527719a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
+        "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -3220,13 +3197,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -3276,6 +3253,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -3290,8 +3275,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -3301,2478 +3286,2466 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
-        "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "Microsoft.Tpl.Dataflow/4.5.24": {
       "sha512": "6BE4Vu74+dkv5AkJd+UxW1sFMepMZOVlUoMZDUKqhc4Bf7pe7yySzCj6QrowUZbCqcDPwOiQsAgz3nXiLQSyMw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Tpl.Dataflow.nuspec",
-        "License-Stable.rtf",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/system.threading.tasks.dataflow.xml",
-        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
+        "License-Stable.rtf",
+        "Microsoft.Tpl.Dataflow.nuspec",
+        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
-        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "Microsoft.VisualBasic.nuspec",
+        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
-        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
-        "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
-        "[Content_Types].xml"
+        "ref/win8/_._",
+        "ref/wpa81/_._"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
-        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "Microsoft.Win32.Primitives.nuspec",
+        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
-        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.Win32.Registry/4.0.0-beta-23123": {
       "sha512": "uDHpWnfXuynO2QyCsQbUjK3u6WZGXiiMOfHtFJ83Mkt/M3EtMeA6z3N/eHMnR9qBdfTAFon9yelVmwRBXXU1nQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Registry.nuspec",
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "Microsoft.Win32.Registry.nuspec",
+        "package/services/metadata/core-properties/a3c99102d20347a1b22da1fd42a907b4.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
         "ref/dotnet/fr/Microsoft.Win32.Registry.xml",
         "ref/dotnet/it/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ja/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ru/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
-        "ref/net46/Microsoft.Win32.Registry.dll",
-        "package/services/metadata/core-properties/a3c99102d20347a1b22da1fd42a907b4.psmdcp",
-        "[Content_Types].xml"
+        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.AppContext.nuspec",
-        "lib/netcore50/System.AppContext.dll",
         "lib/DNXCore50/System.AppContext.dll",
-        "lib/net46/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
-        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
         "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
         "ref/dotnet/it/System.AppContext.xml",
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
-        "ref/dotnet/es/System.AppContext.xml",
-        "ref/net46/System.AppContext.dll",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
-        "[Content_Types].xml"
+        "System.AppContext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.nuspec",
-        "lib/netcore50/System.Collections.dll",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
-        "ref/dotnet/zh-hant/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
         "ref/dotnet/it/System.Collections.xml",
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
-        "ref/dotnet/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
         "ref/dotnet/it/System.Collections.Concurrent.xml",
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
-        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
-        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
         "ref/dotnet/it/System.Collections.NonGeneric.xml",
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet/es/System.Collections.NonGeneric.xml",
-        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
         "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
         "ref/dotnet/it/System.ComponentModel.xml",
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
-        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.ComponentModel.dll",
         "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
         "ref/dotnet/it/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.Annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
     "System.Console/4.0.0-beta-23123": {
       "sha512": "fPglodP4GQV7HBBDhmCZaCD8fzBvhtHmBmiN/8yWiJz0NNnA55YUNBh3myvR2DP/6IOHJ75/tTRkvwdpX3BWXA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
-        "lib/net46/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
-        "ref/dotnet/zh-hant/System.Console.xml",
+        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
         "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
         "ref/dotnet/it/System.Console.xml",
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
-        "ref/dotnet/es/System.Console.xml",
-        "ref/net46/System.Console.dll",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
-        "[Content_Types].xml"
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Contracts.nuspec",
-        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
         "ref/dotnet/it/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Contracts.dll",
         "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
-        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
         "ref/dotnet/it/System.Diagnostics.Debug.xml",
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
-        "ref/dotnet/es/System.Diagnostics.Debug.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
     "System.Diagnostics.FileVersionInfo/4.0.0-beta-23123": {
       "sha512": "RMpg/uZOZcORanGz9aqyatYgiHOE+w+5CfeMwnbE1WiLBdDA2d0v2m/lD7YQSkwk7HYsexYVmMkZflNcWPw3qQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.FileVersionInfo.nuspec",
         "lib/DNXCore50/System.Diagnostics.FileVersionInfo.dll",
-        "lib/net46/System.Diagnostics.FileVersionInfo.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.FileVersionInfo.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.FileVersionInfo.dll",
-        "ref/dotnet/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.FileVersionInfo.xml",
+        "package/services/metadata/core-properties/b6337943521840fbb8b9ca67c64bbdd8.psmdcp",
         "ref/dotnet/de/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet/es/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/fr/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/it/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/ja/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/ko/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/ru/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet/System.Diagnostics.FileVersionInfo.dll",
+        "ref/dotnet/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet/es/System.Diagnostics.FileVersionInfo.xml",
-        "ref/net46/System.Diagnostics.FileVersionInfo.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.FileVersionInfo.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.FileVersionInfo.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b6337943521840fbb8b9ca67c64bbdd8.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.FileVersionInfo.nuspec"
       ]
     },
     "System.Diagnostics.Process/4.0.0-beta-23123": {
       "sha512": "EUeT1XD9Nmnn4gIhEu1tA7/7RtWlQOIt7ZdETDScQoAYbLUtcY1Zc5Qy6B7+YbKnyqS8TIdGe/fxDEa0EDTsjA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Process.nuspec",
         "lib/DNXCore50/System.Diagnostics.Process.dll",
-        "lib/net46/System.Diagnostics.Process.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Process.dll",
-        "ref/dotnet/System.Diagnostics.Process.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
+        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Process.xml",
+        "ref/dotnet/es/System.Diagnostics.Process.xml",
         "ref/dotnet/fr/System.Diagnostics.Process.xml",
         "ref/dotnet/it/System.Diagnostics.Process.xml",
         "ref/dotnet/ja/System.Diagnostics.Process.xml",
         "ref/dotnet/ko/System.Diagnostics.Process.xml",
         "ref/dotnet/ru/System.Diagnostics.Process.xml",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/dotnet/System.Diagnostics.Process.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Process.xml",
-        "ref/dotnet/es/System.Diagnostics.Process.xml",
-        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.Process.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
-        "lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "lib/net46/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
+        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/it/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
         "ref/dotnet/it/System.Diagnostics.Tools.xml",
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
-        "ref/dotnet/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
         "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
       "sha512": "MZxMo9Skg9oZrJYwGpRfeOfrTfHxmTPWhj8XIXdIryfArzwG1FjZgzOrkWWcON0PdV9OywZYGly09nUCs/JdhA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.TraceSource.nuspec",
         "lib/DNXCore50/System.Diagnostics.TraceSource.dll",
         "lib/net46/System.Diagnostics.TraceSource.dll",
+        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
         "ref/dotnet/System.Diagnostics.TraceSource.dll",
         "ref/net46/System.Diagnostics.TraceSource.dll",
-        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.TraceSource.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tracing.nuspec",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
         "ref/dotnet/it/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Dynamic.Runtime.nuspec",
-        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
         "ref/dotnet/it/System.Dynamic.Runtime.xml",
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
-        "ref/dotnet/es/System.Dynamic.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "System.Dynamic.Runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.nuspec",
-        "lib/netcore50/System.Globalization.dll",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
-        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
         "ref/dotnet/it/System.Globalization.xml",
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
-        "ref/dotnet/es/System.Globalization.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Calendars.nuspec",
-        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
-        "lib/net46/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
         "ref/dotnet/it/System.Globalization.Calendars.xml",
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet/es/System.Globalization.Calendars.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
-        "lib/net46/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
         "ref/dotnet/it/System.Globalization.Extensions.xml",
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet/es/System.Globalization.Extensions.xml",
-        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
-        "[Content_Types].xml"
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.nuspec",
-        "lib/netcore50/System.IO.dll",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
-        "ref/dotnet/zh-hant/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
         "ref/dotnet/it/System.IO.xml",
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
-        "ref/dotnet/es/System.IO.xml",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
         "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
         "ref/dotnet/it/System.IO.Compression.xml",
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
-        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.clrcompression-x86.nuspec",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "runtimes/win10-x86/native/ClrCompression.dll",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win10-x86/native/ClrCompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "System.IO.Compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
-        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
-        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.ZipFile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
-        "lib/netcore50/System.IO.FileSystem.dll",
-        "lib/net46/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
         "ref/dotnet/it/System.IO.FileSystem.xml",
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
-        "ref/dotnet/es/System.IO.FileSystem.xml",
-        "ref/net46/System.IO.FileSystem.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
-        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
-        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.IO.Pipes/4.0.0-beta-23123": {
       "sha512": "TnytoLSYehYWAdumEN7WAq8YoIyqsdLNCA+6IuWFI0594egTzAgv7LH4gv5IN/1NgoN1LLxcK4P/m/EKyf4XCw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Pipes.nuspec",
         "lib/DNXCore50/System.IO.Pipes.dll",
         "lib/net46/System.IO.Pipes.dll",
-        "ref/dotnet/System.IO.Pipes.dll",
-        "ref/dotnet/System.IO.Pipes.xml",
-        "ref/dotnet/zh-hant/System.IO.Pipes.xml",
+        "package/services/metadata/core-properties/f57aab004bb94ccbb87be8c4c3babf1d.psmdcp",
         "ref/dotnet/de/System.IO.Pipes.xml",
+        "ref/dotnet/es/System.IO.Pipes.xml",
         "ref/dotnet/fr/System.IO.Pipes.xml",
         "ref/dotnet/it/System.IO.Pipes.xml",
         "ref/dotnet/ja/System.IO.Pipes.xml",
         "ref/dotnet/ko/System.IO.Pipes.xml",
         "ref/dotnet/ru/System.IO.Pipes.xml",
+        "ref/dotnet/System.IO.Pipes.dll",
+        "ref/dotnet/System.IO.Pipes.xml",
         "ref/dotnet/zh-hans/System.IO.Pipes.xml",
-        "ref/dotnet/es/System.IO.Pipes.xml",
+        "ref/dotnet/zh-hant/System.IO.Pipes.xml",
         "ref/net46/System.IO.Pipes.dll",
-        "package/services/metadata/core-properties/f57aab004bb94ccbb87be8c4c3babf1d.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Pipes.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
         "ref/dotnet/it/System.Linq.xml",
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.dll",
         "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Expressions.nuspec",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
-        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
         "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
         "ref/dotnet/it/System.Linq.Expressions.xml",
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
-        "ref/dotnet/es/System.Linq.Expressions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
         "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
         "ref/dotnet/it/System.Linq.Parallel.xml",
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
-        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
-        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
         "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
         "ref/dotnet/it/System.Linq.Queryable.xml",
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
-        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Queryable.dll",
         "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Http.nuspec",
-        "lib/netcore50/System.Net.Http.dll",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
-        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
         "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
         "ref/dotnet/it/System.Net.Http.xml",
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
-        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Http.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
-        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.10-beta-23123": {
       "sha512": "NkKpsUm2MLoxT+YlSwexidAw2jGFIJuc6i4H9pT3nU3TQj7MZVursD/ohWj3nyBxthy7i00XLWkRZAwGao/zsg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Primitives.nuspec",
-        "lib/netcore50/System.Net.Primitives.dll",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
         "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
         "ref/dotnet/it/System.Net.Primitives.xml",
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
-        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Primitives.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Numerics.Vectors.nuspec",
         "lib/dotnet/System.Numerics.Vectors.dll",
-        "lib/net46/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
         "ref/dotnet/System.Numerics.Vectors.dll",
-        "ref/net46/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "[Content_Types].xml"
+        "System.Numerics.Vectors.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
-        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
         "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
         "ref/dotnet/it/System.ObjectModel.xml",
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
-        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
-        "[Content_Types].xml"
+        "System.ObjectModel.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Networking.nuspec",
-        "lib/netcore50/System.Private.Networking.dll",
         "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Networking.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Uri.nuspec",
-        "lib/netcore50/System.Private.Uri.dll",
         "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.nuspec",
-        "lib/netcore50/System.Reflection.dll",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
-        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
         "ref/dotnet/it/System.Reflection.xml",
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
-        "ref/dotnet/es/System.Reflection.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.DispatchProxy.nuspec",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
-        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
         "ref/dotnet/it/System.Reflection.Emit.xml",
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
-        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
-        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
-        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Extensions.nuspec",
-        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
         "ref/dotnet/it/System.Reflection.Extensions.xml",
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
-        "ref/dotnet/es/System.Reflection.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Extensions.dll",
         "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Metadata.nuspec",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Primitives.nuspec",
-        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
         "ref/dotnet/it/System.Reflection.Primitives.xml",
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
-        "ref/dotnet/es/System.Reflection.Primitives.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.TypeExtensions.nuspec",
-        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
-        "lib/net46/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Resources.ResourceManager.nuspec",
-        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
-        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
         "ref/dotnet/it/System.Resources.ResourceManager.xml",
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
-        "ref/dotnet/es/System.Resources.ResourceManager.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Resources.ResourceManager.dll",
         "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.nuspec",
-        "lib/netcore50/System.Runtime.dll",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
         "ref/dotnet/it/System.Runtime.xml",
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
-        "ref/dotnet/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Extensions.nuspec",
-        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
         "ref/dotnet/it/System.Runtime.Extensions.xml",
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
-        "ref/dotnet/es/System.Runtime.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
-        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
         "ref/dotnet/it/System.Runtime.Handles.xml",
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
-        "ref/dotnet/es/System.Runtime.Handles.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
-        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
-        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
         "ref/dotnet/it/System.Runtime.InteropServices.xml",
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
-        "ref/dotnet/es/System.Runtime.InteropServices.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
       "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
         "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
         "ref/dotnet/it/System.Runtime.Numerics.xml",
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
-        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.Numerics.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/net46/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
         "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
         "ref/dotnet/it/System.Security.Claims.xml",
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/net46/System.Security.Claims.dll",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Claims.nuspec"
       ]
     },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Cryptography.Encryption.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
-        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
-        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
+        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
         "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/it/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
-        "ref/net46/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encryption.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Cryptography.Encryption.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
-        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
         "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
         "ref/dotnet/it/System.Security.Principal.xml",
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
-        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Principal.nuspec"
       ]
     },
     "System.Security.SecureString/4.0.0-beta-23123": {
       "sha512": "T35YL/7zWBYOLJCcntF+bQgZBgOy5qc6oPn4GWL1phv0borJawTL60iwk4MO2ReYYSK89JmJ7/yqKahqYNw72g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.SecureString.nuspec",
         "lib/DNXCore50/System.Security.SecureString.dll",
-        "lib/net46/System.Security.SecureString.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.SecureString.dll",
-        "ref/dotnet/System.Security.SecureString.xml",
-        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
         "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
         "ref/dotnet/fr/System.Security.SecureString.xml",
         "ref/dotnet/it/System.Security.SecureString.xml",
         "ref/dotnet/ja/System.Security.SecureString.xml",
         "ref/dotnet/ko/System.Security.SecureString.xml",
         "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/zh-hans/System.Security.SecureString.xml",
-        "ref/dotnet/es/System.Security.SecureString.xml",
-        "ref/net46/System.Security.SecureString.dll",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.nuspec",
-        "lib/netcore50/System.Text.Encoding.dll",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
         "ref/dotnet/it/System.Text.Encoding.xml",
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
-        "ref/dotnet/es/System.Text.Encoding.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.Extensions.nuspec",
-        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
-        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
         "ref/dotnet/it/System.Text.RegularExpressions.xml",
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
-        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
-        "[Content_Types].xml"
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
-        "lib/netcore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
-        "ref/dotnet/zh-hant/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
         "ref/dotnet/it/System.Threading.xml",
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
-        "ref/dotnet/es/System.Threading.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Overlapped.nuspec",
-        "lib/netcore50/System.Threading.Overlapped.dll",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
-        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
         "ref/dotnet/it/System.Threading.Overlapped.xml",
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
-        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.nuspec",
-        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
         "ref/dotnet/it/System.Threading.Tasks.xml",
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
-        "ref/dotnet/es/System.Threading.Tasks.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
     "System.Threading.Thread/4.0.0-beta-23123": {
       "sha512": "qu18HhV/xvNSqh3KjY5olJnVN4dJI2FoPB/BQ7vyDbvSJUEhemUmwuNGAx4TpyO4aBdbGCcLxVkWQIo30yxbeQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Thread.nuspec",
         "lib/DNXCore50/System.Threading.Thread.dll",
-        "lib/net46/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.xml",
-        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
+        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
         "ref/dotnet/de/System.Threading.Thread.xml",
+        "ref/dotnet/es/System.Threading.Thread.xml",
         "ref/dotnet/fr/System.Threading.Thread.xml",
         "ref/dotnet/it/System.Threading.Thread.xml",
         "ref/dotnet/ja/System.Threading.Thread.xml",
         "ref/dotnet/ko/System.Threading.Thread.xml",
         "ref/dotnet/ru/System.Threading.Thread.xml",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/dotnet/System.Threading.Thread.xml",
         "ref/dotnet/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet/es/System.Threading.Thread.xml",
-        "ref/net46/System.Threading.Thread.dll",
+        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Thread.nuspec"
       ]
     },
     "System.Threading.ThreadPool/4.0.10-beta-23123": {
       "sha512": "v3gETuR6Z96CPmZrM7260+MK2eFP8wVm4VcaSH3HDEqIHCByWDWOfY7C80TUdtXshnITcUeIoSU/C6rLwKoiVg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.ThreadPool.nuspec",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/dotnet/System.Threading.ThreadPool.xml",
-        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
         "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
         "ref/dotnet/fr/System.Threading.ThreadPool.xml",
         "ref/dotnet/it/System.Threading.ThreadPool.xml",
         "ref/dotnet/ja/System.Threading.ThreadPool.xml",
         "ref/dotnet/ko/System.Threading.ThreadPool.xml",
         "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet/es/System.Threading.ThreadPool.xml",
-        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Timer.nuspec",
-        "lib/netcore50/System.Threading.Timer.dll",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
-        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
         "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
         "ref/dotnet/it/System.Threading.Timer.xml",
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
-        "ref/dotnet/es/System.Threading.Timer.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
-        "ref/win81/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
         "ref/dotnet/it/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XDocument.nuspec",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
         "ref/dotnet/it/System.Xml.XDocument.xml",
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XDocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XmlDocument.dll",
-        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XmlDocument.xml",
-        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XmlDocument.nuspec"
       ]
     },
     "System.Xml.XPath/4.0.0": {
       "sha512": "jalVwhZSwErcW28NZOE3Dqb6B1XA4DAsL15JvykYIKXtXYQU8PI5GXssjF5G0bLm8/6Gko2e1SOjRs/MoeAKrw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.nuspec",
         "lib/dotnet/System.Xml.XPath.dll",
-        "lib/net46/System.Xml.XPath.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XPath.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.dll",
-        "ref/dotnet/System.Xml.XPath.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
+        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.xml",
+        "ref/dotnet/es/System.Xml.XPath.xml",
         "ref/dotnet/fr/System.Xml.XPath.xml",
         "ref/dotnet/it/System.Xml.XPath.xml",
         "ref/dotnet/ja/System.Xml.XPath.xml",
         "ref/dotnet/ko/System.Xml.XPath.xml",
         "ref/dotnet/ru/System.Xml.XPath.xml",
+        "ref/dotnet/System.Xml.XPath.dll",
+        "ref/dotnet/System.Xml.XPath.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.xml",
-        "ref/dotnet/es/System.Xml.XPath.xml",
-        "ref/net46/System.Xml.XPath.dll",
+        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XPath.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.nuspec"
       ]
     },
     "System.Xml.XPath.XmlDocument/4.0.0": {
       "sha512": "toGFsezsdAJ3Fkau0l386iGBg3qfYauQrM4haX1nWPYnUOWb0hXfAEVIi47/Ke4ET3gl9h9ZppKiws8QWeJVyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XPath.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
+        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.XmlDocument.nuspec"
       ]
     }
   },
@@ -5788,20 +5761,21 @@
     "DNXCore,Version=v5.0": [
       "Microsoft.NETCore >= 5.0.0",
       "Microsoft.NETCore.Portable.Compatibility >= 1.0.0",
+      "Microsoft.NETCore.Runtime >= 1.0.0",
+      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
       "System.Console >= 4.0.0-beta-23123",
-      "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Diagnostics.Contracts >= 4.0.0",
       "System.Diagnostics.FileVersionInfo >= 4.0.0-beta-23123",
       "System.Diagnostics.Process >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
       "System.IO.Pipes >= 4.0.0-beta-23123",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
+      "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Threading.Thread >= 4.0.0-beta-23123",
       "System.Threading.ThreadPool >= 4.0.10-beta-23123",
-      "System.Xml.XmlDocument >= 4.0.0",
-      "System.Xml.XPath.XmlDocument >= 4.0.0",
       "System.Xml.ReaderWriter >= 4.0.10",
-      "Microsoft.NETCore.Runtime >= 1.0.0",
-      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123"
+      "System.Xml.XmlDocument >= 4.0.0",
+      "System.Xml.XPath.XmlDocument >= 4.0.0"
     ]
   }
 }

--- a/src/XMakeCommandLine/UnitTests/project.json
+++ b/src/XMakeCommandLine/UnitTests/project.json
@@ -27,6 +27,7 @@
         "System.Runtime": "4.0.20",
         "Microsoft.NETCore.Runtime": "1.0.0",
         "Microsoft.NETCore.TestHost-x86": "1.0.0-beta-23123",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
         "System.Diagnostics.Process": "4.0.0-beta-23123",
         "System.Threading.Thread": "4.0.0-beta-23123",

--- a/src/XMakeCommandLine/UnitTests/project.lock.json
+++ b/src/XMakeCommandLine/UnitTests/project.lock.json
@@ -11,6 +11,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -72,6 +91,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -131,6 +169,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -220,6 +277,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -1220,28 +1296,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2831,28 +2894,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -3938,6 +3988,19 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Collections.Concurrent.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
@@ -5273,17 +5336,16 @@
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
         "System.Reflection.Metadata.nuspec"
       ]
     },
@@ -6377,6 +6439,7 @@
       "Microsoft.Win32.Registry >= 4.0.0-beta-23127",
       "System.Console >= 4.0.0-beta-23123",
       "System.Diagnostics.Process >= 4.0.0-beta-23123",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
       "System.Runtime >= 4.0.20",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Threading.Thread >= 4.0.0-beta-23123",

--- a/src/XMakeCommandLine/project.json
+++ b/src/XMakeCommandLine/project.json
@@ -15,6 +15,7 @@
         "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23123",
         "System.Diagnostics.Process": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Threading.Thread": "4.0.0-beta-23123",
         "System.Xml.XmlDocument": "4.0.0",
         "System.Xml.XPath.XmlDocument": "4.0.0",

--- a/src/XMakeCommandLine/project.lock.json
+++ b/src/XMakeCommandLine/project.lock.json
@@ -10,6 +10,54 @@
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.5.1/win7-x86": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
       }
     },
     ".NETFramework,Version=v4.6": {
@@ -19,6 +67,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -39,8 +106,65 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6/win7-x86": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -53,22 +177,22 @@
     "DNXCore,Version=v5.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -80,6 +204,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -104,8 +229,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -132,8 +257,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -174,30 +298,30 @@
       "Microsoft.NETCore.Runtime/1.0.0": {},
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {},
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -220,13 +344,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23127": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23127, )",
-          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
-          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
           "System.Collections": "[4.0.10-beta-23127, )",
-          "System.Globalization": "[4.0.10-beta-23127, )"
+          "System.Globalization": "[4.0.10-beta-23127, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
+          "System.Runtime": "[4.0.20-beta-23127, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
+          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
+          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -259,15 +383,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -278,13 +402,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -296,12 +420,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -323,16 +447,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -344,9 +468,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -358,15 +482,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -399,10 +523,10 @@
       },
       "System.Diagnostics.FileVersionInfo/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO.FileSystem": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.FileVersionInfo.dll": {}
@@ -413,25 +537,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -453,13 +577,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -481,20 +605,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -516,8 +640,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -528,11 +652,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -556,15 +680,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -575,14 +699,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -593,19 +717,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -627,18 +751,18 @@
       },
       "System.IO.Pipes/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Principal": "[4.0.0, )",
           "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Pipes.dll": {}
@@ -649,13 +773,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -666,10 +790,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -681,21 +805,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -706,16 +830,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -726,13 +850,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -743,21 +867,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -787,9 +911,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -801,10 +925,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -816,25 +940,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -853,9 +977,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -866,13 +990,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -884,11 +1008,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -899,9 +1023,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -912,8 +1036,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -922,28 +1046,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -959,8 +1070,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -971,9 +1082,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -1017,9 +1128,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -1031,8 +1142,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -1043,9 +1154,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1057,14 +1168,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1075,11 +1186,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -1101,10 +1212,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1140,10 +1251,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1191,17 +1302,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1212,14 +1323,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -1264,20 +1375,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1288,17 +1399,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1309,16 +1420,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1329,15 +1440,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -1348,16 +1459,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -1367,73 +1478,25 @@
         }
       }
     },
-    ".NETFramework,Version=v4.5.1/win7-x86": {
-      "Microsoft.Tpl.Dataflow/4.5.24": {
-        "compile": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      }
-    },
-    ".NETFramework,Version=v4.6/win7-x86": {
-      "Microsoft.Tpl.Dataflow/4.5.24": {
-        "compile": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      },
-      "System.Resources.ResourceManager/4.0.0": {
-        "compile": {
-          "ref/net45/_._": {}
-        },
-        "runtime": {
-          "lib/net45/_._": {}
-        }
-      },
-      "System.Runtime/4.0.20": {
-        "compile": {
-          "ref/net46/_._": {}
-        },
-        "runtime": {
-          "lib/net46/_._": {}
-        }
-      },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
-        "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
-        }
-      }
-    },
     "DNXCore,Version=v5.0/win7-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -1445,6 +1508,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -1469,8 +1533,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -1497,8 +1561,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -1540,29 +1603,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1582,8 +1645,8 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
@@ -1596,8 +1659,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1660,13 +1723,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1720,22 +1783,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -1758,13 +1821,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23127": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23127, )",
-          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
-          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
           "System.Collections": "[4.0.10-beta-23127, )",
-          "System.Globalization": "[4.0.10-beta-23127, )"
+          "System.Globalization": "[4.0.10-beta-23127, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
+          "System.Runtime": "[4.0.20-beta-23127, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
+          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
+          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -1797,15 +1860,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1816,13 +1879,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -1834,12 +1897,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1861,16 +1924,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1882,9 +1945,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -1896,15 +1959,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -1937,10 +2000,10 @@
       },
       "System.Diagnostics.FileVersionInfo/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO.FileSystem": "[4.0.0, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.FileVersionInfo.dll": {}
@@ -1951,25 +2014,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -1980,8 +2043,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -2003,13 +2066,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -2031,20 +2094,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -2066,8 +2129,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -2078,11 +2141,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2106,15 +2169,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -2130,14 +2193,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2148,19 +2211,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2182,18 +2245,18 @@
       },
       "System.IO.Pipes/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Principal": "[4.0.0, )",
           "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Pipes.dll": {}
@@ -2204,13 +2267,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2221,10 +2284,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2236,21 +2299,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2261,16 +2324,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -2281,13 +2344,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -2298,21 +2361,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -2345,9 +2408,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2359,10 +2422,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2374,25 +2437,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -2411,9 +2474,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2424,13 +2487,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2442,11 +2505,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2457,9 +2520,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2471,9 +2534,9 @@
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
           "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2484,8 +2547,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -2494,28 +2557,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2531,8 +2581,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2543,9 +2593,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -2589,9 +2639,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -2603,8 +2653,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -2615,9 +2665,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2629,14 +2679,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2647,11 +2697,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -2673,10 +2723,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2712,10 +2762,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2763,17 +2813,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -2784,14 +2834,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -2836,20 +2886,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -2860,17 +2910,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -2881,16 +2931,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -2901,15 +2951,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -2920,16 +2970,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -2945,83 +2995,71 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.CSharp.nuspec",
         "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
-        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "Microsoft.CSharp.nuspec",
+        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
         "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
-        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
+        "_._",
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
-        "_._",
-        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp",
-        "[Content_Types].xml"
+        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
-        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
-        "lib/netcore50/System.Net.dll",
-        "lib/netcore50/System.Numerics.dll",
-        "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
-        "lib/netcore50/System.ServiceModel.Web.dll",
-        "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
-        "lib/netcore50/System.Xml.Linq.dll",
-        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.dll",
@@ -3035,9 +3073,23 @@
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "lib/netcore50/System.Core.dll",
+        "lib/netcore50/System.dll",
+        "lib/netcore50/System.Net.dll",
+        "lib/netcore50/System.Numerics.dll",
+        "lib/netcore50/System.Runtime.Serialization.dll",
+        "lib/netcore50/System.ServiceModel.dll",
+        "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.Windows.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.Xml.Linq.dll",
+        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
+        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
         "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
@@ -3051,21 +3103,7 @@
         "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
-        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
-        "runtimes/aot/lib/netcore50/System.Net.dll",
-        "runtimes/aot/lib/netcore50/System.Numerics.dll",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
-        "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -3079,85 +3117,100 @@
         "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/aot/lib/netcore50/mscorlib.dll",
+        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "runtimes/aot/lib/netcore50/System.Core.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/System.Net.dll",
+        "runtimes/aot/lib/netcore50/System.Numerics.dll",
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.Windows.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
+        "ref/dotnet/_._",
+        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
         "runtimes/win7-x86/native/dbgshim.dll",
         "runtimes/win7-x86/native/mscordaccore.dll",
         "runtimes/win7-x86/native/mscordbi.dll",
         "runtimes/win7-x86/native/mscorrc.debug.dll",
-        "runtimes/win7-x86/native/mscorrc.dll",
-        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
-        "ref/dotnet/_._",
-        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/4.9.0": {
       "sha512": "32pNFQTn/nVB15hYIztKn1Ij05ibGn8C9CfOiENbc+GbzxWWQQztDyWhS/vGzUcrFFZpcXbJ0yGHem2syNHMwQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/49a06ab6e27f4682b9b0c258f69b4fe2.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {
       "sha512": "hLIFc0enPvCCOt1pXl3etWtkhvB+lb8qcjxWM39Jk9n8UTLvIH4lwzFbTv6Tij3LYmNbToTKEPKYmx3TfjUevw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
-        "runtimes/win7-x86/native/CoreRun.exe",
         "package/services/metadata/core-properties/71ad7e2008a84dfdb75618cb7527719a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
+        "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -3220,13 +3273,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -3276,6 +3329,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -3290,8 +3351,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -3301,2478 +3362,2479 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
-        "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "Microsoft.Tpl.Dataflow/4.5.24": {
       "sha512": "6BE4Vu74+dkv5AkJd+UxW1sFMepMZOVlUoMZDUKqhc4Bf7pe7yySzCj6QrowUZbCqcDPwOiQsAgz3nXiLQSyMw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Tpl.Dataflow.nuspec",
-        "License-Stable.rtf",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/system.threading.tasks.dataflow.xml",
-        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
+        "License-Stable.rtf",
+        "Microsoft.Tpl.Dataflow.nuspec",
+        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
-        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "Microsoft.VisualBasic.nuspec",
+        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
-        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
-        "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
-        "[Content_Types].xml"
+        "ref/win8/_._",
+        "ref/wpa81/_._"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
-        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "Microsoft.Win32.Primitives.nuspec",
+        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
-        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.Win32.Registry/4.0.0-beta-23127": {
       "sha512": "OLlm5CChfeoBvo2hkE9hYtXFm2bn61npTtBmTjc+hrYKltIy3W/yIpwBPNGmKR7/OG4C/senZrrVS5PgPIU5Lw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Registry.nuspec",
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "Microsoft.Win32.Registry.nuspec",
+        "package/services/metadata/core-properties/ab5e15917647479181745bf7b998cc45.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
         "ref/dotnet/fr/Microsoft.Win32.Registry.xml",
         "ref/dotnet/it/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ja/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ru/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
-        "ref/net46/Microsoft.Win32.Registry.dll",
-        "package/services/metadata/core-properties/ab5e15917647479181745bf7b998cc45.psmdcp",
-        "[Content_Types].xml"
+        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.AppContext.nuspec",
-        "lib/netcore50/System.AppContext.dll",
         "lib/DNXCore50/System.AppContext.dll",
-        "lib/net46/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
-        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
         "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
         "ref/dotnet/it/System.AppContext.xml",
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
-        "ref/dotnet/es/System.AppContext.xml",
-        "ref/net46/System.AppContext.dll",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
-        "[Content_Types].xml"
+        "System.AppContext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.nuspec",
-        "lib/netcore50/System.Collections.dll",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
-        "ref/dotnet/zh-hant/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
         "ref/dotnet/it/System.Collections.xml",
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
-        "ref/dotnet/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
         "ref/dotnet/it/System.Collections.Concurrent.xml",
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Concurrent.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
-        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
-        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
         "ref/dotnet/it/System.Collections.NonGeneric.xml",
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet/es/System.Collections.NonGeneric.xml",
-        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
         "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
         "ref/dotnet/it/System.ComponentModel.xml",
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
-        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.ComponentModel.dll",
         "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
         "ref/dotnet/it/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.Annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
     "System.Console/4.0.0-beta-23123": {
       "sha512": "fPglodP4GQV7HBBDhmCZaCD8fzBvhtHmBmiN/8yWiJz0NNnA55YUNBh3myvR2DP/6IOHJ75/tTRkvwdpX3BWXA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
-        "lib/net46/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
-        "ref/dotnet/zh-hant/System.Console.xml",
+        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
         "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
         "ref/dotnet/it/System.Console.xml",
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
-        "ref/dotnet/es/System.Console.xml",
-        "ref/net46/System.Console.dll",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
-        "[Content_Types].xml"
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Contracts.nuspec",
-        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
         "ref/dotnet/it/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Contracts.dll",
         "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
-        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
         "ref/dotnet/it/System.Diagnostics.Debug.xml",
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
-        "ref/dotnet/es/System.Diagnostics.Debug.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
     "System.Diagnostics.FileVersionInfo/4.0.0-beta-23123": {
       "sha512": "RMpg/uZOZcORanGz9aqyatYgiHOE+w+5CfeMwnbE1WiLBdDA2d0v2m/lD7YQSkwk7HYsexYVmMkZflNcWPw3qQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.FileVersionInfo.nuspec",
         "lib/DNXCore50/System.Diagnostics.FileVersionInfo.dll",
-        "lib/net46/System.Diagnostics.FileVersionInfo.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.FileVersionInfo.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.FileVersionInfo.dll",
-        "ref/dotnet/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.FileVersionInfo.xml",
+        "package/services/metadata/core-properties/b6337943521840fbb8b9ca67c64bbdd8.psmdcp",
         "ref/dotnet/de/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet/es/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/fr/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/it/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/ja/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/ko/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/ru/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet/System.Diagnostics.FileVersionInfo.dll",
+        "ref/dotnet/System.Diagnostics.FileVersionInfo.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet/es/System.Diagnostics.FileVersionInfo.xml",
-        "ref/net46/System.Diagnostics.FileVersionInfo.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.FileVersionInfo.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.FileVersionInfo.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b6337943521840fbb8b9ca67c64bbdd8.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.FileVersionInfo.nuspec"
       ]
     },
     "System.Diagnostics.Process/4.0.0-beta-23123": {
       "sha512": "EUeT1XD9Nmnn4gIhEu1tA7/7RtWlQOIt7ZdETDScQoAYbLUtcY1Zc5Qy6B7+YbKnyqS8TIdGe/fxDEa0EDTsjA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Process.nuspec",
         "lib/DNXCore50/System.Diagnostics.Process.dll",
-        "lib/net46/System.Diagnostics.Process.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Process.dll",
-        "ref/dotnet/System.Diagnostics.Process.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
+        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Process.xml",
+        "ref/dotnet/es/System.Diagnostics.Process.xml",
         "ref/dotnet/fr/System.Diagnostics.Process.xml",
         "ref/dotnet/it/System.Diagnostics.Process.xml",
         "ref/dotnet/ja/System.Diagnostics.Process.xml",
         "ref/dotnet/ko/System.Diagnostics.Process.xml",
         "ref/dotnet/ru/System.Diagnostics.Process.xml",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/dotnet/System.Diagnostics.Process.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Process.xml",
-        "ref/dotnet/es/System.Diagnostics.Process.xml",
-        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.Process.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
-        "lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "lib/net46/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
+        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/it/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
         "ref/dotnet/it/System.Diagnostics.Tools.xml",
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
-        "ref/dotnet/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
         "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
       "sha512": "MZxMo9Skg9oZrJYwGpRfeOfrTfHxmTPWhj8XIXdIryfArzwG1FjZgzOrkWWcON0PdV9OywZYGly09nUCs/JdhA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.TraceSource.nuspec",
         "lib/DNXCore50/System.Diagnostics.TraceSource.dll",
         "lib/net46/System.Diagnostics.TraceSource.dll",
+        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
         "ref/dotnet/System.Diagnostics.TraceSource.dll",
         "ref/net46/System.Diagnostics.TraceSource.dll",
-        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.TraceSource.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tracing.nuspec",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
         "ref/dotnet/it/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Dynamic.Runtime.nuspec",
-        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
         "ref/dotnet/it/System.Dynamic.Runtime.xml",
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
-        "ref/dotnet/es/System.Dynamic.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "System.Dynamic.Runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.nuspec",
-        "lib/netcore50/System.Globalization.dll",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
-        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
         "ref/dotnet/it/System.Globalization.xml",
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
-        "ref/dotnet/es/System.Globalization.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Calendars.nuspec",
-        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
-        "lib/net46/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
         "ref/dotnet/it/System.Globalization.Calendars.xml",
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet/es/System.Globalization.Calendars.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
-        "lib/net46/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
         "ref/dotnet/it/System.Globalization.Extensions.xml",
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet/es/System.Globalization.Extensions.xml",
-        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
-        "[Content_Types].xml"
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.nuspec",
-        "lib/netcore50/System.IO.dll",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
-        "ref/dotnet/zh-hant/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
         "ref/dotnet/it/System.IO.xml",
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
-        "ref/dotnet/es/System.IO.xml",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
         "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
         "ref/dotnet/it/System.IO.Compression.xml",
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
-        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.clrcompression-x86.nuspec",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "runtimes/win10-x86/native/ClrCompression.dll",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win10-x86/native/ClrCompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "System.IO.Compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
-        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
-        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.ZipFile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
-        "lib/netcore50/System.IO.FileSystem.dll",
-        "lib/net46/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
         "ref/dotnet/it/System.IO.FileSystem.xml",
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
-        "ref/dotnet/es/System.IO.FileSystem.xml",
-        "ref/net46/System.IO.FileSystem.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
-        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
-        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.IO.Pipes/4.0.0-beta-23123": {
       "sha512": "TnytoLSYehYWAdumEN7WAq8YoIyqsdLNCA+6IuWFI0594egTzAgv7LH4gv5IN/1NgoN1LLxcK4P/m/EKyf4XCw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Pipes.nuspec",
         "lib/DNXCore50/System.IO.Pipes.dll",
         "lib/net46/System.IO.Pipes.dll",
-        "ref/dotnet/System.IO.Pipes.dll",
-        "ref/dotnet/System.IO.Pipes.xml",
-        "ref/dotnet/zh-hant/System.IO.Pipes.xml",
+        "package/services/metadata/core-properties/f57aab004bb94ccbb87be8c4c3babf1d.psmdcp",
         "ref/dotnet/de/System.IO.Pipes.xml",
+        "ref/dotnet/es/System.IO.Pipes.xml",
         "ref/dotnet/fr/System.IO.Pipes.xml",
         "ref/dotnet/it/System.IO.Pipes.xml",
         "ref/dotnet/ja/System.IO.Pipes.xml",
         "ref/dotnet/ko/System.IO.Pipes.xml",
         "ref/dotnet/ru/System.IO.Pipes.xml",
+        "ref/dotnet/System.IO.Pipes.dll",
+        "ref/dotnet/System.IO.Pipes.xml",
         "ref/dotnet/zh-hans/System.IO.Pipes.xml",
-        "ref/dotnet/es/System.IO.Pipes.xml",
+        "ref/dotnet/zh-hant/System.IO.Pipes.xml",
         "ref/net46/System.IO.Pipes.dll",
-        "package/services/metadata/core-properties/f57aab004bb94ccbb87be8c4c3babf1d.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Pipes.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
         "ref/dotnet/it/System.Linq.xml",
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.dll",
         "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Expressions.nuspec",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
-        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
         "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
         "ref/dotnet/it/System.Linq.Expressions.xml",
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
-        "ref/dotnet/es/System.Linq.Expressions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
         "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
         "ref/dotnet/it/System.Linq.Parallel.xml",
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
-        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
-        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
         "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
         "ref/dotnet/it/System.Linq.Queryable.xml",
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
-        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Queryable.dll",
         "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Http.nuspec",
-        "lib/netcore50/System.Net.Http.dll",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
-        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
         "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
         "ref/dotnet/it/System.Net.Http.xml",
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
-        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Http.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
-        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.10-beta-23123": {
       "sha512": "NkKpsUm2MLoxT+YlSwexidAw2jGFIJuc6i4H9pT3nU3TQj7MZVursD/ohWj3nyBxthy7i00XLWkRZAwGao/zsg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Primitives.nuspec",
-        "lib/netcore50/System.Net.Primitives.dll",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
         "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
         "ref/dotnet/it/System.Net.Primitives.xml",
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
-        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Primitives.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Numerics.Vectors.nuspec",
         "lib/dotnet/System.Numerics.Vectors.dll",
-        "lib/net46/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
         "ref/dotnet/System.Numerics.Vectors.dll",
-        "ref/net46/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "[Content_Types].xml"
+        "System.Numerics.Vectors.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
-        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
         "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
         "ref/dotnet/it/System.ObjectModel.xml",
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
-        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
-        "[Content_Types].xml"
+        "System.ObjectModel.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Networking.nuspec",
-        "lib/netcore50/System.Private.Networking.dll",
         "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Networking.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Uri.nuspec",
-        "lib/netcore50/System.Private.Uri.dll",
         "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.nuspec",
-        "lib/netcore50/System.Reflection.dll",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
-        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
         "ref/dotnet/it/System.Reflection.xml",
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
-        "ref/dotnet/es/System.Reflection.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.DispatchProxy.nuspec",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
-        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
         "ref/dotnet/it/System.Reflection.Emit.xml",
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
-        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
-        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
-        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Extensions.nuspec",
-        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
         "ref/dotnet/it/System.Reflection.Extensions.xml",
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
-        "ref/dotnet/es/System.Reflection.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Extensions.dll",
         "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Metadata.nuspec",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Primitives.nuspec",
-        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
         "ref/dotnet/it/System.Reflection.Primitives.xml",
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
-        "ref/dotnet/es/System.Reflection.Primitives.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.TypeExtensions.nuspec",
-        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
-        "lib/net46/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Resources.ResourceManager.nuspec",
-        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
-        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
         "ref/dotnet/it/System.Resources.ResourceManager.xml",
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
-        "ref/dotnet/es/System.Resources.ResourceManager.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Resources.ResourceManager.dll",
         "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.nuspec",
-        "lib/netcore50/System.Runtime.dll",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
         "ref/dotnet/it/System.Runtime.xml",
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
-        "ref/dotnet/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Extensions.nuspec",
-        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
         "ref/dotnet/it/System.Runtime.Extensions.xml",
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
-        "ref/dotnet/es/System.Runtime.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
-        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
         "ref/dotnet/it/System.Runtime.Handles.xml",
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
-        "ref/dotnet/es/System.Runtime.Handles.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
-        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
-        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
         "ref/dotnet/it/System.Runtime.InteropServices.xml",
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
-        "ref/dotnet/es/System.Runtime.InteropServices.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
       "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
         "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
         "ref/dotnet/it/System.Runtime.Numerics.xml",
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
-        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.Numerics.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/net46/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
         "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
         "ref/dotnet/it/System.Security.Claims.xml",
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/net46/System.Security.Claims.dll",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Claims.nuspec"
       ]
     },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Cryptography.Encryption.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
-        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
-        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
+        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
         "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/it/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
-        "ref/net46/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encryption.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Cryptography.Encryption.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
-        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
         "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
         "ref/dotnet/it/System.Security.Principal.xml",
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
-        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Principal.nuspec"
       ]
     },
     "System.Security.SecureString/4.0.0-beta-23123": {
       "sha512": "T35YL/7zWBYOLJCcntF+bQgZBgOy5qc6oPn4GWL1phv0borJawTL60iwk4MO2ReYYSK89JmJ7/yqKahqYNw72g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.SecureString.nuspec",
         "lib/DNXCore50/System.Security.SecureString.dll",
-        "lib/net46/System.Security.SecureString.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.SecureString.dll",
-        "ref/dotnet/System.Security.SecureString.xml",
-        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
         "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
         "ref/dotnet/fr/System.Security.SecureString.xml",
         "ref/dotnet/it/System.Security.SecureString.xml",
         "ref/dotnet/ja/System.Security.SecureString.xml",
         "ref/dotnet/ko/System.Security.SecureString.xml",
         "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/zh-hans/System.Security.SecureString.xml",
-        "ref/dotnet/es/System.Security.SecureString.xml",
-        "ref/net46/System.Security.SecureString.dll",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.nuspec",
-        "lib/netcore50/System.Text.Encoding.dll",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
         "ref/dotnet/it/System.Text.Encoding.xml",
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
-        "ref/dotnet/es/System.Text.Encoding.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.Extensions.nuspec",
-        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
-        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
         "ref/dotnet/it/System.Text.RegularExpressions.xml",
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
-        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
-        "[Content_Types].xml"
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
-        "lib/netcore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
-        "ref/dotnet/zh-hant/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
         "ref/dotnet/it/System.Threading.xml",
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
-        "ref/dotnet/es/System.Threading.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Overlapped.nuspec",
-        "lib/netcore50/System.Threading.Overlapped.dll",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
-        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
         "ref/dotnet/it/System.Threading.Overlapped.xml",
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
-        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.nuspec",
-        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
         "ref/dotnet/it/System.Threading.Tasks.xml",
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
-        "ref/dotnet/es/System.Threading.Tasks.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
     "System.Threading.Thread/4.0.0-beta-23123": {
       "sha512": "qu18HhV/xvNSqh3KjY5olJnVN4dJI2FoPB/BQ7vyDbvSJUEhemUmwuNGAx4TpyO4aBdbGCcLxVkWQIo30yxbeQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Thread.nuspec",
         "lib/DNXCore50/System.Threading.Thread.dll",
-        "lib/net46/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.xml",
-        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
+        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
         "ref/dotnet/de/System.Threading.Thread.xml",
+        "ref/dotnet/es/System.Threading.Thread.xml",
         "ref/dotnet/fr/System.Threading.Thread.xml",
         "ref/dotnet/it/System.Threading.Thread.xml",
         "ref/dotnet/ja/System.Threading.Thread.xml",
         "ref/dotnet/ko/System.Threading.Thread.xml",
         "ref/dotnet/ru/System.Threading.Thread.xml",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/dotnet/System.Threading.Thread.xml",
         "ref/dotnet/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet/es/System.Threading.Thread.xml",
-        "ref/net46/System.Threading.Thread.dll",
+        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Thread.nuspec"
       ]
     },
     "System.Threading.ThreadPool/4.0.10-beta-23123": {
       "sha512": "v3gETuR6Z96CPmZrM7260+MK2eFP8wVm4VcaSH3HDEqIHCByWDWOfY7C80TUdtXshnITcUeIoSU/C6rLwKoiVg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.ThreadPool.nuspec",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/dotnet/System.Threading.ThreadPool.xml",
-        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
         "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
         "ref/dotnet/fr/System.Threading.ThreadPool.xml",
         "ref/dotnet/it/System.Threading.ThreadPool.xml",
         "ref/dotnet/ja/System.Threading.ThreadPool.xml",
         "ref/dotnet/ko/System.Threading.ThreadPool.xml",
         "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet/es/System.Threading.ThreadPool.xml",
-        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Timer.nuspec",
-        "lib/netcore50/System.Threading.Timer.dll",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
-        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
         "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
         "ref/dotnet/it/System.Threading.Timer.xml",
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
-        "ref/dotnet/es/System.Threading.Timer.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
-        "ref/win81/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
         "ref/dotnet/it/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XDocument.nuspec",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
         "ref/dotnet/it/System.Xml.XDocument.xml",
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XDocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XmlDocument.dll",
-        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XmlDocument.xml",
-        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XmlDocument.nuspec"
       ]
     },
     "System.Xml.XPath/4.0.0": {
       "sha512": "jalVwhZSwErcW28NZOE3Dqb6B1XA4DAsL15JvykYIKXtXYQU8PI5GXssjF5G0bLm8/6Gko2e1SOjRs/MoeAKrw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.nuspec",
         "lib/dotnet/System.Xml.XPath.dll",
-        "lib/net46/System.Xml.XPath.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XPath.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.dll",
-        "ref/dotnet/System.Xml.XPath.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
+        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.xml",
+        "ref/dotnet/es/System.Xml.XPath.xml",
         "ref/dotnet/fr/System.Xml.XPath.xml",
         "ref/dotnet/it/System.Xml.XPath.xml",
         "ref/dotnet/ja/System.Xml.XPath.xml",
         "ref/dotnet/ko/System.Xml.XPath.xml",
         "ref/dotnet/ru/System.Xml.XPath.xml",
+        "ref/dotnet/System.Xml.XPath.dll",
+        "ref/dotnet/System.Xml.XPath.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.xml",
-        "ref/dotnet/es/System.Xml.XPath.xml",
-        "ref/net46/System.Xml.XPath.dll",
+        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XPath.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.nuspec"
       ]
     },
     "System.Xml.XPath.XmlDocument/4.0.0": {
       "sha512": "toGFsezsdAJ3Fkau0l386iGBg3qfYauQrM4haX1nWPYnUOWb0hXfAEVIi47/Ke4ET3gl9h9ZppKiws8QWeJVyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XPath.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
+        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.XmlDocument.nuspec"
       ]
     }
   },
@@ -5783,19 +5845,20 @@
     "DNXCore,Version=v5.0": [
       "Microsoft.NETCore >= 5.0.0",
       "Microsoft.NETCore.Portable.Compatibility >= 1.0.0",
+      "Microsoft.NETCore.Runtime >= 1.0.0",
+      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
+      "Microsoft.Win32.Registry >= 4.0.0-beta-23127",
       "System.Console >= 4.0.0-beta-23123",
-      "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
-      "System.IO.Pipes >= 4.0.0-beta-23123",
       "System.Diagnostics.FileVersionInfo >= 4.0.0-beta-23123",
       "System.Diagnostics.Process >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
+      "System.IO.Pipes >= 4.0.0-beta-23123",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
+      "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Threading.Thread >= 4.0.0-beta-23123",
-      "System.Xml.XmlDocument >= 4.0.0",
-      "System.Xml.XPath.XmlDocument >= 4.0.0",
       "System.Xml.ReaderWriter >= 4.0.10",
-      "Microsoft.NETCore.Runtime >= 1.0.0",
-      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
-      "Microsoft.Win32.Registry >= 4.0.0-beta-23127"
+      "System.Xml.XmlDocument >= 4.0.0",
+      "System.Xml.XPath.XmlDocument >= 4.0.0"
     ]
   }
 }

--- a/src/XMakeTasks/AppConfig/AppConfigException.cs
+++ b/src/XMakeTasks/AppConfig/AppConfigException.cs
@@ -10,7 +10,12 @@ namespace Microsoft.Build.Tasks
     /// An exception thrown while parsing through an app.config.
     /// </summary>
     [Serializable]
-    internal class AppConfigException : System.ApplicationException
+    internal class AppConfigException :
+#if FEATURE_VARIOUS_EXCEPTIONS
+        System.ApplicationException
+#else
+        Exception
+#endif
     {
         /// <summary>
         /// The name of the app.config file.
@@ -65,11 +70,13 @@ namespace Microsoft.Build.Tasks
             _column = column;
         }
 
+#if FEATURE_BINARY_SERIALIZATION
         /// <summary>
         /// Construct the exception.
         /// </summary>
         protected AppConfigException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/XMakeTasks/AppConfig/BindingRedirect.cs
+++ b/src/XMakeTasks/AppConfig/BindingRedirect.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Tasks
         /// The reader is positioned on a &lt;bindingRedirect&gt; element--read it.
         /// </summary>
         /// <param name="reader"></param>
-        internal void Read(XmlTextReader reader)
+        internal void Read(XmlReader reader)
         {
             string oldVersion = reader.GetAttribute("oldVersion");
 

--- a/src/XMakeTasks/AppConfig/DependentAssembly.cs
+++ b/src/XMakeTasks/AppConfig/DependentAssembly.cs
@@ -33,7 +33,11 @@ namespace Microsoft.Build.Tasks
         {
             set
             {
+#if FEATURE_ASSEMBLYNAME_CLONE
                 _partialAssemblyName = (AssemblyName)value.Clone();
+#else
+                _partialAssemblyName = new AssemblyName(value.FullName);
+#endif
                 _partialAssemblyName.Version = null;
             }
             get
@@ -42,7 +46,11 @@ namespace Microsoft.Build.Tasks
                 {
                     return null;
                 }
+#if FEATURE_ASSEMBLYNAME_CLONE
                 return (AssemblyName)_partialAssemblyName.Clone();
+#else
+                return new AssemblyName(_partialAssemblyName.FullName);
+#endif
             }
         }
 
@@ -50,7 +58,7 @@ namespace Microsoft.Build.Tasks
         /// The reader is positioned on a &lt;dependentassembly&gt; element--read it.
         /// </summary>
         /// <param name="reader"></param>
-        internal void Read(XmlTextReader reader)
+        internal void Read(XmlReader reader)
         {
             ArrayList redirects = new ArrayList();
 

--- a/src/XMakeTasks/AppConfig/RuntimeSection.cs
+++ b/src/XMakeTasks/AppConfig/RuntimeSection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Tasks
         /// The reader is positioned on a &lt;runtime&gt; element--read it.
         /// </summary>
         /// <param name="reader"></param>
-        internal void Read(XmlTextReader reader)
+        internal void Read(XmlReader reader)
         {
             while (reader.Read())
             {

--- a/src/XMakeTasks/AssemblyDependency/AssemblyNameReferenceAscendingVersionComparer.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyNameReferenceAscendingVersionComparer.cs
@@ -36,12 +36,12 @@ namespace Microsoft.Build.Tasks
 
             if (v1 == null)
             {
-                v1 = new Version();
+                v1 = new Version(0, 0);
             }
 
             if (v2 == null)
             {
-                v2 = new Version();
+                v2 = new Version(0, 0);
             }
 
             return v1.CompareTo(v2);

--- a/src/XMakeTasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyResolution.cs
@@ -160,10 +160,12 @@ namespace Microsoft.Build.Tasks
                 {
                     resolvers[p] = new CandidateAssemblyFilesResolver(candidateAssemblyFiles, searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
                 }
+#if FEATURE_GAC
                 else if (0 == String.Compare(basePath, AssemblyResolutionConstants.gacSentinel, StringComparison.OrdinalIgnoreCase))
                 {
                     resolvers[p] = new GacResolver(targetProcessorArchitecture, searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, getAssemblyPathInGac);
                 }
+#endif
                 else if (0 == String.Compare(basePath, AssemblyResolutionConstants.assemblyFoldersSentinel, StringComparison.OrdinalIgnoreCase))
                 {
                     resolvers[p] = new AssemblyFoldersResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);

--- a/src/XMakeTasks/AssemblyDependency/BadImageReferenceException.cs
+++ b/src/XMakeTasks/AssemblyDependency/BadImageReferenceException.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Build.Tasks
         {
         }
 
+#if FEATURE_BINARY_SERIALIZATION
         /// <summary>
         /// Construct
         /// </summary>
@@ -34,5 +35,6 @@ namespace Microsoft.Build.Tasks
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/XMakeTasks/AssemblyDependency/DependencyResolutionException.cs
+++ b/src/XMakeTasks/AssemblyDependency/DependencyResolutionException.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Build.Tasks
         {
         }
 
+#if FEATURE_BINARY_SERIALIZATION
         /// <summary>
         /// Construct
         /// </summary>
@@ -34,5 +35,6 @@ namespace Microsoft.Build.Tasks
             : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/XMakeTasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/XMakeTasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -129,7 +129,10 @@ namespace Microsoft.Build.Tasks
                 OutputAppConfigFile.SetMetadata(ItemMetadataNames.targetPath, TargetName);
             }
 
-            doc.Save(OutputAppConfigFile.ItemSpec);
+            using (var stream = FileUtilities.OpenWrite(OutputAppConfigFile.ItemSpec, false))
+            {
+                doc.Save(stream);
+            }
 
             return !Log.HasLoggedErrors;
         }

--- a/src/XMakeTasks/AssemblyDependency/InvalidReferenceAssemblyNameException.cs
+++ b/src/XMakeTasks/AssemblyDependency/InvalidReferenceAssemblyNameException.cs
@@ -38,12 +38,14 @@ namespace Microsoft.Build.Tasks
             _sourceItemSpec = sourceItemSpec;
         }
 
+#if FEATURE_BINARY_SERIALIZATION
         /// <summary>
         /// Construct
         /// </summary>
         private InvalidReferenceAssemblyNameException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#endif
 
         /// <summary>
         /// The item spec of the item that is the source fo the problem.

--- a/src/XMakeTasks/AssemblyDependency/ReferenceResolutionException.cs
+++ b/src/XMakeTasks/AssemblyDependency/ReferenceResolutionException.cs
@@ -35,12 +35,13 @@ namespace Microsoft.Build.Tasks
         {
         }
 
-
+#if FEATURE_BINARY_SERIALIZATION
         /// <summary>
         /// Implement required constructors for serialization
         /// </summary>
         private ReferenceResolutionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/XMakeTasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/XMakeTasks/AssemblyDependency/ReferenceTable.cs
@@ -1075,7 +1075,11 @@ namespace Microsoft.Build.Tasks
                 string name = preUnificationAssemblyName.Name;
                 // First, unify the assembly name so that we're dealing with the right version.
                 // Not AssemblyNameExtension because we're going to write to it.
+#if FEATURE_ASSEMBLYNAME_CLONE
                 AssemblyNameExtension dependentAssembly = new AssemblyNameExtension((AssemblyName)preUnificationAssemblyName.AssemblyName.Clone());
+#else
+                AssemblyNameExtension dependentAssembly = new AssemblyNameExtension(new AssemblyName(preUnificationAssemblyName.AssemblyName.FullName));
+#endif
 
                 Version unifiedVersion;
                 bool isPrerequisite;
@@ -1884,7 +1888,11 @@ namespace Microsoft.Build.Tasks
                 byte[] pkt = assemblyName.GetPublicKeyToken();
                 if (pkt != null && pkt.Length > 0)
                 {
+#if FEATURE_ASSEMBLYNAME_CLONE
                     AssemblyName baseKey = (AssemblyName)assemblyName.AssemblyName.Clone();
+#else
+                    AssemblyName baseKey = new AssemblyName(assemblyName.AssemblyName.FullName);
+#endif
                     Version version = baseKey.Version;
                     baseKey.Version = null;
                     string key = baseKey.ToString();
@@ -2374,7 +2382,11 @@ namespace Microsoft.Build.Tasks
                 foreach (DependentAssembly remappedAssembly in _remappedAssemblies)
                 {
                     // First, exclude anything without the simple name match
+#if FEATURE_ASSEMBLYNAME_CLONE
                     AssemblyNameExtension comparisonAssembly = new AssemblyNameExtension((AssemblyName)remappedAssembly.PartialAssemblyName.Clone());
+#else
+                    AssemblyNameExtension comparisonAssembly = new AssemblyNameExtension(new AssemblyName(remappedAssembly.PartialAssemblyName.FullName));
+#endif
                     if (assemblyName.CompareBaseNameTo(comparisonAssembly) == 0)
                     {
                         // Comparison assembly is a partial name. Give it our version.

--- a/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -41,10 +41,13 @@ namespace Microsoft.Build.Tasks
         /// <returns>String array of redist or subset lists</returns>
         private delegate string[] GetListPath(string targetFrameworkDirectory);
 
+
+#if FEATURE_BINARY_SERIALIZATION
         /// <summary>
         /// Cache of system state information, used to optimize performance.
         /// </summary>
         private SystemState _cache = null;
+#endif
 
         /// <summary>
         /// Construct
@@ -1812,6 +1815,7 @@ namespace Microsoft.Build.Tasks
             }
         }
         #endregion
+#if FEATURE_BINARY_SERIALIZATION
         #region StateFile
         /// <summary>
         /// Reads the state file (if present) into the cache.
@@ -1838,6 +1842,7 @@ namespace Microsoft.Build.Tasks
             }
         }
         #endregion
+#endif
         #region App.config
         /// <summary>
         /// Read the app.config and get any assembly remappings from it.
@@ -2040,6 +2045,7 @@ namespace Microsoft.Build.Tasks
                         }
                     }
 
+#if FEATURE_BINARY_SERIALIZATION
                     // Load any prior saved state.
                     ReadStateFile();
                     _cache.SetGetLastWriteTime(getLastWriteTime);
@@ -2051,6 +2057,7 @@ namespace Microsoft.Build.Tasks
                     fileExists = _cache.CacheDelegate(fileExists);
                     getDirectories = _cache.CacheDelegate(getDirectories);
                     getRuntimeVersion = _cache.CacheDelegate(getRuntimeVersion);
+#endif
 
                     _projectTargetFramework = FrameworkVersionFromString(_projectTargetFrameworkAsString);
 
@@ -2259,7 +2266,9 @@ namespace Microsoft.Build.Tasks
 
                     this.DependsOnSystemRuntime = useSystemRuntime.ToString();
 
+#if FEATURE_BINARY_SERIALIZATION
                     WriteStateFile();
+#endif
 
                     // Save the new state out and put into the file exists if it is actually on disk.
                     if (_stateFile != null && fileExists(_stateFile))
@@ -2878,7 +2887,11 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private string GetAssemblyPathInGac(AssemblyNameExtension assemblyName, SystemProcessorArchitecture targetProcessorArchitecture, GetAssemblyRuntimeVersion getRuntimeVersion, Version targetedRuntimeVersion, FileExists fileExists, bool fullFusionName, bool specificVersion)
         {
+#if FEATURE_GAC
             return GlobalAssemblyCache.GetLocation(BuildEngine as IBuildEngine4, assemblyName, targetProcessorArchitecture, getRuntimeVersion, targetedRuntimeVersion, fullFusionName, fileExists, null, null, specificVersion /* this value does not matter if we are passing a full fusion name*/);
+#else
+            return string.Empty;
+#endif
         }
 
         /// <summary>

--- a/src/XMakeTasks/AssignTargetPath.cs
+++ b/src/XMakeTasks/AssignTargetPath.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Tasks
                             // we should avoid calling it whenever possible
                             string itemSpecFullFileNamePath = Path.GetFullPath(Files[i].ItemSpec);
 
-                            if (String.Compare(fullRootPath, 0, itemSpecFullFileNamePath, 0, fullRootPath.Length, true, CultureInfo.CurrentCulture) == 0)
+                            if (String.Compare(fullRootPath, 0, itemSpecFullFileNamePath, 0, fullRootPath.Length, StringComparison.CurrentCultureIgnoreCase) == 0)
                             {
                                 // The item spec file is in the "cone" of the RootFolder. Return the relative path from the cone root.
                                 targetPath = itemSpecFullFileNamePath.Substring(fullRootPath.Length);

--- a/src/XMakeTasks/GetReferenceAssemblyPaths.cs
+++ b/src/XMakeTasks/GetReferenceAssemblyPaths.cs
@@ -196,6 +196,7 @@ namespace Microsoft.Build.Tasks
                     monikerWithNoProfile = new FrameworkNameVersioning(moniker.Identifier, moniker.Version);
                 }
 
+#if FEATURE_GAC
                 // This is a very specific "hack" to ensure that when we're targeting certain .NET Framework versions that
                 // WPF gets to rely on .NET FX 3.5 SP1 being installed on the build machine.
                 // This only needs to occur when we are targeting a .NET FX prior to v4.0
@@ -218,6 +219,7 @@ namespace Microsoft.Build.Tasks
                         Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NETFX35SP1NotIntstalled", TargetFrameworkMoniker);
                     }
                 }
+#endif
             }
             catch (ArgumentException e)
             {

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -203,6 +203,15 @@
     <Compile Include="AppConfig\*.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssemblyDependency\AssemblyFoldersExResolver.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\AssemblyFoldersResolver.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\AssemblyInformation.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="AssemblyDependency\AssemblyNameReference.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -218,6 +227,9 @@
     <Compile Include="AssemblyDependency\BadImageReferenceException.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssemblyDependency\CandidateAssemblyFilesResolver.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="AssemblyDependency\ConflictLossReason.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -227,6 +239,18 @@
     <Compile Include="AssemblyDependency\DependencyResolutionException.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssemblyDependency\DirectoryResolver.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\DisposableBase.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\FrameworkPathResolver.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\HintPathResolver.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="AssemblyDependency\InstalledAssemblies.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -234,6 +258,9 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\NoMatchReason.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\RawFilenameResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\Reference.cs">
@@ -268,6 +295,9 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\WarnOrErrorOnTargetArchitectureMismatchBehavior.cs" />
+    <Compile Include="AssemblyFolder.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="AssemblyInfo.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -311,6 +341,7 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="GetReferenceAssemblyPaths.cs" />
+    <Compile Include="InstalledSDKResolver.cs" />
     <Compile Include="MSBuild.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -418,41 +449,11 @@
     <Compile Include="AspNetCompiler.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssemblyDependency\AssemblyFoldersExResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\AssemblyFoldersResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\AssemblyInformation.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\CandidateAssemblyFilesResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\DirectoryResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\DisposableBase.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\FrameworkPathResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="AssemblyDependency\GacResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\GenerateBindingRedirects.cs" />
     <Compile Include="AssemblyDependency\GlobalAssemblyCache.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\HintPathResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\RawFilenameResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyFolder.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyRegistrationCache.cs">
@@ -561,7 +562,6 @@
     <Compile Include="IComReferenceResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="InstalledSDKResolver.cs" />
     <Compile Include="RCWForCurrentContext.cs" />
     <Compile Include="LC.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -13,6 +13,7 @@
     <RootNamespace>Microsoft.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -430,6 +431,9 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResolveCodeAnalysisRuleSet.cs" /> 
+    <Compile Include="ResolveKeySource.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="TaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -587,9 +591,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResolveComReferenceCache.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="ResolveKeySource.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResolveManifestFiles.cs" Condition="!$(Configuration.EndsWith('MONO'))">

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -248,6 +248,7 @@
     <Compile Include="AssemblyDependency\FrameworkPathResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssemblyDependency\GenerateBindingRedirects.cs" />
     <Compile Include="AssemblyDependency\HintPathResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -305,6 +306,9 @@
     <Compile Include="AssemblyResources.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssignTargetPath.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="CallTarget.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -340,23 +344,11 @@
     <Compile Include="FindAppConfigFile.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="GetFrameworkPath.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="GetReferenceAssemblyPaths.cs" />
     <Compile Include="InstalledSDKResolver.cs" />
-    <Compile Include="MSBuild.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="Message.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="NativeMethods.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="TaskExtension.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="ToolTaskExtension.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="ErrorFromResources.cs" />
     <Compile Include="ExtractedClassName.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
@@ -421,11 +413,27 @@
     <Compile Include="MakeDir.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Message.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="Move.cs" />
+    <Compile Include="MSBuild.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="NativeMethods.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="RedistList.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="RemoveDir.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="ResolveCodeAnalysisRuleSet.cs" /> 
+    <Compile Include="TaskExtension.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="ToolTaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Touch.cs">
@@ -452,7 +460,6 @@
     <Compile Include="AssemblyDependency\GacResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssemblyDependency\GenerateBindingRedirects.cs" />
     <Compile Include="AssemblyDependency\GlobalAssemblyCache.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -461,9 +468,6 @@
     </Compile>
     <Compile Include="AssignLinkMetadata.cs" />
     <Compile Include="AssignProjectConfiguration.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssignTargetPath.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AxImp.cs" />
@@ -551,9 +555,6 @@
     <Compile Include="GetAssemblyIdentity.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="GetFrameworkPath.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="GetFrameworkSDKPath.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -582,7 +583,6 @@
     <Compile Include="ResGenDependencies.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="ResolveCodeAnalysisRuleSet.cs" />
     <Compile Include="ResolveComReference.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -78,6 +78,9 @@
       <Link>Constants.cs</Link>
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="ConvertToAbsolutePath.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="..\Shared\CopyOnWriteDictionary.cs" />
     <Compile Include="..\Shared\ExtensionFoldersRegistryKey.cs">
       <Link>ExtensionFoldersRegistryKey.cs</Link>
@@ -197,15 +200,78 @@
     <Compile Include="..\Shared\LanguageParser\tokenEnumerator.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="Message.cs">
+    <Compile Include="AppConfig\*.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="TaskExtension.cs">
+    <Compile Include="AssemblyDependency\AssemblyNameReference.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssemblyDependency\AssemblyNameReferenceAscendingVersionComparer.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\AssemblyResolution.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\AssemblyResolutionConstants.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\BadImageReferenceException.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\ConflictLossReason.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\CopyLocalState.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\DependencyResolutionException.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\InstalledAssemblies.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\InvalidReferenceAssemblyNameException.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\NoMatchReason.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\Reference.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\ReferenceResolutionException.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\ReferenceTable.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\ResolutionSearchLocation.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\Resolver.cs">
+      <SubType>Code</SubType>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\ResolveAssemblyReference.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\TaskItemSpecFilenameComparer.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\UnificationReason.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\UnificationVersion.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\UnifiedAssemblyName.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="AssemblyDependency\WarnOrErrorOnTargetArchitectureMismatchBehavior.cs" />
     <Compile Include="AssemblyInfo.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssemblyRemapping.cs" />
     <Compile Include="AssemblyResources.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -241,10 +307,20 @@
     <Compile Include="Exec.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="FindAppConfigFile.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="GetReferenceAssemblyPaths.cs" />
     <Compile Include="MSBuild.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Message.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="NativeMethods.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
+    <Compile Include="TaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ToolTaskExtension.cs">
@@ -315,6 +391,9 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Move.cs" />
+    <Compile Include="RedistList.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="RemoveDir.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -336,9 +415,6 @@
     <Compile Include="AppDomainIsolatedTaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AppConfig\*.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="AspNetCompiler.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -351,31 +427,7 @@
     <Compile Include="AssemblyDependency\AssemblyInformation.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssemblyDependency\AssemblyNameReference.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\AssemblyNameReferenceAscendingVersionComparer.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\AssemblyResolution.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\AssemblyResolutionConstants.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\BadImageReferenceException.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="AssemblyDependency\CandidateAssemblyFilesResolver.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\ConflictLossReason.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\CopyLocalState.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\DependencyResolutionException.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\DirectoryResolver.cs">
@@ -397,57 +449,15 @@
     <Compile Include="AssemblyDependency\HintPathResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssemblyDependency\InstalledAssemblies.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\InvalidReferenceAssemblyNameException.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\NoMatchReason.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="AssemblyDependency\RawFilenameResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssemblyDependency\Reference.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\ReferenceResolutionException.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\ReferenceTable.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\ResolutionSearchLocation.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\ResolveAssemblyReference.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\Resolver.cs">
-      <SubType>Code</SubType>
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\TaskItemSpecFilenameComparer.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\UnificationReason.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\UnificationVersion.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\UnifiedAssemblyName.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="AssemblyDependency\WarnOrErrorOnTargetArchitectureMismatchBehavior.cs" />
     <Compile Include="AssemblyFolder.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyRegistrationCache.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssemblyRemapping.cs" />
     <Compile Include="AssignLinkMetadata.cs" />
     <Compile Include="AssignProjectConfiguration.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
@@ -488,9 +498,6 @@
     <Compile Include="ComReferenceWrapperInfo.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="ConvertToAbsolutePath.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="CreateCSharpManifestResourceName.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -516,9 +523,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="DependencyFile.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="FindAppConfigFile.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="FindInvalidProjectReferences.cs" />
@@ -553,7 +557,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="GetInstalledSDKLocations.cs" />
-    <Compile Include="GetReferenceAssemblyPaths.cs" />
     <Compile Include="GetSDKReferenceFiles.cs" />
     <Compile Include="IComReferenceResolver.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
@@ -570,9 +573,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="PiaReference.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="RedistList.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="RegisterAssembly.cs">

--- a/src/XMakeTasks/ResolveKeySource.cs
+++ b/src/XMakeTasks/ResolveKeySource.cs
@@ -10,7 +10,9 @@ using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+#if FEATURE_PFX_SIGNING
 using Microsoft.Runtime.Hosting;
+#endif
 
 namespace Microsoft.Build.Tasks
 {
@@ -159,6 +161,7 @@ namespace Microsoft.Build.Tasks
                     }
                     else
                     {
+#if FEATURE_PFX_SIGNING
                         pfxSuccess = false;
                         // it is .pfx file. It is being imported into key container with name = "VS_KEY_<MD5 check sum of the encrypted file>"
                         System.IO.FileStream fs = null;
@@ -219,6 +222,10 @@ namespace Microsoft.Build.Tasks
                                 fs.Close();
                             }
                         }
+#else
+                        Log.LogError("PFX signing not supported on .NET Core");
+                        pfxSuccess = false;
+#endif
                     }
                 }
             }
@@ -247,7 +254,11 @@ namespace Microsoft.Build.Tasks
                 }
                 finally
                 {
+#if FEATURE_PFX_SIGNING
                     personalStore.Close();
+#else
+                    personalStore.Dispose();
+#endif
                 }
                 if (!certSuccess)
                 {
@@ -257,6 +268,7 @@ namespace Microsoft.Build.Tasks
 
             if (!string.IsNullOrEmpty(CertificateFile) && !certInStore)
             {
+#if FEATURE_PFX_SIGNING
                 // if the cert isn't on disk, we can't import it
                 if (!File.Exists(CertificateFile))
                 {
@@ -318,6 +330,9 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                 }
+#else
+                Log.LogError("Certificate signing not supported on .NET Core");
+#endif
             }
             else if (!certInStore && !string.IsNullOrEmpty(CertificateFile) && !string.IsNullOrEmpty(CertificateThumbprint))
             {

--- a/src/XMakeTasks/UnitTests/project.json
+++ b/src/XMakeTasks/UnitTests/project.json
@@ -26,6 +26,7 @@
         "System.Console": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
         "System.Globalization": "4.0.10",
+        "System.Reflection.Metadata": "1.1.0-alpha-00014",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
         "System.Xml.XmlDocument": "4.0.0",
         "System.Xml.ReaderWriter": "4.0.10",

--- a/src/XMakeTasks/UnitTests/project.lock.json
+++ b/src/XMakeTasks/UnitTests/project.lock.json
@@ -11,6 +11,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -72,6 +91,25 @@
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
       "xunit/2.1.0-rc1-build3168": {
         "dependencies": {
           "xunit.assert": "[2.1.0-rc1-build3168, 2.1.0-rc1-build3168]",
@@ -131,6 +169,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -220,6 +277,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -1236,28 +1312,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2863,28 +2926,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Collections": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -3970,6 +4020,19 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Collections.Concurrent.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
@@ -5327,17 +5390,16 @@
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
         "_rels/.rels",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
         "System.Reflection.Metadata.nuspec"
       ]
     },
@@ -6432,6 +6494,7 @@
       "System.Console >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
       "System.Globalization >= 4.0.10",
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
       "System.Xml.ReaderWriter >= 4.0.10",
       "System.Xml.XmlDocument >= 4.0.0"

--- a/src/XMakeTasks/UnitTests/project.lock.json
+++ b/src/XMakeTasks/UnitTests/project.lock.json
@@ -1450,6 +1450,24 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -1463,6 +1481,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -2187,6 +2233,68 @@
         },
         "runtime": {
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Globalization.Calendars": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Runtime.Numerics": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Cng": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Csp": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -3064,6 +3172,64 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -3077,6 +3243,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -3921,6 +4115,73 @@
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
         "ref/net46/Microsoft.Win32.Registry.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "IC7PgaDHuFUsCPW2zzuOA50NJIBDDvzh2JE83+y2hfL5A06aOZ/MegykcBEwfP0Dq6s7eT+2ZD19MJTMH/9QGw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/924fcc98aafd49cbac18eb8675970437.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "xbu5Wtp85oj6UviMDDyKuu+hNe2yNGvMXEpMBBHGq2WVzqSZE+ToYBrAoCHV5VbdBj3dS/bWQLxKwG0kCnbt4A==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/df8825162d064ad4bf2f5fc454e91be5.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "jh5U0VdyM8EUaqPEfYgVy1bVb8RKPgmn61YLIIyhCK6l1Fst8LmNwVC7Q3EzaQwCWIMh29CTQzihwkBVsoVXrw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/db47208018624b188fa7c43863463d75.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hant/System.Security.Cryptography.X509Certificates.xml"
       ]
     },
     "System.AppContext/4.0.0": {
@@ -5724,6 +5985,86 @@
         "System.Security.Claims.nuspec"
       ]
     },
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "25LZE9MSAs9/S2JxL3r0B7NmeGitGN++zCUvW/TAqsO5CMl/Ysse/q6F2783EHczGdCo+RJSkLgcxOJ6KGj1Qg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/20419424c30243f8aec61118e5d8eeaa.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Algorithms.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Algorithms.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+      "sha512": "Fwvz+VL5hCdJVxfLPnvFLhIKarGVED0iqouCLC7bHXL3fLTzb/B9a4Mcyv2Y8d+5J58ezRog0Gpl/fuNUPNDHg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Cng.dll",
+        "lib/net46/System.Security.Cryptography.Cng.dll",
+        "package/services/metadata/core-properties/9ab35fd122304d878e0a747255d00a93.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Cng.dll",
+        "ref/net46/System.Security.Cryptography.Cng.dll",
+        "System.Security.Cryptography.Cng.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+      "sha512": "m4VvZZSnZjZLoeDgif960VH0ghlMb/Id9hZNjFF2OHc0MiWXuWwD0Ii+CM+gyFonpCXIcDwVFCZMEZ+5sWMbJQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/648fed08d33f46959697f33a336f2d8d.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Csp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Csp.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "ko7c7fMmiWAk5/jBPxu/ne79AHCgEj7mVTKr9nT7tdyIF/XBEdFhBO4MnBOMdRMmKlGU5r8JIXSVTWogl52KUA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/96181ca5472843aab9f5d726a71879a6.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Encoding.nuspec"
+      ]
+    },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
@@ -5754,6 +6095,50 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Security.Cryptography.Encryption.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+      "sha512": "qfy2ZTRu7Xd0zlh/4dnpbPm38zZLcE8e1/e+Go3P9L9iPZARSOJWEja60ceIIrfSOS9wUGQwbdHetIjIq0rjkw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/6a1dc1f915064f9c9ba3c3aa7526d8e7.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Primitives.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "yes70JDjOIw9uDifXfXIq7RrnaPlnom1XcEjmeTN8TRdnIeckFUlYlvSkH2tztVYw8CY/Sy7/qlqIOIzBlpDag==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/a1c258831c694973aafeb648ffe94e76.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {

--- a/src/XMakeTasks/project.json
+++ b/src/XMakeTasks/project.json
@@ -24,6 +24,7 @@
         "System.Console": "4.0.0-beta-23123",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23019",
         "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23302",
+        "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23328",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
         "System.Xml.XmlDocument": "4.0.0",
         "System.Xml.ReaderWriter": "4.0.10",

--- a/src/XMakeTasks/project.json
+++ b/src/XMakeTasks/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-
+    "System.Reflection.Metadata": "1.1.0-alpha-00014"
   },
   "runtimes": {
     "win7-x86": { }

--- a/src/XMakeTasks/project.lock.json
+++ b/src/XMakeTasks/project.lock.json
@@ -1210,6 +1210,24 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -1223,6 +1241,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -1860,6 +1906,68 @@
         },
         "runtime": {
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Text.Encoding.Extensions": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Collections": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Globalization.Calendars": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Runtime.Numerics": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Cng": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Csp": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.AppContext/4.0.0": {
@@ -2701,6 +2809,64 @@
           "lib/dotnet/System.Security.Claims.dll": {}
         }
       },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Primitives": "[4.0.0-beta-23328, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
           "System.Globalization": "[4.0.0, )",
@@ -2714,6 +2880,34 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+        "dependencies": {
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Security.Cryptography.Algorithms": "[4.0.0-beta-23328, )",
+          "System.Security.Cryptography.Encoding": "[4.0.0-beta-23328, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -3471,6 +3665,73 @@
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
         "ref/net46/Microsoft.Win32.Registry.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "IC7PgaDHuFUsCPW2zzuOA50NJIBDDvzh2JE83+y2hfL5A06aOZ/MegykcBEwfP0Dq6s7eT+2ZD19MJTMH/9QGw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/924fcc98aafd49cbac18eb8675970437.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Algorithms.dll"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "xbu5Wtp85oj6UviMDDyKuu+hNe2yNGvMXEpMBBHGq2WVzqSZE+ToYBrAoCHV5VbdBj3dS/bWQLxKwG0kCnbt4A==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/df8825162d064ad4bf2f5fc454e91be5.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml"
+      ]
+    },
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "jh5U0VdyM8EUaqPEfYgVy1bVb8RKPgmn61YLIIyhCK6l1Fst8LmNwVC7Q3EzaQwCWIMh29CTQzihwkBVsoVXrw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/db47208018624b188fa7c43863463d75.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/win7/lib/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/de/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/es/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/fr/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/it/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ja/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ko/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/ru/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll",
+        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "runtimes/win7/lib/netcore50/zh-hant/System.Security.Cryptography.X509Certificates.xml"
       ]
     },
     "System.AppContext/4.0.0": {
@@ -5218,6 +5479,86 @@
         "System.Security.Claims.nuspec"
       ]
     },
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23328": {
+      "sha512": "25LZE9MSAs9/S2JxL3r0B7NmeGitGN++zCUvW/TAqsO5CMl/Ysse/q6F2783EHczGdCo+RJSkLgcxOJ6KGj1Qg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/20419424c30243f8aec61118e5d8eeaa.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Algorithms.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Algorithms.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Cng/4.0.0-beta-23328": {
+      "sha512": "Fwvz+VL5hCdJVxfLPnvFLhIKarGVED0iqouCLC7bHXL3fLTzb/B9a4Mcyv2Y8d+5J58ezRog0Gpl/fuNUPNDHg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Cng.dll",
+        "lib/net46/System.Security.Cryptography.Cng.dll",
+        "package/services/metadata/core-properties/9ab35fd122304d878e0a747255d00a93.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Cng.dll",
+        "ref/net46/System.Security.Cryptography.Cng.dll",
+        "System.Security.Cryptography.Cng.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-beta-23328": {
+      "sha512": "m4VvZZSnZjZLoeDgif960VH0ghlMb/Id9hZNjFF2OHc0MiWXuWwD0Ii+CM+gyFonpCXIcDwVFCZMEZ+5sWMbJQ==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/648fed08d33f46959697f33a336f2d8d.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Csp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Csp.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23328": {
+      "sha512": "ko7c7fMmiWAk5/jBPxu/ne79AHCgEj7mVTKr9nT7tdyIF/XBEdFhBO4MnBOMdRMmKlGU5r8JIXSVTWogl52KUA==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/96181ca5472843aab9f5d726a71879a6.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.Encoding.nuspec"
+      ]
+    },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
@@ -5248,6 +5589,50 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "System.Security.Cryptography.Encryption.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23328": {
+      "sha512": "qfy2ZTRu7Xd0zlh/4dnpbPm38zZLcE8e1/e+Go3P9L9iPZARSOJWEja60ceIIrfSOS9wUGQwbdHetIjIq0rjkw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/dotnet/System.Security.Cryptography.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/6a1dc1f915064f9c9ba3c3aa7526d8e7.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Security.Cryptography.Primitives.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23328": {
+      "sha512": "yes70JDjOIw9uDifXfXIq7RrnaPlnom1XcEjmeTN8TRdnIeckFUlYlvSkH2tztVYw8CY/Sy7/qlqIOIzBlpDag==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/a1c258831c694973aafeb648ffe94e76.psmdcp",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
@@ -5831,6 +6216,7 @@
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
       "System.IO.FileSystem.DriveInfo >= 4.0.0-beta-23302",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
+      "System.Security.Cryptography.X509Certificates >= 4.0.0-beta-23328",
       "System.Xml.ReaderWriter >= 4.0.10",
       "System.Xml.XmlDocument >= 4.0.0"
     ]

--- a/src/XMakeTasks/project.lock.json
+++ b/src/XMakeTasks/project.lock.json
@@ -10,6 +10,54 @@
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
         }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.5.1/win7-x86": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
       }
     },
     ".NETFramework,Version=v4.6": {
@@ -19,6 +67,25 @@
         },
         "runtime": {
           "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -39,8 +106,65 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6/win7-x86": {
+      "Microsoft.Tpl.Dataflow/4.5.24": {
+        "compile": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.36": {
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
+        "dependencies": {
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -53,22 +177,22 @@
     "DNXCore,Version=v5.0": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -80,6 +204,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -104,8 +229,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -132,8 +257,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -175,29 +299,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -208,30 +332,30 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {},
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -254,13 +378,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23127": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23127, )",
-          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
-          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
           "System.Collections": "[4.0.10-beta-23127, )",
-          "System.Globalization": "[4.0.10-beta-23127, )"
+          "System.Globalization": "[4.0.10-beta-23127, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
+          "System.Runtime": "[4.0.20-beta-23127, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
+          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
+          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -293,15 +417,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -312,13 +436,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -330,12 +454,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -357,16 +481,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -378,9 +502,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -392,15 +516,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -433,25 +557,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -462,8 +586,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -485,13 +609,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -513,20 +637,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -548,8 +672,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -560,11 +684,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -588,15 +712,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -607,14 +731,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -625,19 +749,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -648,11 +772,11 @@
       },
       "System.IO.FileSystem.DriveInfo/4.0.0-beta-23302": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -675,13 +799,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -692,10 +816,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -707,21 +831,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -732,16 +856,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -752,13 +876,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -769,21 +893,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -813,9 +937,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -827,10 +951,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -842,25 +966,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -879,9 +1003,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -892,13 +1016,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -910,11 +1034,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -925,9 +1049,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -938,8 +1062,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -948,28 +1072,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -985,8 +1096,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -997,9 +1108,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -1043,9 +1154,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -1057,8 +1168,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -1069,9 +1180,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -1083,14 +1194,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -1101,11 +1212,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -1127,10 +1238,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1166,10 +1277,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -1217,17 +1328,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -1238,14 +1349,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -1290,20 +1401,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -1314,17 +1425,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -1335,16 +1446,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -1355,15 +1466,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -1374,16 +1485,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -1393,73 +1504,25 @@
         }
       }
     },
-    ".NETFramework,Version=v4.5.1/win7-x86": {
-      "Microsoft.Tpl.Dataflow/4.5.24": {
-        "compile": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      }
-    },
-    ".NETFramework,Version=v4.6/win7-x86": {
-      "Microsoft.Tpl.Dataflow/4.5.24": {
-        "compile": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll": {}
-        }
-      },
-      "System.Resources.ResourceManager/4.0.0": {
-        "compile": {
-          "ref/net45/_._": {}
-        },
-        "runtime": {
-          "lib/net45/_._": {}
-        }
-      },
-      "System.Runtime/4.0.20": {
-        "compile": {
-          "ref/net46/_._": {}
-        },
-        "runtime": {
-          "lib/net46/_._": {}
-        }
-      },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
-        "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
-        }
-      }
-    },
     "DNXCore,Version=v5.0/win7-x86": {
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.CSharp.dll": {}
@@ -1471,6 +1534,7 @@
       "Microsoft.NETCore/5.0.0": {
         "dependencies": {
           "Microsoft.CSharp": "[4.0.0, )",
+          "Microsoft.NETCore.Targets": "[1.0.0, )",
           "Microsoft.VisualBasic": "[10.0.0, )",
           "System.AppContext": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
@@ -1495,8 +1559,8 @@
           "System.Linq.Expressions": "[4.0.10, )",
           "System.Linq.Parallel": "[4.0.0, )",
           "System.Linq.Queryable": "[4.0.0, )",
-          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Http": "[4.0.0, )",
+          "System.Net.NetworkInformation": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
           "System.Numerics.Vectors": "[4.1.0, )",
           "System.ObjectModel": "[4.0.10, )",
@@ -1523,8 +1587,7 @@
           "System.Threading.Tasks.Parallel": "[4.0.0, )",
           "System.Threading.Timer": "[4.0.0, )",
           "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XDocument": "[4.0.10, )",
-          "Microsoft.NETCore.Targets": "[1.0.0, )"
+          "System.Xml.XDocument": "[4.0.10, )"
         }
       },
       "Microsoft.NETCore.Platforms/1.0.0": {},
@@ -1566,29 +1629,29 @@
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
         "dependencies": {
           "System.Collections": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
           "System.Diagnostics.Debug": "[4.0.10, 4.0.10]",
+          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
+          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
           "System.Globalization": "[4.0.10, 4.0.10]",
+          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
           "System.IO": "[4.0.10, 4.0.10]",
           "System.ObjectModel": "[4.0.10, 4.0.10]",
+          "System.Private.Uri": "[4.0.0, 4.0.0]",
           "System.Reflection": "[4.0.10, 4.0.10]",
+          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
+          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
+          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
+          "System.Runtime": "[4.0.20, 4.0.20]",
           "System.Runtime.Extensions": "[4.0.10, 4.0.10]",
+          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
+          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]",
           "System.Text.Encoding": "[4.0.10, 4.0.10]",
           "System.Text.Encoding.Extensions": "[4.0.10, 4.0.10]",
           "System.Threading": "[4.0.10, 4.0.10]",
           "System.Threading.Tasks": "[4.0.10, 4.0.10]",
-          "System.Diagnostics.Contracts": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.StackTrace": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tools": "[4.0.0, 4.0.0]",
-          "System.Globalization.Calendars": "[4.0.0, 4.0.0]",
-          "System.Reflection.Extensions": "[4.0.0, 4.0.0]",
-          "System.Reflection.Primitives": "[4.0.0, 4.0.0]",
-          "System.Resources.ResourceManager": "[4.0.0, 4.0.0]",
-          "System.Runtime.Handles": "[4.0.0, 4.0.0]",
-          "System.Threading.Timer": "[4.0.0, 4.0.0]",
-          "System.Private.Uri": "[4.0.0, 4.0.0]",
-          "System.Diagnostics.Tracing": "[4.0.20, 4.0.20]",
-          "System.Runtime": "[4.0.20, 4.0.20]",
-          "System.Runtime.InteropServices": "[4.0.20, 4.0.20]"
+          "System.Threading.Timer": "[4.0.0, 4.0.0]"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1608,8 +1671,8 @@
       },
       "Microsoft.NETCore.Targets/1.0.0": {
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )",
-          "Microsoft.NETCore.Platforms": "[1.0.0, )"
+          "Microsoft.NETCore.Platforms": "[1.0.0, )",
+          "Microsoft.NETCore.Targets.DNXCore": "[4.9.0, )"
         }
       },
       "Microsoft.NETCore.Targets.DNXCore/4.9.0": {},
@@ -1622,8 +1685,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1686,13 +1749,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1746,22 +1809,22 @@
       },
       "Microsoft.VisualBasic/10.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Reflection": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Dynamic.Runtime": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
           "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.10, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.ObjectModel": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.VisualBasic.dll": {}
@@ -1784,13 +1847,13 @@
       },
       "Microsoft.Win32.Registry/4.0.0-beta-23127": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23127, )",
-          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
-          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
           "System.Collections": "[4.0.10-beta-23127, )",
-          "System.Globalization": "[4.0.10-beta-23127, )"
+          "System.Globalization": "[4.0.10-beta-23127, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23127, )",
+          "System.Runtime": "[4.0.20-beta-23127, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23127, )",
+          "System.Runtime.Handles": "[4.0.0-beta-23127, )",
+          "System.Runtime.InteropServices": "[4.0.20-beta-23127, )"
         },
         "compile": {
           "ref/dotnet/Microsoft.Win32.Registry.dll": {}
@@ -1823,15 +1886,15 @@
       },
       "System.Collections.Concurrent/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.Concurrent.dll": {}
@@ -1842,13 +1905,13 @@
       },
       "System.Collections.Immutable/1.1.37": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Threading": "[4.0.0, )"
         },
         "compile": {
@@ -1860,12 +1923,12 @@
       },
       "System.Collections.NonGeneric/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Collections.NonGeneric.dll": {}
@@ -1887,16 +1950,16 @@
       },
       "System.ComponentModel.Annotations/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
+          "System.Collections": "[4.0.10, )",
           "System.ComponentModel": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Globalization": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -1908,9 +1971,9 @@
       },
       "System.ComponentModel.EventBasedAsync/4.0.10": {
         "dependencies": {
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -1922,15 +1985,15 @@
       },
       "System.Console/4.0.0-beta-23123": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
           "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
@@ -1963,25 +2026,25 @@
       },
       "System.Diagnostics.Process/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Security.SecureString": "[4.0.0-beta-23123, )",
-          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Threading.Thread": "[4.0.0-beta-23123, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
+          "Microsoft.Win32.Registry": "[4.0.0-beta-23123, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Security.SecureString": "[4.0.0-beta-23123, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Threading.Thread": "[4.0.0-beta-23123, )",
+          "System.Threading.ThreadPool": "[4.0.10-beta-23123, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.Process.dll": {}
@@ -1992,8 +2055,8 @@
       },
       "System.Diagnostics.StackTrace/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
@@ -2015,13 +2078,13 @@
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
         "dependencies": {
-          "System.Runtime": "[4.0.20-beta-23019, )",
-          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
           "System.Collections": "[4.0.10-beta-23019, )",
-          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
           "System.Diagnostics.Debug": "[4.0.10-beta-23019, )",
-          "System.Threading": "[4.0.10-beta-23019, )",
-          "System.Globalization": "[4.0.10-beta-23019, )"
+          "System.Globalization": "[4.0.10-beta-23019, )",
+          "System.Resources.ResourceManager": "[4.0.0-beta-23019, )",
+          "System.Runtime": "[4.0.20-beta-23019, )",
+          "System.Runtime.Extensions": "[4.0.10-beta-23019, )",
+          "System.Threading": "[4.0.10-beta-23019, )"
         },
         "compile": {
           "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
@@ -2043,20 +2106,20 @@
       },
       "System.Dynamic.Runtime/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Linq.Expressions": "[4.0.10, )"
+          "System.Linq.Expressions": "[4.0.10, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Dynamic.Runtime.dll": {}
@@ -2078,8 +2141,8 @@
       },
       "System.Globalization.Calendars/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Globalization": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Calendars.dll": {}
@@ -2090,11 +2153,11 @@
       },
       "System.Globalization.Extensions/4.0.0": {
         "dependencies": {
+          "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Globalization.Extensions.dll": {}
@@ -2118,15 +2181,15 @@
       },
       "System.IO.Compression/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )"
+          "System.Runtime.InteropServices": "[4.0.0, )",
+          "System.Text.Encoding": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.dll": {}
@@ -2142,14 +2205,14 @@
       },
       "System.IO.Compression.ZipFile/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO.Compression": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
           "System.IO": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.IO.Compression": "[4.0.0, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
@@ -2160,19 +2223,19 @@
       },
       "System.IO.FileSystem/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
           "System.Text.Encoding.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.FileSystem.dll": {}
@@ -2183,11 +2246,11 @@
       },
       "System.IO.FileSystem.DriveInfo/4.0.0-beta-23302": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
@@ -2210,13 +2273,13 @@
       },
       "System.IO.UnmanagedMemoryStream/4.0.0": {
         "dependencies": {
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Runtime": "[4.0.20, )",
           "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
@@ -2227,10 +2290,10 @@
       },
       "System.Linq/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2242,21 +2305,21 @@
       },
       "System.Linq.Expressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.TypeExtensions": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Reflection.Emit": "[4.0.0, )",
-          "System.ObjectModel": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Linq": "[4.0.0, )",
+          "System.ObjectModel": "[4.0.0, )",
+          "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit": "[4.0.0, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Reflection.TypeExtensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
@@ -2267,16 +2330,16 @@
       },
       "System.Linq.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Linq": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Threading": "[4.0.10, )",
+          "System.Collections.Concurrent": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Parallel.dll": {}
@@ -2287,13 +2350,13 @@
       },
       "System.Linq.Queryable/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Linq.Expressions": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
           "System.Linq": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Linq.Expressions": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )"
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Linq.Queryable.dll": {}
@@ -2304,21 +2367,21 @@
       },
       "System.Net.Http/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
           "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.IO.Compression": "[4.0.0, )",
           "System.Net.Primitives": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Net.Http.dll": {}
@@ -2351,9 +2414,9 @@
       },
       "System.Numerics.Vectors/4.1.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2365,10 +2428,10 @@
       },
       "System.ObjectModel/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2380,25 +2443,25 @@
       },
       "System.Private.Networking/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Diagnostics.Tracing": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Runtime.Handles": "[4.0.0, )",
+          "Microsoft.Win32.Primitives": "[4.0.0, )",
+          "System.Collections": "[4.0.10, )",
           "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections.NonGeneric": "[4.0.0, )",
-          "Microsoft.Win32.Primitives": "[4.0.0, )",
-          "System.IO.FileSystem": "[4.0.0, )",
-          "System.Threading.Overlapped": "[4.0.0, )",
-          "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Collections": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.ComponentModel.EventBasedAsync": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Diagnostics.Tracing": "[4.0.20, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.IO.FileSystem": "[4.0.0, )",
+          "System.IO.FileSystem.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )"
+          "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Threading.Overlapped": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -2417,9 +2480,9 @@
       },
       "System.Reflection/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.dll": {}
@@ -2430,13 +2493,13 @@
       },
       "System.Reflection.DispatchProxy/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Linq": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Reflection": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Linq": "[4.0.0, )",
+          "System.Reflection": "[4.0.10, )",
+          "System.Reflection.Extensions": "[4.0.0, )",
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Threading": "[4.0.10, )"
         },
         "compile": {
@@ -2448,11 +2511,11 @@
       },
       "System.Reflection.Emit/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.IO": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.dll": {}
@@ -2463,9 +2526,9 @@
       },
       "System.Reflection.Emit.ILGeneration/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
+          "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
@@ -2477,9 +2540,9 @@
       "System.Reflection.Emit.Lightweight/4.0.0": {
         "dependencies": {
           "System.Reflection": "[4.0.0, )",
+          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
@@ -2490,8 +2553,8 @@
       },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.Extensions.dll": {}
@@ -2500,28 +2563,15 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.0.22": {
+      "System.Reflection.Metadata/1.1.0-alpha-00014": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.0, )",
-          "System.Runtime.InteropServices": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
-          "System.Text.Encoding.Extensions": "[4.0.0, )",
-          "System.Reflection.Extensions": "[4.0.0, )",
-          "System.Collections.Immutable": "[1.1.37, )"
+          "System.Collections.Immutable": "[1.1.36, )"
         },
         "compile": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Reflection.Metadata.dll": {}
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
         }
       },
       "System.Reflection.Primitives/4.0.0": {
@@ -2537,8 +2587,8 @@
       },
       "System.Reflection.TypeExtensions/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )"
+          "System.Reflection": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
@@ -2549,9 +2599,9 @@
       },
       "System.Resources.ResourceManager/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Runtime": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Resources.ResourceManager.dll": {}
@@ -2595,9 +2645,9 @@
       },
       "System.Runtime.InteropServices/4.0.20": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
           "System.Reflection": "[4.0.0, )",
           "System.Reflection.Primitives": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
           "System.Runtime.Handles": "[4.0.0, )"
         },
         "compile": {
@@ -2609,8 +2659,8 @@
       },
       "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )"
         },
         "compile": {
           "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
@@ -2621,9 +2671,9 @@
       },
       "System.Runtime.Numerics/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )"
         },
         "compile": {
@@ -2635,14 +2685,14 @@
       },
       "System.Security.Claims/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Security.Principal": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
           "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Globalization": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.IO": "[4.0.0, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Security.Principal": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Claims.dll": {}
@@ -2653,11 +2703,11 @@
       },
       "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Globalization": "[4.0.0, )",
           "System.IO": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Globalization": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Security.Cryptography.Encryption.dll": {}
@@ -2679,10 +2729,10 @@
       },
       "System.Security.SecureString/4.0.0-beta-23123": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Handles": "[4.0.0, )",
+          "System.Runtime.InteropServices": "[4.0.20, )",
           "System.Security.Cryptography.Encryption": "[4.0.0-beta-23123, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2718,10 +2768,10 @@
       },
       "System.Text.RegularExpressions/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )"
         },
@@ -2769,17 +2819,17 @@
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
         "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.0, )",
-          "System.Collections.Concurrent": "[4.0.0, )",
           "System.Collections": "[4.0.0, )",
-          "System.Threading.Tasks": "[4.0.0, )",
-          "System.Dynamic.Runtime": "[4.0.0, )",
+          "System.Collections.Concurrent": "[4.0.0, )",
+          "System.Diagnostics.Debug": "[4.0.0, )",
           "System.Diagnostics.Tracing": "[4.0.0, )",
-          "System.Threading": "[4.0.0, )",
+          "System.Dynamic.Runtime": "[4.0.0, )",
           "System.Linq": "[4.0.0, )",
-          "System.Runtime.Extensions": "[4.0.0, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.0, )",
+          "System.Runtime.Extensions": "[4.0.0, )",
+          "System.Threading": "[4.0.0, )",
+          "System.Threading.Tasks": "[4.0.0, )"
         },
         "compile": {
           "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
@@ -2790,14 +2840,14 @@
       },
       "System.Threading.Tasks.Parallel/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
           "System.Collections.Concurrent": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Diagnostics.Tracing": "[4.0.20, )",
           "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
@@ -2842,20 +2892,20 @@
       },
       "System.Xml.ReaderWriter/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
           "System.IO": "[4.0.10, )",
-          "System.Threading.Tasks": "[4.0.10, )",
-          "System.Runtime.InteropServices": "[4.0.20, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.IO.FileSystem": "[4.0.0, )",
           "System.IO.FileSystem.Primitives": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Text.RegularExpressions": "[4.0.10, )",
-          "System.Collections": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
-          "System.Text.Encoding.Extensions": "[4.0.10, )"
+          "System.Runtime.InteropServices": "[4.0.20, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Text.Encoding.Extensions": "[4.0.10, )",
+          "System.Text.RegularExpressions": "[4.0.10, )",
+          "System.Threading.Tasks": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.ReaderWriter.dll": {}
@@ -2866,17 +2916,17 @@
       },
       "System.Xml.XDocument/4.0.10": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
+          "System.Diagnostics.Debug": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )",
-          "System.Text.Encoding": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
           "System.Reflection": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )"
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XDocument.dll": {}
@@ -2887,16 +2937,16 @@
       },
       "System.Xml.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.IO": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
-          "System.Text.Encoding": "[4.0.10, )",
           "System.Collections": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
+          "System.Text.Encoding": "[4.0.10, )",
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XmlDocument.dll": {}
@@ -2907,15 +2957,15 @@
       },
       "System.Xml.XPath/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.IO": "[4.0.10, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Globalization": "[4.0.10, )",
           "System.Diagnostics.Debug": "[4.0.10, )",
+          "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
           "System.Runtime.Extensions": "[4.0.10, )",
-          "System.Threading": "[4.0.10, )"
+          "System.Threading": "[4.0.10, )",
+          "System.Xml.ReaderWriter": "[4.0.10, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.dll": {}
@@ -2926,16 +2976,16 @@
       },
       "System.Xml.XPath.XmlDocument/4.0.0": {
         "dependencies": {
-          "System.Runtime": "[4.0.20, )",
-          "System.Xml.XmlDocument": "[4.0.0, )",
-          "System.Xml.ReaderWriter": "[4.0.10, )",
-          "System.Xml.XPath": "[4.0.0, )",
-          "System.Resources.ResourceManager": "[4.0.0, )",
           "System.Collections": "[4.0.10, )",
-          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Globalization": "[4.0.10, )",
+          "System.IO": "[4.0.10, )",
+          "System.Resources.ResourceManager": "[4.0.0, )",
+          "System.Runtime": "[4.0.20, )",
+          "System.Runtime.Extensions": "[4.0.10, )",
           "System.Threading": "[4.0.10, )",
-          "System.IO": "[4.0.10, )"
+          "System.Xml.ReaderWriter": "[4.0.10, )",
+          "System.Xml.XmlDocument": "[4.0.0, )",
+          "System.Xml.XPath": "[4.0.0, )"
         },
         "compile": {
           "ref/dotnet/System.Xml.XPath.XmlDocument.dll": {}
@@ -2951,83 +3001,71 @@
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.CSharp.nuspec",
         "lib/dotnet/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.CSharp.dll",
-        "ref/dotnet/Microsoft.CSharp.xml",
-        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "Microsoft.CSharp.nuspec",
+        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
         "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
         "ref/dotnet/fr/Microsoft.CSharp.xml",
         "ref/dotnet/it/Microsoft.CSharp.xml",
         "ref/dotnet/ja/Microsoft.CSharp.xml",
         "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
         "ref/dotnet/ru/Microsoft.CSharp.xml",
         "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
-        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.CSharp.dll",
         "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a8a7171824ab4656b3141cda0591ff66.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
+        "_._",
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
-        "_._",
-        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp",
-        "[Content_Types].xml"
+        "package/services/metadata/core-properties/340ac37fb1224580ae47c59ebdd88964.psmdcp"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/36b51d4c6b524527902ff1a182a64e42.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
-        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "lib/netcore50/System.Core.dll",
-        "lib/netcore50/System.dll",
-        "lib/netcore50/System.Net.dll",
-        "lib/netcore50/System.Numerics.dll",
-        "lib/netcore50/System.Runtime.Serialization.dll",
-        "lib/netcore50/System.ServiceModel.dll",
-        "lib/netcore50/System.ServiceModel.Web.dll",
-        "lib/netcore50/System.Windows.dll",
-        "lib/netcore50/System.Xml.dll",
-        "lib/netcore50/System.Xml.Linq.dll",
-        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.dll",
@@ -3041,9 +3079,23 @@
         "lib/dnxcore50/System.Xml.Linq.dll",
         "lib/dnxcore50/System.Xml.Serialization.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "lib/netcore50/System.Core.dll",
+        "lib/netcore50/System.dll",
+        "lib/netcore50/System.Net.dll",
+        "lib/netcore50/System.Numerics.dll",
+        "lib/netcore50/System.Runtime.Serialization.dll",
+        "lib/netcore50/System.ServiceModel.dll",
+        "lib/netcore50/System.ServiceModel.Web.dll",
+        "lib/netcore50/System.Windows.dll",
+        "lib/netcore50/System.Xml.dll",
+        "lib/netcore50/System.Xml.Linq.dll",
+        "lib/netcore50/System.Xml.Serialization.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "Microsoft.NETCore.Portable.Compatibility.nuspec",
+        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
         "ref/dotnet/mscorlib.dll",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
@@ -3057,21 +3109,7 @@
         "ref/dotnet/System.Xml.dll",
         "ref/dotnet/System.Xml.Linq.dll",
         "ref/dotnet/System.Xml.Serialization.dll",
-        "runtimes/aot/lib/netcore50/mscorlib.dll",
-        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
-        "runtimes/aot/lib/netcore50/System.Core.dll",
-        "runtimes/aot/lib/netcore50/System.dll",
-        "runtimes/aot/lib/netcore50/System.Net.dll",
-        "runtimes/aot/lib/netcore50/System.Numerics.dll",
-        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
-        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
-        "runtimes/aot/lib/netcore50/System.Windows.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
-        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/mscorlib.dll",
         "ref/netcore50/System.ComponentModel.DataAnnotations.dll",
         "ref/netcore50/System.Core.dll",
@@ -3085,85 +3123,100 @@
         "ref/netcore50/System.Xml.dll",
         "ref/netcore50/System.Xml.Linq.dll",
         "ref/netcore50/System.Xml.Serialization.dll",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8131b8ae030a45e7986737a0c1d04ef5.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/aot/lib/netcore50/mscorlib.dll",
+        "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll",
+        "runtimes/aot/lib/netcore50/System.Core.dll",
+        "runtimes/aot/lib/netcore50/System.dll",
+        "runtimes/aot/lib/netcore50/System.Net.dll",
+        "runtimes/aot/lib/netcore50/System.Numerics.dll",
+        "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.dll",
+        "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll",
+        "runtimes/aot/lib/netcore50/System.Windows.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Linq.dll",
+        "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/f289de2ffef9428684eca0c193bc8765.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
+        "ref/dotnet/_._",
+        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
         "runtimes/win7-x86/native/dbgshim.dll",
         "runtimes/win7-x86/native/mscordaccore.dll",
         "runtimes/win7-x86/native/mscordbi.dll",
         "runtimes/win7-x86/native/mscorrc.debug.dll",
-        "runtimes/win7-x86/native/mscorrc.dll",
-        "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
-        "ref/dotnet/_._",
-        "package/services/metadata/core-properties/dd7e29450ade4bdaab9794850cd11d7a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/5413a5ed3fde4121a1c9ee8feb12ba66.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.DNXCore/4.9.0": {
       "sha512": "32pNFQTn/nVB15hYIztKn1Ij05ibGn8C9CfOiENbc+GbzxWWQQztDyWhS/vGzUcrFFZpcXbJ0yGHem2syNHMwQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
-        "runtime.json",
         "package/services/metadata/core-properties/49a06ab6e27f4682b9b0c258f69b4fe2.psmdcp",
-        "[Content_Types].xml"
+        "runtime.json"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23123": {
       "sha512": "hLIFc0enPvCCOt1pXl3etWtkhvB+lb8qcjxWM39Jk9n8UTLvIH4lwzFbTv6Tij3LYmNbToTKEPKYmx3TfjUevw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
-        "runtimes/win7-x86/native/CoreRun.exe",
         "package/services/metadata/core-properties/71ad7e2008a84dfdb75618cb7527719a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
+        "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -3226,13 +3279,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -3282,6 +3335,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -3296,8 +3357,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -3307,2449 +3368,2452 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
-        "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/b773d829b3664669b45b4b4e97bdb635.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "Microsoft.Tpl.Dataflow/4.5.24": {
       "sha512": "6BE4Vu74+dkv5AkJd+UxW1sFMepMZOVlUoMZDUKqhc4Bf7pe7yySzCj6QrowUZbCqcDPwOiQsAgz3nXiLQSyMw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Tpl.Dataflow.nuspec",
-        "License-Stable.rtf",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/system.threading.tasks.dataflow.xml",
-        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/system.threading.tasks.dataflow.xml",
+        "License-Stable.rtf",
+        "Microsoft.Tpl.Dataflow.nuspec",
+        "package/services/metadata/core-properties/3dd86853af3a4ae392f3331459714ce0.psmdcp"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/Microsoft.VisualBasic.dll",
-        "ref/dotnet/Microsoft.VisualBasic.xml",
-        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "Microsoft.VisualBasic.nuspec",
+        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
         "ref/dotnet/fr/Microsoft.VisualBasic.xml",
         "ref/dotnet/it/Microsoft.VisualBasic.xml",
         "ref/dotnet/ja/Microsoft.VisualBasic.xml",
         "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/ru/Microsoft.VisualBasic.xml",
         "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
-        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
-        "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5dbd3a7042354092a8b352b655cf4376.psmdcp",
-        "[Content_Types].xml"
+        "ref/win8/_._",
+        "ref/wpa81/_._"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
-        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "Microsoft.Win32.Primitives.nuspec",
+        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
-        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d4eb9d0228b48b88d2df3822fba2d86.psmdcp",
-        "[Content_Types].xml"
+        "ref/xamarinmac20/_._"
       ]
     },
     "Microsoft.Win32.Registry/4.0.0-beta-23127": {
       "sha512": "OLlm5CChfeoBvo2hkE9hYtXFm2bn61npTtBmTjc+hrYKltIy3W/yIpwBPNGmKR7/OG4C/senZrrVS5PgPIU5Lw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "Microsoft.Win32.Registry.nuspec",
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.dll",
-        "ref/dotnet/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "Microsoft.Win32.Registry.nuspec",
+        "package/services/metadata/core-properties/ab5e15917647479181745bf7b998cc45.psmdcp",
         "ref/dotnet/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
         "ref/dotnet/fr/Microsoft.Win32.Registry.xml",
         "ref/dotnet/it/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ja/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.xml",
         "ref/dotnet/ru/Microsoft.Win32.Registry.xml",
         "ref/dotnet/zh-hans/Microsoft.Win32.Registry.xml",
-        "ref/dotnet/es/Microsoft.Win32.Registry.xml",
-        "ref/net46/Microsoft.Win32.Registry.dll",
-        "package/services/metadata/core-properties/ab5e15917647479181745bf7b998cc45.psmdcp",
-        "[Content_Types].xml"
+        "ref/dotnet/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.AppContext.nuspec",
-        "lib/netcore50/System.AppContext.dll",
         "lib/DNXCore50/System.AppContext.dll",
-        "lib/net46/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.AppContext.dll",
-        "ref/dotnet/System.AppContext.xml",
-        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
         "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
         "ref/dotnet/fr/System.AppContext.xml",
         "ref/dotnet/it/System.AppContext.xml",
         "ref/dotnet/ja/System.AppContext.xml",
         "ref/dotnet/ko/System.AppContext.xml",
         "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
         "ref/dotnet/zh-hans/System.AppContext.xml",
-        "ref/dotnet/es/System.AppContext.xml",
-        "ref/net46/System.AppContext.dll",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3b390478e0cd42eb8818bbab19299738.psmdcp",
-        "[Content_Types].xml"
+        "System.AppContext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.nuspec",
-        "lib/netcore50/System.Collections.dll",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
-        "ref/dotnet/zh-hant/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
         "ref/dotnet/it/System.Collections.xml",
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
-        "ref/dotnet/es/System.Collections.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Concurrent.nuspec",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
         "ref/dotnet/it/System.Collections.Concurrent.xml",
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Concurrent.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.36": {
+      "sha512": "MOlivTIeAIQPPMUPWIIoMCvZczjFRLYUWSYwqi1szu8QPyeIbsaPeI+hpXe1DzTxNwnRnmfYaoToi6kXIfSPNg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "package/services/metadata/core-properties/c8b7b781850445db852bd2d848380ca6.psmdcp",
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "package/services/metadata/core-properties/a02fdeabe1114a24bba55860b8703852.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.Immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Collections.NonGeneric.nuspec",
         "lib/dotnet/System.Collections.NonGeneric.dll",
-        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.NonGeneric.dll",
-        "ref/dotnet/System.Collections.NonGeneric.xml",
-        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
         "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
         "ref/dotnet/fr/System.Collections.NonGeneric.xml",
         "ref/dotnet/it/System.Collections.NonGeneric.xml",
         "ref/dotnet/ja/System.Collections.NonGeneric.xml",
         "ref/dotnet/ko/System.Collections.NonGeneric.xml",
         "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
         "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet/es/System.Collections.NonGeneric.xml",
-        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/185704b1dc164b078b61038bde9ab31a.psmdcp",
-        "[Content_Types].xml"
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.ComponentModel.dll",
-        "ref/dotnet/System.ComponentModel.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
         "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
         "ref/dotnet/fr/System.ComponentModel.xml",
         "ref/dotnet/it/System.ComponentModel.xml",
         "ref/dotnet/ja/System.ComponentModel.xml",
         "ref/dotnet/ko/System.ComponentModel.xml",
         "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.xml",
-        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.ComponentModel.dll",
         "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/58b9abdedb3a4985a487cb8bf4bdcbd7.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.Annotations.dll",
-        "ref/dotnet/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
         "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
         "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
         "ref/dotnet/it/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
         "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
-        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/012e5fa97b3d450eb20342cd9ba88069.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.Annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
-        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
         "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
         "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
-        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5094900f1f7e4f4dae27507acc72f2a5.psmdcp",
-        "[Content_Types].xml"
+        "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
     "System.Console/4.0.0-beta-23123": {
       "sha512": "fPglodP4GQV7HBBDhmCZaCD8fzBvhtHmBmiN/8yWiJz0NNnA55YUNBh3myvR2DP/6IOHJ75/tTRkvwdpX3BWXA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Console.nuspec",
         "lib/DNXCore50/System.Console.dll",
-        "lib/net46/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Console.dll",
-        "ref/dotnet/System.Console.xml",
-        "ref/dotnet/zh-hant/System.Console.xml",
+        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
         "ref/dotnet/de/System.Console.xml",
+        "ref/dotnet/es/System.Console.xml",
         "ref/dotnet/fr/System.Console.xml",
         "ref/dotnet/it/System.Console.xml",
         "ref/dotnet/ja/System.Console.xml",
         "ref/dotnet/ko/System.Console.xml",
         "ref/dotnet/ru/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
+        "ref/dotnet/System.Console.xml",
         "ref/dotnet/zh-hans/System.Console.xml",
-        "ref/dotnet/es/System.Console.xml",
-        "ref/net46/System.Console.dll",
+        "ref/dotnet/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/8d7a3fc8c6314a7b8e950ea4ca023405.psmdcp",
-        "[Content_Types].xml"
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Contracts.nuspec",
-        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
         "ref/dotnet/it/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
-        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Contracts.dll",
         "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
-        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
         "ref/dotnet/it/System.Diagnostics.Debug.xml",
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
-        "ref/dotnet/es/System.Diagnostics.Debug.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
     "System.Diagnostics.Process/4.0.0-beta-23123": {
       "sha512": "EUeT1XD9Nmnn4gIhEu1tA7/7RtWlQOIt7ZdETDScQoAYbLUtcY1Zc5Qy6B7+YbKnyqS8TIdGe/fxDEa0EDTsjA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Process.nuspec",
         "lib/DNXCore50/System.Diagnostics.Process.dll",
-        "lib/net46/System.Diagnostics.Process.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Process.dll",
-        "ref/dotnet/System.Diagnostics.Process.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
+        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Process.xml",
+        "ref/dotnet/es/System.Diagnostics.Process.xml",
         "ref/dotnet/fr/System.Diagnostics.Process.xml",
         "ref/dotnet/it/System.Diagnostics.Process.xml",
         "ref/dotnet/ja/System.Diagnostics.Process.xml",
         "ref/dotnet/ko/System.Diagnostics.Process.xml",
         "ref/dotnet/ru/System.Diagnostics.Process.xml",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/dotnet/System.Diagnostics.Process.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Process.xml",
-        "ref/dotnet/es/System.Diagnostics.Process.xml",
-        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Process.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/62bb66ff8fc94426b267bb086f8f7d40.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.Process.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
-        "lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "lib/net46/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
+        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
         "ref/dotnet/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/fr/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/it/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ja/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ko/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/System.Diagnostics.StackTrace.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet/es/System.Diagnostics.StackTrace.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5c7ca489a36944d895c628fced7e9107.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
-        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
         "ref/dotnet/it/System.Diagnostics.Tools.xml",
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
-        "ref/dotnet/es/System.Diagnostics.Tools.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Diagnostics.Tools.dll",
         "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
       "sha512": "MZxMo9Skg9oZrJYwGpRfeOfrTfHxmTPWhj8XIXdIryfArzwG1FjZgzOrkWWcON0PdV9OywZYGly09nUCs/JdhA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.TraceSource.nuspec",
         "lib/DNXCore50/System.Diagnostics.TraceSource.dll",
         "lib/net46/System.Diagnostics.TraceSource.dll",
+        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
         "ref/dotnet/System.Diagnostics.TraceSource.dll",
         "ref/net46/System.Diagnostics.TraceSource.dll",
-        "package/services/metadata/core-properties/9a5f24590c094ed0bb58db8306906532.psmdcp",
-        "[Content_Types].xml"
+        "System.Diagnostics.TraceSource.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Diagnostics.Tracing.nuspec",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
         "ref/dotnet/it/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Dynamic.Runtime.nuspec",
-        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Dynamic.Runtime.dll",
-        "ref/dotnet/System.Dynamic.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
         "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
         "ref/dotnet/fr/System.Dynamic.Runtime.xml",
         "ref/dotnet/it/System.Dynamic.Runtime.xml",
         "ref/dotnet/ja/System.Dynamic.Runtime.xml",
         "ref/dotnet/ko/System.Dynamic.Runtime.xml",
         "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
         "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
-        "ref/dotnet/es/System.Dynamic.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/b7571751b95d4952803c5011dab33c3b.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "System.Dynamic.Runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.nuspec",
-        "lib/netcore50/System.Globalization.dll",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
-        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
         "ref/dotnet/it/System.Globalization.xml",
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
-        "ref/dotnet/es/System.Globalization.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Calendars.nuspec",
-        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
-        "lib/net46/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Calendars.dll",
-        "ref/dotnet/System.Globalization.Calendars.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
         "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
         "ref/dotnet/fr/System.Globalization.Calendars.xml",
         "ref/dotnet/it/System.Globalization.Calendars.xml",
         "ref/dotnet/ja/System.Globalization.Calendars.xml",
         "ref/dotnet/ko/System.Globalization.Calendars.xml",
         "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
         "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet/es/System.Globalization.Calendars.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/95fc8eb4808e4f31a967f407c94eba0f.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Globalization.Extensions.nuspec",
         "lib/dotnet/System.Globalization.Extensions.dll",
-        "lib/net46/System.Globalization.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.Extensions.dll",
-        "ref/dotnet/System.Globalization.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
         "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
         "ref/dotnet/fr/System.Globalization.Extensions.xml",
         "ref/dotnet/it/System.Globalization.Extensions.xml",
         "ref/dotnet/ja/System.Globalization.Extensions.xml",
         "ref/dotnet/ko/System.Globalization.Extensions.xml",
         "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
         "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet/es/System.Globalization.Extensions.xml",
-        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a0490a34737f448fb53635b5210e48e4.psmdcp",
-        "[Content_Types].xml"
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.nuspec",
-        "lib/netcore50/System.IO.dll",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
-        "ref/dotnet/zh-hant/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
         "ref/dotnet/it/System.IO.xml",
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
-        "ref/dotnet/es/System.IO.xml",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.nuspec",
         "lib/dotnet/System.IO.Compression.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.dll",
-        "ref/dotnet/System.IO.Compression.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
         "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
         "ref/dotnet/fr/System.IO.Compression.xml",
         "ref/dotnet/it/System.IO.Compression.xml",
         "ref/dotnet/ja/System.IO.Compression.xml",
         "ref/dotnet/ko/System.IO.Compression.xml",
         "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.xml",
-        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.IO.Compression.dll",
         "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/cdbbc16eba65486f85d2caf9357894f3.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.clrcompression-x86.nuspec",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "runtimes/win10-x86/native/ClrCompression.dll",
         "package/services/metadata/core-properties/cd12f86c8cc2449589dfbe349763f7b3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win10-x86/native/ClrCompression.dll",
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "System.IO.Compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
-        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
         "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
         "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
-        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/60dc66d592ac41008e1384536912dabf.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.Compression.ZipFile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
-        "lib/netcore50/System.IO.FileSystem.dll",
-        "lib/net46/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
         "ref/dotnet/it/System.IO.FileSystem.xml",
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
-        "ref/dotnet/es/System.IO.FileSystem.xml",
-        "ref/net46/System.IO.FileSystem.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.DriveInfo/4.0.0-beta-23302": {
       "sha512": "pbZYqNnchljr2Epj7yP/HJrthPSGlOabfpD3iqVCNFEzNSATcTiTTV9KH8gZcf+AjjhVZfCL8Dv58ve7KKjBCg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.DriveInfo.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.DriveInfo.dll",
-        "lib/net46/System.IO.FileSystem.DriveInfo.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.DriveInfo.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/c1d5c5ba76824b0cbbcc85f2eb7dd723.psmdcp",
         "ref/dotnet/System.IO.FileSystem.DriveInfo.dll",
-        "ref/net46/System.IO.FileSystem.DriveInfo.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.DriveInfo.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c1d5c5ba76824b0cbbcc85f2eb7dd723.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.DriveInfo.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
-        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
-        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
         "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
         "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cce1d37d7dc24e5fb4170ead20101af0.psmdcp",
-        "[Content_Types].xml"
+        "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
         "ref/dotnet/it/System.Linq.xml",
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.dll",
         "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Expressions.nuspec",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Linq.Expressions.dll",
-        "ref/dotnet/System.Linq.Expressions.xml",
-        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
         "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
         "ref/dotnet/it/System.Linq.Expressions.xml",
         "ref/dotnet/ja/System.Linq.Expressions.xml",
         "ref/dotnet/ko/System.Linq.Expressions.xml",
         "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
         "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
-        "ref/dotnet/es/System.Linq.Expressions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/4e3c061f7c0a427fa5b65bd3d84e9bc3.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Parallel.dll",
-        "ref/dotnet/System.Linq.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
         "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
         "ref/dotnet/fr/System.Linq.Parallel.xml",
         "ref/dotnet/it/System.Linq.Parallel.xml",
         "ref/dotnet/ja/System.Linq.Parallel.xml",
         "ref/dotnet/ko/System.Linq.Parallel.xml",
         "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
         "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
-        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5cc7d35889814f73a239a1b7dcd33451.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.Queryable.dll",
-        "ref/dotnet/System.Linq.Queryable.xml",
-        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
         "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
         "ref/dotnet/fr/System.Linq.Queryable.xml",
         "ref/dotnet/it/System.Linq.Queryable.xml",
         "ref/dotnet/ja/System.Linq.Queryable.xml",
         "ref/dotnet/ko/System.Linq.Queryable.xml",
         "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
         "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
-        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Linq.Queryable.dll",
         "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/24a380caa65148a7883629840bf0c343.psmdcp",
-        "[Content_Types].xml"
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Http.nuspec",
-        "lib/netcore50/System.Net.Http.dll",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Net.Http.dll",
-        "ref/dotnet/System.Net.Http.xml",
-        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
         "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
         "ref/dotnet/fr/System.Net.Http.xml",
         "ref/dotnet/it/System.Net.Http.xml",
         "ref/dotnet/ja/System.Net.Http.xml",
         "ref/dotnet/ko/System.Net.Http.xml",
         "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
         "ref/dotnet/zh-hans/System.Net.Http.xml",
-        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62d64206d25643df9c8d01e867c05e27.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Http.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
-        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Net.NetworkInformation.dll",
         "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5daeae3f7319444d8efbd8a0c539559c.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.10-beta-23123": {
       "sha512": "NkKpsUm2MLoxT+YlSwexidAw2jGFIJuc6i4H9pT3nU3TQj7MZVursD/ohWj3nyBxthy7i00XLWkRZAwGao/zsg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.NetworkInformation.nuspec",
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.NetworkInformation.dll",
-        "ref/dotnet/System.Net.NetworkInformation.xml",
-        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
         "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
         "ref/dotnet/fr/System.Net.NetworkInformation.xml",
         "ref/dotnet/it/System.Net.NetworkInformation.xml",
         "ref/dotnet/ja/System.Net.NetworkInformation.xml",
         "ref/dotnet/ko/System.Net.NetworkInformation.xml",
         "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
         "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
-        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3328bb5ab25b4ea996ec8f74eee2a320.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.NetworkInformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Net.Primitives.nuspec",
-        "lib/netcore50/System.Net.Primitives.dll",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Net.Primitives.dll",
-        "ref/dotnet/System.Net.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
         "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
         "ref/dotnet/fr/System.Net.Primitives.xml",
         "ref/dotnet/it/System.Net.Primitives.xml",
         "ref/dotnet/ja/System.Net.Primitives.xml",
         "ref/dotnet/ko/System.Net.Primitives.xml",
         "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
         "ref/dotnet/zh-hans/System.Net.Primitives.xml",
-        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/3e2f49037d5645bdad757b3fd5b7c103.psmdcp",
-        "[Content_Types].xml"
+        "System.Net.Primitives.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Numerics.Vectors.nuspec",
         "lib/dotnet/System.Numerics.Vectors.dll",
-        "lib/net46/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
         "ref/dotnet/System.Numerics.Vectors.dll",
-        "ref/net46/System.Numerics.Vectors.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e501a8a91f4a4138bd1d134abcc769b0.psmdcp",
-        "[Content_Types].xml"
+        "System.Numerics.Vectors.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.ObjectModel.nuspec",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.ObjectModel.dll",
-        "ref/dotnet/System.ObjectModel.xml",
-        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
         "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
         "ref/dotnet/fr/System.ObjectModel.xml",
         "ref/dotnet/it/System.ObjectModel.xml",
         "ref/dotnet/ja/System.ObjectModel.xml",
         "ref/dotnet/ko/System.ObjectModel.xml",
         "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
         "ref/dotnet/zh-hans/System.ObjectModel.xml",
-        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/36c2aaa0c5d24949a7707921f36ee13f.psmdcp",
-        "[Content_Types].xml"
+        "System.ObjectModel.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Networking.nuspec",
-        "lib/netcore50/System.Private.Networking.dll",
         "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/b57bed5f606b4402bbdf153fcf3df3ae.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Networking.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Private.Uri.nuspec",
-        "lib/netcore50/System.Private.Uri.dll",
         "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
-        "[Content_Types].xml"
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.nuspec",
-        "lib/netcore50/System.Reflection.dll",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
-        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
         "ref/dotnet/it/System.Reflection.xml",
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
-        "ref/dotnet/es/System.Reflection.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.DispatchProxy.nuspec",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
         "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
         "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/1e015137cc52490b9dcde73fb35dee23.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "System.Reflection.DispatchProxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
-        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.Emit.dll",
-        "ref/dotnet/System.Reflection.Emit.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
         "ref/dotnet/fr/System.Reflection.Emit.xml",
         "ref/dotnet/it/System.Reflection.Emit.xml",
         "ref/dotnet/ja/System.Reflection.Emit.xml",
         "ref/dotnet/ko/System.Reflection.Emit.xml",
         "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
-        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f6dc998f8a6b43d7b08f33375407a384.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
-        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
-        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
-        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/d044dd882ed2456486ddb05f1dd0420f.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
-        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
         "lib/wp80/_._",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
-        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
         "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
-        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/52abced289cd46eebf8599b9b4c1c67b.psmdcp",
-        "[Content_Types].xml"
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Extensions.nuspec",
-        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
         "ref/dotnet/it/System.Reflection.Extensions.xml",
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
-        "ref/dotnet/es/System.Reflection.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Extensions.dll",
         "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.0.22": {
-      "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
+    "System.Reflection.Metadata/1.1.0-alpha-00014": {
+      "sha512": "rVeIWjVoLQS0aNrGdzndZReskyfxu4EfO9BKqT5GJt0YfGtlsHB1aDPnjl4jIBDTr+WJC9YsnZg8S5sKT1X42g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Metadata.nuspec",
-        "lib/dotnet/System.Reflection.Metadata.dll",
-        "lib/dotnet/System.Reflection.Metadata.xml",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/2ad78f291fda48d1847edf84e50139e6.psmdcp",
-        "[Content_Types].xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.pdb",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "package/services/metadata/core-properties/a48ecf967b1540bba8edfe9af3a99ea5.psmdcp",
+        "System.Reflection.Metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.Primitives.nuspec",
-        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Primitives.dll",
-        "ref/dotnet/System.Reflection.Primitives.xml",
-        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
         "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
         "ref/dotnet/fr/System.Reflection.Primitives.xml",
         "ref/dotnet/it/System.Reflection.Primitives.xml",
         "ref/dotnet/ja/System.Reflection.Primitives.xml",
         "ref/dotnet/ko/System.Reflection.Primitives.xml",
         "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
         "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
-        "ref/dotnet/es/System.Reflection.Primitives.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Reflection.TypeExtensions.nuspec",
-        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
-        "lib/net46/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
         "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a37798ee61124eb7b6c56400aee24da1.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Resources.ResourceManager.nuspec",
-        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
-        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
         "ref/dotnet/it/System.Resources.ResourceManager.xml",
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
-        "ref/dotnet/es/System.Resources.ResourceManager.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Resources.ResourceManager.dll",
         "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.nuspec",
-        "lib/netcore50/System.Runtime.dll",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
         "ref/dotnet/it/System.Runtime.xml",
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
-        "ref/dotnet/es/System.Runtime.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Extensions.nuspec",
-        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
         "ref/dotnet/it/System.Runtime.Extensions.xml",
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
-        "ref/dotnet/es/System.Runtime.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
-        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
         "ref/dotnet/it/System.Runtime.Handles.xml",
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
-        "ref/dotnet/es/System.Runtime.Handles.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
-        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
-        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
         "ref/dotnet/it/System.Runtime.InteropServices.xml",
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
-        "ref/dotnet/es/System.Runtime.InteropServices.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
       "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
         "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Runtime.Numerics.dll",
-        "ref/dotnet/System.Runtime.Numerics.xml",
-        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
         "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
         "ref/dotnet/fr/System.Runtime.Numerics.xml",
         "ref/dotnet/it/System.Runtime.Numerics.xml",
         "ref/dotnet/ja/System.Runtime.Numerics.xml",
         "ref/dotnet/ko/System.Runtime.Numerics.xml",
         "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
         "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
-        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/2e43dbd3dfbf4af5bb74bedaf3a67bd5.psmdcp",
-        "[Content_Types].xml"
+        "System.Runtime.Numerics.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Claims.nuspec",
         "lib/dotnet/System.Security.Claims.dll",
-        "lib/net46/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
         "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
         "ref/dotnet/fr/System.Security.Claims.xml",
         "ref/dotnet/it/System.Security.Claims.xml",
         "ref/dotnet/ja/System.Security.Claims.xml",
         "ref/dotnet/ko/System.Security.Claims.xml",
         "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
         "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/net46/System.Security.Claims.dll",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b682071d85754e6793ca9777ffabaf8a.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Claims.nuspec"
       ]
     },
     "System.Security.Cryptography.Encryption/4.0.0-beta-23123": {
       "sha512": "IjawUtwaF88Ao3xkigg2I6pVj/uevJvuYtDk2lKXD6gYp833yK7D3dyelGGq0wV/GJtmEp64YqXLi6gW69/JGg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Cryptography.Encryption.nuspec",
         "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
-        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encryption.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
-        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
+        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
         "ref/dotnet/de/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/fr/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/it/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ja/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ko/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/ru/System.Security.Cryptography.Encryption.xml",
+        "ref/dotnet/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/System.Security.Cryptography.Encryption.xml",
         "ref/dotnet/zh-hans/System.Security.Cryptography.Encryption.xml",
-        "ref/dotnet/es/System.Security.Cryptography.Encryption.xml",
-        "ref/net46/System.Security.Cryptography.Encryption.dll",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encryption.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encryption.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2074e63e0b6f4a3f9643aa5e83c3e849.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Cryptography.Encryption.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Security.Principal.dll",
-        "ref/dotnet/System.Security.Principal.xml",
-        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
         "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
         "ref/dotnet/fr/System.Security.Principal.xml",
         "ref/dotnet/it/System.Security.Principal.xml",
         "ref/dotnet/ja/System.Security.Principal.xml",
         "ref/dotnet/ko/System.Security.Principal.xml",
         "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
         "ref/dotnet/zh-hans/System.Security.Principal.xml",
-        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Security.Principal.dll",
         "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/5d44fbabc99d4204b6a2f76329d0a184.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.Principal.nuspec"
       ]
     },
     "System.Security.SecureString/4.0.0-beta-23123": {
       "sha512": "T35YL/7zWBYOLJCcntF+bQgZBgOy5qc6oPn4GWL1phv0borJawTL60iwk4MO2ReYYSK89JmJ7/yqKahqYNw72g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Security.SecureString.nuspec",
         "lib/DNXCore50/System.Security.SecureString.dll",
-        "lib/net46/System.Security.SecureString.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Security.SecureString.dll",
-        "ref/dotnet/System.Security.SecureString.xml",
-        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
         "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
         "ref/dotnet/fr/System.Security.SecureString.xml",
         "ref/dotnet/it/System.Security.SecureString.xml",
         "ref/dotnet/ja/System.Security.SecureString.xml",
         "ref/dotnet/ko/System.Security.SecureString.xml",
         "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
         "ref/dotnet/zh-hans/System.Security.SecureString.xml",
-        "ref/dotnet/es/System.Security.SecureString.xml",
-        "ref/net46/System.Security.SecureString.dll",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/0f5b99c6bf5d40fa93b9952b703518fa.psmdcp",
-        "[Content_Types].xml"
+        "System.Security.SecureString.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.nuspec",
-        "lib/netcore50/System.Text.Encoding.dll",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
         "ref/dotnet/it/System.Text.Encoding.xml",
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
-        "ref/dotnet/es/System.Text.Encoding.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.Encoding.Extensions.nuspec",
-        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
-        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Text.RegularExpressions.nuspec",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
-        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
         "ref/dotnet/it/System.Text.RegularExpressions.xml",
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
-        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
-        "[Content_Types].xml"
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
-        "lib/netcore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
-        "ref/dotnet/zh-hant/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
         "ref/dotnet/it/System.Threading.xml",
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
-        "ref/dotnet/es/System.Threading.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Overlapped.nuspec",
-        "lib/netcore50/System.Threading.Overlapped.dll",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
-        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
         "ref/dotnet/it/System.Threading.Overlapped.xml",
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
-        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.nuspec",
-        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
         "ref/dotnet/it/System.Threading.Tasks.xml",
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
-        "ref/dotnet/es/System.Threading.Tasks.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "package/services/metadata/core-properties/b27f9e16f16b429f924c31eb4be21d09.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
-        "lib/win8/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
-        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
-        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/net45/_._",
-        "ref/win8/_._",
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/260c0741092249239a3182de21f409ef.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
     "System.Threading.Thread/4.0.0-beta-23123": {
       "sha512": "qu18HhV/xvNSqh3KjY5olJnVN4dJI2FoPB/BQ7vyDbvSJUEhemUmwuNGAx4TpyO4aBdbGCcLxVkWQIo30yxbeQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Thread.nuspec",
         "lib/DNXCore50/System.Threading.Thread.dll",
-        "lib/net46/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Thread.dll",
-        "ref/dotnet/System.Threading.Thread.xml",
-        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
+        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
         "ref/dotnet/de/System.Threading.Thread.xml",
+        "ref/dotnet/es/System.Threading.Thread.xml",
         "ref/dotnet/fr/System.Threading.Thread.xml",
         "ref/dotnet/it/System.Threading.Thread.xml",
         "ref/dotnet/ja/System.Threading.Thread.xml",
         "ref/dotnet/ko/System.Threading.Thread.xml",
         "ref/dotnet/ru/System.Threading.Thread.xml",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/dotnet/System.Threading.Thread.xml",
         "ref/dotnet/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet/es/System.Threading.Thread.xml",
-        "ref/net46/System.Threading.Thread.dll",
+        "ref/dotnet/zh-hant/System.Threading.Thread.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/225c5ec09d794360a1780ad0e354d0a0.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.Thread.nuspec"
       ]
     },
     "System.Threading.ThreadPool/4.0.10-beta-23123": {
       "sha512": "v3gETuR6Z96CPmZrM7260+MK2eFP8wVm4VcaSH3HDEqIHCByWDWOfY7C80TUdtXshnITcUeIoSU/C6rLwKoiVg==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.ThreadPool.nuspec",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/dotnet/System.Threading.ThreadPool.xml",
-        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
         "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
         "ref/dotnet/fr/System.Threading.ThreadPool.xml",
         "ref/dotnet/it/System.Threading.ThreadPool.xml",
         "ref/dotnet/ja/System.Threading.ThreadPool.xml",
         "ref/dotnet/ko/System.Threading.ThreadPool.xml",
         "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
         "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet/es/System.Threading.ThreadPool.xml",
-        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/070274d00332414391608fe2d7c17bbd.psmdcp",
-        "[Content_Types].xml"
+        "System.Threading.ThreadPool.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Threading.Timer.nuspec",
-        "lib/netcore50/System.Threading.Timer.dll",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Threading.Timer.dll",
-        "ref/dotnet/System.Threading.Timer.xml",
-        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
         "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
         "ref/dotnet/fr/System.Threading.Timer.xml",
         "ref/dotnet/it/System.Threading.Timer.xml",
         "ref/dotnet/ja/System.Threading.Timer.xml",
         "ref/dotnet/ko/System.Threading.Timer.xml",
         "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
         "ref/dotnet/zh-hans/System.Threading.Timer.xml",
-        "ref/dotnet/es/System.Threading.Timer.xml",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
         "ref/net451/_._",
-        "ref/win81/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c02c4d3d0eff43ec9b54de9f60bd68ad.psmdcp",
-        "[Content_Types].xml"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
         "ref/dotnet/it/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XDocument.nuspec",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
         "ref/dotnet/it/System.Xml.XDocument.xml",
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XDocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XmlDocument.dll",
-        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
         "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XmlDocument.xml",
-        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/89840371bf3f4e0d9ab7b6b34213c74c.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XmlDocument.nuspec"
       ]
     },
     "System.Xml.XPath/4.0.0": {
       "sha512": "jalVwhZSwErcW28NZOE3Dqb6B1XA4DAsL15JvykYIKXtXYQU8PI5GXssjF5G0bLm8/6Gko2e1SOjRs/MoeAKrw==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.nuspec",
         "lib/dotnet/System.Xml.XPath.dll",
-        "lib/net46/System.Xml.XPath.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XPath.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.dll",
-        "ref/dotnet/System.Xml.XPath.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
+        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.xml",
+        "ref/dotnet/es/System.Xml.XPath.xml",
         "ref/dotnet/fr/System.Xml.XPath.xml",
         "ref/dotnet/it/System.Xml.XPath.xml",
         "ref/dotnet/ja/System.Xml.XPath.xml",
         "ref/dotnet/ko/System.Xml.XPath.xml",
         "ref/dotnet/ru/System.Xml.XPath.xml",
+        "ref/dotnet/System.Xml.XPath.dll",
+        "ref/dotnet/System.Xml.XPath.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.xml",
-        "ref/dotnet/es/System.Xml.XPath.xml",
-        "ref/net46/System.Xml.XPath.dll",
+        "ref/dotnet/zh-hant/System.Xml.XPath.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XPath.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d021107d37ac4c0c92e4a52a049b2db5.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.nuspec"
       ]
     },
     "System.Xml.XPath.XmlDocument/4.0.0": {
       "sha512": "toGFsezsdAJ3Fkau0l386iGBg3qfYauQrM4haX1nWPYnUOWb0hXfAEVIi47/Ke4ET3gl9h9ZppKiws8QWeJVyQ==",
       "type": "Package",
       "files": [
+        "[Content_Types].xml",
         "_rels/.rels",
-        "System.Xml.XPath.XmlDocument.nuspec",
         "lib/dotnet/System.Xml.XPath.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
-        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
+        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
         "ref/dotnet/de/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/fr/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/it/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ja/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ko/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/ru/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XPath.XmlDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XPath.XmlDocument.xml",
-        "ref/dotnet/es/System.Xml.XPath.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XPath.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d80c68d7cec54f53bc0a59c937fdbf0b.psmdcp",
-        "[Content_Types].xml"
+        "System.Xml.XPath.XmlDocument.nuspec"
       ]
     }
   },
   "projectFileDependencyGroups": {
-    "": [],
+    "": [
+      "System.Reflection.Metadata >= 1.1.0-alpha-00014"
+    ],
     ".NETFramework,Version=v4.5.1": [
       "Microsoft.Tpl.Dataflow >= 4.5.24"
     ],
@@ -5760,15 +5824,15 @@
     "DNXCore,Version=v5.0": [
       "Microsoft.NETCore >= 5.0.0",
       "Microsoft.NETCore.Portable.Compatibility >= 1.0.0",
+      "Microsoft.NETCore.Runtime >= 1.0.0",
+      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
+      "Microsoft.Win32.Registry >= 4.0.0-beta-23127",
       "System.Console >= 4.0.0-beta-23123",
       "System.Diagnostics.TraceSource >= 4.0.0-beta-23019",
       "System.IO.FileSystem.DriveInfo >= 4.0.0-beta-23302",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23213",
-      "System.Xml.XmlDocument >= 4.0.0",
       "System.Xml.ReaderWriter >= 4.0.10",
-      "Microsoft.NETCore.Runtime >= 1.0.0",
-      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-23123",
-      "Microsoft.Win32.Registry >= 4.0.0-beta-23127"
+      "System.Xml.XmlDocument >= 4.0.0"
     ]
   }
 }

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -39,7 +39,9 @@
         <dependency id="System.IO.FileSystem.DriveInfo" version="4.0.0-beta-23302" />
         <dependency id="System.IO.FileSystem.Primitives" version="4.0.0" />
         <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.ObjectModel" version="4.0.10" />
         <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Reflection.Metadata" version="1.0.22" />
         <dependency id="System.Resources.ResourceManager" version="4.0.0" />
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="System.Runtime.Extensions" version="4.0.10" />
@@ -51,8 +53,10 @@
         <dependency id="System.Text.RegularExpressions" version="4.0.10" />
         <dependency id="System.Threading" version="4.0.10" />
         <dependency id="System.Threading.Tasks" version="4.0.10" />
+        <dependency id="System.Threading.Tasks.Parallel" version="4.0.0" />
         <dependency id="System.Threading.Thread" version="4.0.0-beta-23123" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.10" />
+        <dependency id="System.Xml.XDocument" version="4.0.10" />
       </group>
     </dependencies>
   </metadata>

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -41,7 +41,7 @@
         <dependency id="System.Linq" version="4.0.0" />
         <dependency id="System.ObjectModel" version="4.0.10" />
         <dependency id="System.Reflection" version="4.0.10" />
-        <dependency id="System.Reflection.Metadata" version="1.0.22" />
+        <dependency id="System.Reflection.Metadata" version="1.1.0-alpha-00014" />
         <dependency id="System.Resources.ResourceManager" version="4.0.0" />
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="System.Runtime.Extensions" version="4.0.10" />

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -48,6 +48,7 @@
         <dependency id="System.Runtime.Handles" version="4.0.0" />
         <dependency id="System.Runtime.InteropServices" version="4.0.20" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-beta-23213" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.0.0-beta-23328" />
         <dependency id="System.Text.Encoding" version="4.0.10" />
         <dependency id="System.Text.Encoding.Extensions" version="4.0.10" />
         <dependency id="System.Text.RegularExpressions" version="4.0.10" />

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -30,6 +30,7 @@
         <dependency id="System.Collections.Concurrent" version="4.0.10" />
         <dependency id="System.Collections.NonGeneric" version="4.0.0" />
         <dependency id="System.Console" version="4.0.0-beta-23123" />
+        <dependency id="System.Diagnostics.Contracts" version="4.0.0" />
         <dependency id="System.Diagnostics.Debug" version="4.0.10" />
         <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0-beta-23123" />
         <dependency id="System.Diagnostics.Process" version="4.0.0-beta-23123" />
@@ -44,6 +45,8 @@
         <dependency id="System.ObjectModel" version="4.0.10" />
         <dependency id="System.Reflection" version="4.0.10" />
         <dependency id="System.Reflection.Extensions" version="4.0.0" />
+        <dependency id="System.Reflection.Metadata" version="1.1.0-alpha-00014" />
+        <dependency id="System.Reflection.Primitives" version="4.0.0" />
         <dependency id="System.Reflection.TypeExtensions" version="4.0.0" />
         <dependency id="System.Resources.ResourceManager" version="4.0.0" />
         <dependency id="System.Runtime" version="4.0.20" />


### PR DESCRIPTION
This adds a variety of tasks to the .NET Core build.  This should be sufficient to compile basic libraries and console applications targeting the .NET Framework with the .NET Core version of MSBuild.