### PR TITLE
Work around universal string coercion in property functions

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -1019,7 +1019,8 @@ namespace Microsoft.Build.Evaluation
                 // If we have only a single result, then just return it
                 if (results == null && expression.Length == sourceIndex)
                 {
-                    return lastResult == null ? null : FileUtilities.MaybeAdjustFilePath(lastResult.ToString());
+                    var resultString = lastResult as string;
+                    return resultString != null ? FileUtilities.MaybeAdjustFilePath(resultString) : lastResult;
                 }
                 else
                 {

--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -2934,7 +2934,7 @@ namespace Microsoft.Build.Evaluation
                         args[0] = Convert.ChangeType(args[0], objectInstance.GetType(), CultureInfo.InvariantCulture);
                     }
 
-                    // If we've been asked for and instance to be constructed, then we
+                    // If we've been asked to construct an instance, then we
                     // need to locate an appropriate constructor and invoke it
                     if (String.Equals("new", _name, StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -1922,6 +1922,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             Assert.Equal("A;B;C;D", result);
         }
+
         /// <summary>
         /// Expand property function that returns a Dictionary
         /// </summary>
@@ -1935,8 +1936,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.Environment]::GetEnvironmentVariables())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ToUpperInvariant();
             string expected = ("OS=" + Environment.GetEnvironmentVariable("OS")).ToUpperInvariant();
 
-
-            Assert.True(result.Contains(expected));
+            Assert.Contains(expected, result);
         }
 
         /// <summary>
@@ -2191,8 +2191,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             object result = expander.ExpandPropertiesLeaveTypedAndEscaped(@"$([System.Version]::new($(ver1)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
-            Version v = result as Version;
-            Assert.NotNull(v);
+            Assert.IsType<Version>(result);
+
+            Version v = (Version)result;
 
             Assert.Equal(1, v.Major);
             Assert.Equal(2, v.Minor);
@@ -2607,7 +2608,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('CurrentRuntime', 'CurrentArchitecture'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
             // This is the current, so it had better be true!
-            Assert.True(String.Equals("true", result, StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("true", result, true);
         }
 
         /// <summary>
@@ -2928,9 +2929,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// A whole bunch error check tests
         /// </summary>
-        [Fact(Skip = "Ignored in MSTest")]
-
-        // Ignore: Flaky test
+        [Fact(Skip = "Flaky test")]
         public void Medley()
         {
             // Make absolutely sure that the static method cache hasn't been polluted by the other tests.  


### PR DESCRIPTION
This fixes #249, at least for unit tests.

@ValMenn does this look ok?  I'm a little concerned about fixing paths at the list-of-paths level, but this does fix all of the unit tests we have.