### PR TITLE
Close project files after reading them in Core

### DIFF
--- a/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectRootElement.cs
@@ -1954,6 +1954,7 @@ namespace Microsoft.Build.Construction
                     }
 #else
                     XmlReaderSettings xmlReaderSettings = new XmlReaderSettings();
+                    xmlReaderSettings.CloseInput = true; // close the stream when disposing the reader
                     xmlReaderSettings.DtdProcessing = DtdProcessing.Ignore;
                     using (XmlReader xr = XmlReader.Create(File.OpenRead(fullPath), xmlReaderSettings))
                     {


### PR DESCRIPTION
Many unit tests were failing on .NET Core because of a subtle difference
in behavior between the XmlTextReader we use on full framework and the
XmlReader we use in its absence--when disposed, XmlTextReader closed the
file, while XmlReader does so only when told to do so explicitly.

Since project files were still open, unit test cleanup that attempted to
delete the test project files was failing with a file-in-use
IOException.  That's bad, but more generally we shouldn't hold a lock on
the files for longer than we need to, so we should match the
full-framework behavior.

This reduces test failures in Engine from 241 to 179.