### PR TITLE
Add target to check for Windows SDK presence

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -11,6 +11,13 @@
     <Message Importance="High" Text="Build binary target directory: '$(BaseOutputPathWithConfig)'" />
   </Target>
 
+  <!-- See https://github.com/Microsoft/msbuild/issues/224 -->
+  <Target Name="EnsureSDKTargetPresent"
+          AfterTargets="_DisplayBuildInfo" >
+    <Error Condition="!Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\Microsoft.NuGet.ImportAfter.targets')" 
+      Text="MSBuild depends on the 'Tools and Windows SDK' Visual Studio plugin. Please install it. Reference: https://github.com/Microsoft/msbuild/wiki/Building+Testing+and+Debugging" />
+  </Target>
+
   <Target Name="_CopyCompilers"
           AfterTargets="_RestoreBuildToolsWrapper"
           Condition="Exists($(BuildToolsSemaphore))">
@@ -47,7 +54,6 @@
              BuildInParallel="true" />
   </Target>
           
-  
   <Target Name="EnsurePrerequisitesCopied"
           BeforeTargets="Build"
           Condition="'$(IsTestProject)' == 'true'">


### PR DESCRIPTION
Fixes #224 

The Windows SDK plugin for Visual Studio adds a msbuild file that represents a hidden dependency for the MSBuild build process.

Added a target early in the build process to check for the existence of this file. The target runs right after `_DisplayBuildInfo`