### PR TITLE
Logger bug #261

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1316,8 +1316,8 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_GET_COMMANDLINE
             // split the command line on (unquoted) whitespace
             ArrayList commandLineArgs = QuotingUtilities.SplitUnquoted(commandLine);
-            
-            s_exeName = FileUtilities.FixFilePath(QuotingUtilities.Unquote((string)commandLineArgs[0
+
+            s_exeName = FileUtilities.FixFilePath(QuotingUtilities.Unquote((string) commandLineArgs[0]));
 #else
             ArrayList commandLineArgs = new ArrayList(commandLine);
 

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1316,17 +1316,19 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_GET_COMMANDLINE
             // split the command line on (unquoted) whitespace
             ArrayList commandLineArgs = QuotingUtilities.SplitUnquoted(commandLine);
-            // discard the first piece, because that's the path to the executable -- the rest are args
-            s_exeName = FileUtilities.FixFilePath(QuotingUtilities.Unquote((string)commandLineArgs[0]));
+            
+            s_exeName = FileUtilities.FixFilePath(QuotingUtilities.Unquote((string)commandLineArgs[0
+#else
+            ArrayList commandLineArgs = new ArrayList(commandLine);
+
+            s_exeName = FileUtilities.FixFilePath(Process.GetCurrentProcess().MainModule.FileName);
+#endif
 
             if (!s_exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {
                 s_exeName += ".exe";
             }
-#else
-            ArrayList commandLineArgs = new ArrayList(commandLine);
-            s_exeName = FileUtilities.FixFilePath(Process.GetCurrentProcess().MainModule.FileName);
-#endif
+
             // discard the first piece, because that's the path to the executable -- the rest are args
             commandLineArgs.RemoveAt(0);
 

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1323,12 +1323,12 @@ namespace Microsoft.Build.CommandLine
             {
                 s_exeName += ".exe";
             }
-
-            commandLineArgs.RemoveAt(0);
 #else
             ArrayList commandLineArgs = new ArrayList(commandLine);
             s_exeName = FileUtilities.FixFilePath(Process.GetCurrentProcess().MainModule.FileName);
 #endif
+            // discard the first piece, because that's the path to the executable -- the rest are args
+            commandLineArgs.RemoveAt(0);
 
             // parse the command line, and flag syntax errors and obvious switch errors
             switchesNotFromAutoResponseFile = new CommandLineSwitches();


### PR DESCRIPTION
Fix for issue #261.

Extract out common ifdef code from MSBuildApp.GatherAllSwitches(): regardless of the ifdef branch, the first argument needs to be deleted since it is not a command line argument but the executable name.

I also extracted out another code snippet that seemed common to both ifdef branches.
