### PR TITLE
Use ASCII instead of UTF8 as the default codepage

### DIFF
--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Shared
 #if FEATURE_ENCODING_DEFAULT
                 s_currentOemEncoding = Encoding.Default;
 #else
-                s_currentOemEncoding = Encoding.UTF8;
+                s_currentOemEncoding = Encoding.ASCII;
 #endif
 #if !MONO && FEATURE_ENCODING_DEFAULT
                 try


### PR DESCRIPTION
On CoreCLR, we can't use Encoding.Default because it doesn't exist.  We
were defaulting to UTF8 but that broke the new
ExecTaskUnicodeCharacterInCommand test, because on Windows + CoreCLR we
didn't emit the required `chcp` command (because it looked like the exec
was fine without it).

I'm not fully confident that this is the best fix for the problem.  Would we be better off changing [`GetEncodingWithOsFallback`](https://github.com/Microsoft/msbuild/blob/xplat/src/XMakeTasks/Exec.cs#L617) to be more aware of the situation?  @ValMenn @AndyGerlicher 