### PR TITLE
More netcore test fixes

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -195,6 +195,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_PFX_SIGNING</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REFLECTION_EMIT_DEBUG_INFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRY_TOOLSETS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_REGISTRY_SDKS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRYHIVE_DYNDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUN_EXE_IN_TESTS</DefineConstants>

--- a/dir.props
+++ b/dir.props
@@ -155,7 +155,7 @@
 
     <!-- Setting this to false stops the AppX targets, which aren't supported on .NET Core, from beeing imported -->
     <WindowsAppContainer>false</WindowsAppContainer>
-    
+
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreSurface)' != 'true'">
@@ -197,6 +197,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRY_TOOLSETS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRYHIVE_DYNDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RUN_EXE_IN_TESTS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PERMISSIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SECURITY_PRINCIPAL_WINDOWS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SPECIAL_FOLDERS</DefineConstants>
@@ -230,7 +231,7 @@
     <!-- This means that msbuild should (as much as possible) be xcopy deployable and not depend on anything
          installed in the program files directory or other machine state. -->
     <DefineConstants>$(DefineConstants);FEATURE_APPLOCAL_MSBUILD</DefineConstants>
-    
+
     <DefineConstants>$(DefineConstants);FEATURE_PROCESSSTARTINFO_ENVIRONMENT</DefineConstants>
   </PropertyGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -188,6 +188,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEPROCESSCORRUPTEDSTATEEXCEPTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEREF</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HTTP_LISTENER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_INSTALLED_MSBUILD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYSTREAM_GETBUFFER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PARALLEL_BUILD</DefineConstants>

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -809,6 +809,18 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// Deletes a directory, ensuring that Directory.Delete does not get a path ending in a slash.
+        /// </summary>
+        /// <remarks>
+        /// This is a workaround for https://github.com/dotnet/corefx/issues/3780, which clashed with a common
+        /// pattern in our tests.
+        /// </remarks>
+        internal static void DeleteWithoutTrailingBackslash(string path, bool recursive = false)
+        {
+            Directory.Delete(EnsureNoTrailingSlash(path), recursive);
+        }
+
+        /// <summary>
         /// A variation of Path.IsRooted that not throw any IO exception.
         /// </summary>
         internal static bool IsRootedNoThrow(string path)

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -612,6 +612,7 @@ namespace Microsoft.Build.Shared
             return GetDotNetFrameworkSpec(version).GetPathToDotNetFramework(architecture);
         }
 
+#if FEATURE_INSTALLED_MSBUILD
         /// <summary>
         /// Check the registry key and value to see if the .net Framework is installed on the machine.
         /// </summary>
@@ -642,6 +643,7 @@ namespace Microsoft.Build.Shared
 
             return true;
         }
+#endif
 
         /// <summary>
         /// Heuristic that first considers the current runtime path and then searches the base of that path for the given
@@ -1386,6 +1388,9 @@ namespace Microsoft.Build.Shared
             /// </summary>
             public virtual string GetPathToDotNetFramework(DotNetFrameworkArchitecture architecture)
             {
+#if !FEATURE_INSTALLED_MSBUILD
+                return null;
+#else
                 string cachedPath;
                 if (this.pathsToDotNetFramework.TryGetValue(architecture, out cachedPath))
                 {
@@ -1428,6 +1433,7 @@ namespace Microsoft.Build.Shared
                 }
 
                 return generatedPathToDotNetFramework;
+#endif
             }
 
             /// <summary>

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -600,8 +600,8 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(workingPathSubfolder);
-                Directory.Delete(workingPath);
+                FileUtilities.DeleteWithoutTrailingBackslash(workingPathSubfolder);
+                FileUtilities.DeleteWithoutTrailingBackslash(workingPath);
             }
         }
 
@@ -623,7 +623,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 File.Delete(fileName);
-                Directory.Delete(workingPath);
+                FileUtilities.DeleteWithoutTrailingBackslash(workingPath);
             }
 
             string result = String.Join(", ", files);
@@ -652,7 +652,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(workingPath, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(workingPath, true);
             }
 
             string result = String.Join(", ", files);

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -737,7 +737,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 File.Delete(path);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -2212,10 +2212,12 @@ namespace Microsoft.Build.Utilities
                     Dictionary<TargetPlatformSDK, TargetPlatformSDK> monikers = new Dictionary<TargetPlatformSDK, TargetPlatformSDK>();
                     GatherSDKListFromDirectory(sdkDiskRoots, monikers);
 
+#if FEATURE_REGISTRY_SDKS
                     if (NativeMethodsShared.IsWindows)
                     {
                         GatherSDKListFromRegistry(registryRoot, monikers);
                     }
+#endif
 
                     collection = monikers.Keys.ToList();
                     s_cachedTargetPlatforms.Add(cachedTargetPlatformsKey, collection);
@@ -2414,6 +2416,7 @@ namespace Microsoft.Build.Utilities
             }
         }
 
+#if FEATURE_REGISTRY_SDKS
         /// <summary>
         /// Given a registry location enumerate the registry and find the installed SDKs.
         /// </summary>
@@ -2632,6 +2635,7 @@ namespace Microsoft.Build.Utilities
                 GatherSDKsFromRegistryImpl(platformMonikers, registryRoot, RegistryView.Default, RegistryHive.LocalMachine, getSubkeyNames, getRegistrySubKeyDefaultValue, openBaseKey, fileExists);
             }
         }
+#endif
 
         /// <summary>
         /// Get the disk locations to search for sdks under. This can be overridden by an environment variable

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -365,7 +365,11 @@ namespace Microsoft.Build.UnitTests
                 SharedDotNetFrameworkArchitecture.Current
             );
 
+#if FEATURE_INSTALLED_MSBUILD
             Assert.Equal(Path.GetDirectoryName(typeof(object).GetTypeInfo().Module.FullyQualifiedName), path);
+#else
+            Assert.Null(path);
+#endif
         }
 
         /*

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -3516,7 +3516,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-
+#if FEATURE_REGISTRY_SDKS
         /// <summary>
         /// Setup some fake entries in the registry and verify we get the correct sdk from there.
         /// </summary>
@@ -3619,6 +3619,7 @@ namespace Microsoft.Build.UnitTests
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Verify based on a fake directory structure with some good directories and some invalid ones at each level that we 
@@ -3746,6 +3747,7 @@ namespace Microsoft.Build.UnitTests
                 targetPlatforms[key].Platforms["PlatformAssembly, Version=0.1.2.3"]);
         }
 
+#if FEATURE_REGISTRY_SDKS
         /// <summary>
         /// Verify based on a fake directory structure with some good directories and some invalid ones at each level that we 
         /// get the expected set out.
@@ -3958,6 +3960,7 @@ namespace Microsoft.Build.UnitTests
                     StringComparison.OrdinalIgnoreCase));
             Assert.True(targetPlatforms[key].ExtensionSDKs.Count == 0);
         }
+#endif
 
         /// <summary>
         /// Make sure if the sdk identifier is null we get an ArgumentNullException because without specifying the
@@ -4101,6 +4104,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+#if FEATURE_REGISTRY_SDKS
         /// <summary>
         /// Verify that the GetPlatformSDKPropsFileLocation method can be correctly called for pre-OneCore SDKs during evaluation time as a msbuild function.
         /// </summary>
@@ -4254,6 +4258,7 @@ namespace Microsoft.Build.UnitTests
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Make a fake SDK structure on disk for testing.
@@ -4568,9 +4573,9 @@ namespace Microsoft.Build.UnitTests
 
             return tempPath;
         }
-        #endregion
+#endregion
 
-        #region HelperMethods
+#region HelperMethods
 
         /// <summary>
         /// Simplified registry access delegate. Given a baseKey and a subKey, get all of the subkey
@@ -4757,6 +4762,6 @@ namespace Microsoft.Build.UnitTests
             return null;
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -3726,7 +3726,7 @@ namespace Microsoft.Build.UnitTests
                 targetPlatforms[key].Path);
             Assert.Equal(0, targetPlatforms[key].ExtensionSDKs.Count);
             Assert.Equal(3, targetPlatforms[key].Platforms.Count);
-            Assert.True(targetPlatforms[key].ContainsPlatform("Twilight", "0.1.2.3"));
+            Assert.True(targetPlatforms[key].ContainsPlatform("PlatformAssembly", "0.1.2.3"));
             Assert.Equal(
                 Path.Combine(new[] { _fakeStructureRoot, "MyPlatform", "8.0", "Platforms", "PlatformAssembly", "0.1.2.3" })
                 + Path.DirectorySeparatorChar,

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -991,6 +991,7 @@ namespace Microsoft.Build.UnitTests
             Assert.True(success); // "Build Failed.  See Std Out for details."
         }
 
+#if FEATURE_CODETASKFACTORY
         [Fact]
         public void VerifyToolsetAndToolLocationHelperAgreeWhenVisualStudioVersionIsEmpty()
         {
@@ -1131,6 +1132,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.True(success); // "Build Failed.  See Std Out for details."
         }
+#endif
 
         #region GenerateReferenceAssemblyPath
         [Fact]

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -118,7 +118,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -142,7 +142,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -166,7 +166,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -209,7 +209,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -328,7 +328,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(tempDirectory))
                 {
-                    Directory.Delete(tempDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(tempDirectory, true);
                 }
             }
         }
@@ -472,7 +472,7 @@ namespace Microsoft.Build.UnitTests
                     SharedDotNetFrameworkArchitecture.Current
                 );
 
-            Directory.Delete(fakeEverettPath);
+            FileUtilities.DeleteWithoutTrailingBackslash(fakeEverettPath);
             Assert.Equal(null, path);
         }
 
@@ -1296,12 +1296,12 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(redist40Directory))
                 {
-                    Directory.Delete(redist40Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(redist40Directory, true);
                 }
 
                 if (Directory.Exists(redist41Directory))
                 {
-                    Directory.Delete(redist41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                 }
             }
         }
@@ -1331,7 +1331,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(redist41Directory))
                 {
-                    Directory.Delete(redist41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                 }
             }
         }
@@ -1361,7 +1361,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(redist41Directory))
                 {
-                    Directory.Delete(redist41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                 }
             }
         }
@@ -1391,7 +1391,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(redist41Directory))
                 {
-                    Directory.Delete(redist41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                 }
             }
         }
@@ -1421,7 +1421,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     if (Directory.Exists(redist40Directory))
                     {
-                        Directory.Delete(redist40Directory, true);
+                        FileUtilities.DeleteWithoutTrailingBackslash(redist40Directory, true);
                     }
                 }
             }
@@ -1454,7 +1454,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(redist41Directory))
                 {
-                    Directory.Delete(redist41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                 }
             }
         }
@@ -1489,7 +1489,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     if (Directory.Exists(redist41Directory))
                     {
-                        Directory.Delete(redist41Directory, true);
+                        FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                     }
                 }
             }
@@ -1524,7 +1524,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     if (Directory.Exists(redist41Directory))
                     {
-                        Directory.Delete(redist41Directory, true);
+                        FileUtilities.DeleteWithoutTrailingBackslash(redist41Directory, true);
                     }
                 }
             }
@@ -1590,17 +1590,17 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework41Directory))
                 {
-                    Directory.Delete(framework41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework41Directory, true);
                 }
 
                 if (Directory.Exists(framework40Directory))
                 {
-                    Directory.Delete(framework40Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework40Directory, true);
                 }
 
                 if (Directory.Exists(framework39Directory))
                 {
-                    Directory.Delete(framework39Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework39Directory, true);
                 }
             }
         }
@@ -1651,12 +1651,12 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework40Directory))
                 {
-                    Directory.Delete(framework40Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework40Directory, true);
                 }
 
                 if (Directory.Exists(framework39Directory))
                 {
-                    Directory.Delete(framework39Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework39Directory, true);
                 }
             }
         }
@@ -1709,12 +1709,12 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework41Directory))
                 {
-                    Directory.Delete(framework41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework41Directory, true);
                 }
 
                 if (Directory.Exists(framework40Directory))
                 {
-                    Directory.Delete(framework40Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework40Directory, true);
                 }
             }
         }
@@ -3108,8 +3108,8 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(frameworkPath, true /* for recursive deletion */);
-                Directory.Delete(frameworkPath2, true /* for recursive deletion */);
+                FileUtilities.DeleteWithoutTrailingBackslash(frameworkPath, true /* for recursive deletion */);
+                FileUtilities.DeleteWithoutTrailingBackslash(frameworkPath2, true /* for recursive deletion */);
             }
         }
         /// <summary>
@@ -3245,7 +3245,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(manifestPath, true /* for recursive deletion */);
+                FileUtilities.DeleteWithoutTrailingBackslash(manifestPath, true /* for recursive deletion */);
             }
         }
 
@@ -3305,7 +3305,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(manifestPath, true /* for recursive deletion */);
+                FileUtilities.DeleteWithoutTrailingBackslash(manifestPath, true /* for recursive deletion */);
             }
         }
 

--- a/src/Utilities/UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities/UnitTests/ToolTask_Tests.cs
@@ -548,21 +548,21 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("x", startInfo.EnvironmentVariables[userVarName]);
             Assert.Equal(String.Empty, startInfo.EnvironmentVariables["path"]);
 #endif
+
             if (NativeMethodsShared.IsWindows)
             {
-                Assert.True(
-                    String.Equals(
+                Assert.Equal(
 #if FEATURE_SPECIAL_FOLDERS
                         Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
 #else
-                        FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.System),
+                        FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.ProgramFiles),
 #endif
 #if FEATURE_PROCESSSTARTINFO_ENVIRONMENT
                         startInfo.Environment["programfiles"],
 #else
                         startInfo.EnvironmentVariables["programfiles"],
 #endif
-                        StringComparison.OrdinalIgnoreCase));
+                        true);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/BuildManager_Tests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             // Delete directory with the dummy project
             if (Directory.Exists(shutdownProjectDirectory))
             {
-                Directory.Delete(shutdownProjectDirectory, true /* recursive delete */);
+                FileUtilities.DeleteWithoutTrailingBackslash(shutdownProjectDirectory, true /* recursive delete */);
             }
         }
 
@@ -1634,7 +1634,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 Environment.SetEnvironmentVariable("MSBUILDNOINPROCNODE", String.Empty);
             }
 
-            Directory.Delete(tempDir, true);
+            FileUtilities.DeleteWithoutTrailingBackslash(tempDir, true);
             Assert.False(Directory.Exists(tempDir)); // "Temp directory should no longer exist."
         }
 

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -2932,7 +2932,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 if (Directory.Exists(directoryForTest))
                 {
-                    Directory.Delete(directoryForTest, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(directoryForTest, true);
                 }
                 else
                 {
@@ -2962,7 +2962,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             {
                 if (Directory.Exists(directoryForTest))
                 {
-                    Directory.Delete(directoryForTest, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(directoryForTest, true);
                 }
             }
         }

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -481,7 +481,7 @@ namespace Microsoft.Build.UnitTests.Logging
             {
                 if (Directory.Exists(testTempPath))
                 {
-                    Directory.Delete(testTempPath, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(testTempPath, true);
                 }
 
                 if (File.Exists(targetsFile))

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
@@ -24,6 +24,8 @@ using Xunit;
 
 namespace Microsoft.Build.UnitTests.Definition
 {
+#if FEATURE_REGISTRY_TOOLSETS
+
     /// <summary>
     /// Unit tests for ToolsetReader class and its derived classes
     /// </summary>
@@ -128,7 +130,7 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 #endif
 
-        #region "Reading from application configuration file tests"
+    #region "Reading from application configuration file tests"
 
 #if FEATURE_SYSTEM_CONFIGURATION
 
@@ -992,9 +994,9 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(@"some>value", values["2>.0"].Properties["foo"].EvaluatedValue);
         }
 #endif
-        #endregion
+    #endregion
 
-        #region "GetToolsetData tests"
+    #region "GetToolsetData tests"
 
         /// <summary>
         /// Tests the case where registry and config file contains different toolsVersion
@@ -1732,7 +1734,6 @@ namespace Microsoft.Build.UnitTests.Definition
         /// "TaskLocation" is the name of the value.  The name of the value and the preceding "@" may be omitted if
         /// the default value is desired.
         /// </summary>
-
         [Fact]
         public void ConfigFileInvalidRegistryExpression1()
         {
@@ -2329,9 +2330,9 @@ namespace Microsoft.Build.UnitTests.Definition
             });
         }
 
-        #endregion
+    #endregion
 
-        #region "SetDefaultToolsetVersion tests"
+    #region "SetDefaultToolsetVersion tests"
 
         /// <summary>
         /// Tests that the default ToolsVersion is correctly resolved when specified
@@ -2842,7 +2843,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal("gv1", values["4.0"].Properties["p2"].EvaluatedValue);
         }
 
-        #endregion
+    #endregion
 
         private ToolsetRegistryReader GetStandardRegistryReader()
         {
@@ -2857,6 +2858,8 @@ namespace Microsoft.Build.UnitTests.Definition
         }
 #endif
     }
+
+#endif
 
     internal class MockRegistryKey : RegistryKeyWrapper
     {

--- a/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/EscapingInProjects_Tests.cs
@@ -635,7 +635,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             finally
             {
                 if (File.Exists(projectAbsolutePath)) File.Delete(projectAbsolutePath);
-                if (Directory.Exists(path)) Directory.Delete(path);
+                if (Directory.Exists(path)) FileUtilities.DeleteWithoutTrailingBackslash(path);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Evaluator_Tests.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 BuildParameters.WarnOnUninitializedProperty = originalValue;
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -479,7 +479,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", originalValue);
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -521,7 +521,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", originalValue);
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -563,7 +563,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", originalValue);
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -609,7 +609,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", originalValue);
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -654,7 +654,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 BuildParameters.WarnOnUninitializedProperty = originalValue;
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -700,7 +700,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 BuildParameters.WarnOnUninitializedProperty = originalValue;
-                Directory.Delete(targetDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
 
@@ -1047,8 +1047,8 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 File.Delete(importPath1);
                 File.Delete(importPath2);
                 File.Delete(projectPath);
-                Directory.Delete(directory2);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory2);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -2937,7 +2937,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -2962,7 +2962,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -2998,7 +2998,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3023,7 +3023,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -3058,7 +3058,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3083,7 +3083,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -3130,7 +3130,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3159,7 +3159,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -3203,7 +3203,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3232,7 +3232,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -3268,7 +3268,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3293,7 +3293,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -3330,7 +3330,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3355,7 +3355,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
             }
         }
@@ -3877,7 +3877,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -3931,7 +3931,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (Directory.Exists(projectDirectory))
                 {
-                    Directory.Delete(projectDirectory, true /* recursive delete */);
+                    FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, true /* recursive delete */);
                 }
 
                 Directory.CreateDirectory(projectDirectory);
@@ -4106,7 +4106,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 if (File.Exists(directory))
                 {
-                    Directory.Delete(directory);
+                    FileUtilities.DeleteWithoutTrailingBackslash(directory);
                 }
 
                 file0 = Path.Combine(directory, "my.proj");
@@ -4149,7 +4149,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 File.Delete(file2);
                 File.Delete(file3);
                 File.Delete(file4);
-                Directory.Delete(directory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory, true);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Construction;
 using System.IO;
+using Microsoft.Build.Shared;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests.Preprocessor
@@ -780,7 +781,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
                 File.Delete(xml1.FullPath);
                 File.Delete(xml2.FullPath);
                 File.Delete(xml3.FullPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTests/FileLogger_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/FileLogger_Tests.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Build.UnitTests
                 if (Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "tempura")))
                 {
                     File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "tempura\\mylogfile1.log"));
-                    Directory.Delete(Path.Combine(Directory.GetCurrentDirectory(), "tempura"));
+                    FileUtilities.DeleteWithoutTrailingBackslash(Path.Combine(Directory.GetCurrentDirectory(), "tempura"));
                 }
                 File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "mylogfile0.log"));
                 File.Delete(Path.Combine(Directory.GetCurrentDirectory(), "mylogfile3.log"));

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectImportElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectImportElement_Tests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             {
                 if (Directory.Exists(testTempPath))
                 {
-                    Directory.Delete(testTempPath, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(testTempPath, true);
                 }
 
                 if (File.Exists(targetsFile))

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Construction/ProjectRootElement_Tests.cs
@@ -587,7 +587,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             }
             finally
             {
-                Directory.Delete(directory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory, true);
             }
         }
 
@@ -618,7 +618,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             }
             finally
             {
-                Directory.Delete(directory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory, true);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/ProjectItem_Tests.cs
@@ -331,8 +331,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             finally
             {
                 File.Delete(file);
-                Directory.Delete(subdirectory);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(subdirectory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -378,8 +378,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             finally
             {
                 File.Delete(file);
-                Directory.Delete(subdirectory);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(subdirectory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -487,7 +487,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 File.Delete(file2);
                 File.Delete(file3);
 
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -1319,7 +1319,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             }
             finally
             {
-                Directory.Delete(projectDirectory, recursive: true);
+                FileUtilities.DeleteWithoutTrailingBackslash(projectDirectory, recursive: true);
             }
         }
 

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Definition/Project_Tests.cs
@@ -1586,7 +1586,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     File.Delete(filePathToRemove);
                 }
 
-                Directory.Delete(testFileRoot);
+                FileUtilities.DeleteWithoutTrailingBackslash(testFileRoot);
             }
         }
 
@@ -2317,7 +2317,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             }
             finally
             {
-                Directory.Delete(directory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory, true);
             }
         }
 
@@ -2439,7 +2439,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 // Delete the temp directory that was created above.
                 if (Directory.Exists(myTempDir))
                 {
-                    Directory.Delete(myTempDir, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(myTempDir, true);
                 }
             }
         }

--- a/src/XMakeBuildEngine/UnitTestsPublicOM/Instance/ProjectInstance_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTestsPublicOM/Instance/ProjectInstance_Tests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 File.Delete(file1);
                 File.Delete(file2);
                 File.Delete(file3);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 

--- a/src/XMakeCommandLine/UnitTests/ProjectSchemaValidationHandler_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/ProjectSchemaValidationHandler_Tests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Build.UnitTests
                 {
                     try
                     {
-                        Directory.Delete(msbuildXsdSubDirectory, true /* recursive */);
+                        FileUtilities.DeleteWithoutTrailingBackslash(msbuildXsdSubDirectory, true /* recursive */);
                         break;
                     }
                     catch (Exception)

--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -682,7 +682,7 @@ namespace Microsoft.Build.UnitTests
                     {
                         if (Directory.Exists(path))
                         {
-                            Directory.Delete(path, true /*and files*/);
+                            FileUtilities.DeleteWithoutTrailingBackslash(path, true /*and files*/);
                         }
                         else if (File.Exists(path))
                         {
@@ -934,7 +934,7 @@ namespace Microsoft.Build.UnitTests
                 Directory.SetCurrentDirectory(currentDirectory);
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -966,7 +966,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -997,7 +997,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -1029,7 +1029,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -1071,11 +1071,11 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
 
                 File.Delete(exePath);
                 File.Delete(mainRspPath);
-                Directory.Delete(exeDirectory);
+                FileUtilities.DeleteWithoutTrailingBackslash(exeDirectory);
             }
         }
 
@@ -1112,7 +1112,7 @@ namespace Microsoft.Build.UnitTests
                 File.Delete(projectPath);
                 File.Delete(rspPath);
                 File.Delete(exePath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -1143,7 +1143,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -1174,7 +1174,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(projectPath);
                 File.Delete(rspPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 
@@ -1201,7 +1201,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 File.Delete(projectPath);
-                Directory.Delete(directory);
+                FileUtilities.DeleteWithoutTrailingBackslash(directory);
             }
         }
 #endif

--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -565,11 +565,11 @@ namespace Microsoft.Build.UnitTests
         }
 #endif
 
+#if FEATURE_RUN_EXE_IN_TESTS
         /// <summary>
         /// Invalid configuration file should not dump stack.
         /// </summary>
         [Fact(Skip = "Ignored in MSTest")]
-
         // Ignore: Test requires installed toolset.
         public void ConfigurationInvalid()
         {
@@ -667,6 +667,7 @@ namespace Microsoft.Build.UnitTests
             // if there's not, we will catch when we try to read the toolsets. Either is fine; we just want to not crash.
             Assert.True(output.Contains("MSB1043") || output.Contains("MSB4136"));
         }
+#endif
 
         /// <summary>
         /// Try hard to delete a file or directory specified
@@ -698,6 +699,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+#if FEATURE_RUN_EXE_IN_TESTS
         /// <summary>
         /// Run the process and get stdout and stderr
         /// </summary>
@@ -750,6 +752,7 @@ namespace Microsoft.Build.UnitTests
 
             return output;
         }
+#endif
 
         /// <summary>
         /// Tests that the environment gets passed on to the node during build.
@@ -851,6 +854,7 @@ namespace Microsoft.Build.UnitTests
         private string _pathToArbitraryBogusFile = Path.Combine(FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.System), "notepad.exe"); // OK on 64 bit as well
 #endif
 
+#if FEATURE_RUN_EXE_IN_TESTS
         /// <summary>
         /// Basic case
         /// </summary>
@@ -1200,6 +1204,7 @@ namespace Microsoft.Build.UnitTests
                 Directory.Delete(directory);
             }
         }
+#endif
 
         #region IgnoreProjectExtensionTests
 

--- a/src/XMakeTasks/UnitTests/Copy_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Copy_Tests.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Build.UnitTests
                 File.Delete(source2);
                 File.Delete(destination1);
                 File.Delete(destination2);
-                Directory.Delete(destinationFolder, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(destinationFolder, true);
             }
         }
 
@@ -2015,7 +2015,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(sourceFile);
                 File.Delete(destFile);
-                Directory.Delete(destFolder, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
             }
         }
 
@@ -2105,7 +2105,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(sourceFile);
                 File.Delete(destFile);
-                Directory.Delete(destFolder, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(destFolder, true);
             }
         }
     }

--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 Environment.SetEnvironmentVariable("TMP", oldTmp);
-                if (Directory.Exists(newTmp)) Directory.Delete(newTmp);
+                if (Directory.Exists(newTmp)) FileUtilities.DeleteWithoutTrailingBackslash(newTmp);
             }
         }
 
@@ -231,7 +231,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 Environment.SetEnvironmentVariable("TMP", oldTmp);
-                if (Directory.Exists(newTmp)) Directory.Delete(newTmp);
+                if (Directory.Exists(newTmp)) FileUtilities.DeleteWithoutTrailingBackslash(newTmp);
             }
         }
 
@@ -257,7 +257,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 Environment.SetEnvironmentVariable("TMP", oldTmp);
-                if (Directory.Exists(newTmp)) Directory.Delete(newTmp);
+                if (Directory.Exists(newTmp)) FileUtilities.DeleteWithoutTrailingBackslash(newTmp);
             }
         }
 
@@ -283,7 +283,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 Environment.SetEnvironmentVariable("TMP", oldTmp);
-                if (Directory.Exists(newTmp)) Directory.Delete(newTmp);
+                if (Directory.Exists(newTmp)) FileUtilities.DeleteWithoutTrailingBackslash(newTmp);
             }
         }
 
@@ -309,7 +309,7 @@ namespace Microsoft.Build.UnitTests
             finally
             {
                 if (Directory.Exists(folder))
-                    Directory.Delete(folder, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(folder, true);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/GenerateResourceOutOfProc_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResourceOutOfProc_Tests.cs
@@ -2245,7 +2245,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
             {
                 if (txtFile != null) File.Delete(txtFile);
                 if (resourcesFile != null) File.Delete(resourcesFile);
-                if (dir != null) Directory.Delete(dir);
+                if (dir != null) FileUtilities.DeleteWithoutTrailingBackslash(dir);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GenerateResource_Tests.cs
@@ -2295,7 +2295,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             {
                 if (txtFile != null) File.Delete(txtFile);
                 if (resourcesFile != null) File.Delete(resourcesFile);
-                if (dir != null) Directory.Delete(dir);
+                if (dir != null) FileUtilities.DeleteWithoutTrailingBackslash(dir);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/GetReferencePaths_Tests.cs
+++ b/src/XMakeTasks/UnitTests/GetReferencePaths_Tests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework41Directory))
                 {
-                    Directory.Delete(framework41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework41Directory, true);
                 }
             }
         }
@@ -126,7 +126,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework41Directory))
                 {
-                    Directory.Delete(framework41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework41Directory, true);
                 }
             }
         }
@@ -211,7 +211,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework41Directory))
                 {
-                    Directory.Delete(framework41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework41Directory, true);
                 }
             }
         }
@@ -257,7 +257,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (Directory.Exists(framework41Directory))
                 {
-                    Directory.Delete(framework41Directory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(framework41Directory, true);
                 }
             }
         }

--- a/src/XMakeTasks/UnitTests/MSBuild_Tests.cs
+++ b/src/XMakeTasks/UnitTests/MSBuild_Tests.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Build.UnitTests
         /// However, it's a situation where the project author doesn't have control over the
         /// property value and so he can't escape it himself.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/259")]
         public void PropertyOverridesContainSemicolon()
         {
             ObjectModelHelpers.DeleteTempProjectDirectory();

--- a/src/XMakeTasks/UnitTests/MakeDir_Tests.cs
+++ b/src/XMakeTasks/UnitTests/MakeDir_Tests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(dir);
+                FileUtilities.DeleteWithoutTrailingBackslash(dir);
             }
         }
 
@@ -105,9 +105,9 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(dir);
+                FileUtilities.DeleteWithoutTrailingBackslash(dir);
                 File.Delete(file);
-                Directory.Delete(dir2);
+                FileUtilities.DeleteWithoutTrailingBackslash(dir2);
             }
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                Directory.Delete(dir);
+                FileUtilities.DeleteWithoutTrailingBackslash(dir);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/Move_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Move_Tests.cs
@@ -687,7 +687,7 @@ namespace Microsoft.Build.UnitTests
             {
                 File.Delete(sourceFile);
                 File.Delete(destFile);
-                Directory.Delete(destFolder);
+                FileUtilities.DeleteWithoutTrailingBackslash(destFolder);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -10282,7 +10282,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 if (Directory.Exists(testPath))
                 {
-                    Directory.Delete(testPath);
+                    FileUtilities.DeleteWithoutTrailingBackslash(testPath);
                 }
             }
         }
@@ -10319,7 +10319,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 if (Directory.Exists(testPath))
                 {
-                    Directory.Delete(testPath);
+                    FileUtilities.DeleteWithoutTrailingBackslash(testPath);
                 }
             }
         }
@@ -10357,7 +10357,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 if (Directory.Exists(testPath))
                 {
-                    Directory.Delete(testPath);
+                    FileUtilities.DeleteWithoutTrailingBackslash(testPath);
                 }
             }
         }
@@ -12139,7 +12139,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 if (Directory.Exists(testPath))
                 {
-                    Directory.Delete(testPath);
+                    FileUtilities.DeleteWithoutTrailingBackslash(testPath);
                 }
             }
         }
@@ -13670,7 +13670,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
             finally
             {
-                Directory.Delete(frameworkDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(frameworkDirectory, true);
             }
         }
 
@@ -13696,7 +13696,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             }
             finally
             {
-                Directory.Delete(frameworkDirectory, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(frameworkDirectory, true);
             }
         }
 
@@ -15956,7 +15956,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 if (Directory.Exists(fullFrameworkDirectory))
                 {
-                    Directory.Delete(fullFrameworkDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(fullFrameworkDirectory, true);
                 }
             }
         }
@@ -16005,7 +16005,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 if (Directory.Exists(fullFrameworkDirectory))
                 {
-                    Directory.Delete(fullFrameworkDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(fullFrameworkDirectory, true);
                 }
             }
         }
@@ -16050,7 +16050,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 if (Directory.Exists(fullFrameworkDirectory))
                 {
-                    Directory.Delete(fullFrameworkDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(fullFrameworkDirectory, true);
                 }
             }
         }
@@ -16100,7 +16100,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 if (Directory.Exists(fullFrameworkDirectory))
                 {
-                    Directory.Delete(fullFrameworkDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(fullFrameworkDirectory, true);
                 }
             }
         }
@@ -16153,7 +16153,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 useFrameworkFileExists = false;
                 if (Directory.Exists(fullFrameworkDirectory))
                 {
-                    Directory.Delete(fullFrameworkDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(fullFrameworkDirectory, true);
                 }
             }
         }
@@ -16207,7 +16207,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 if (Directory.Exists(fullFrameworkDirectory))
                 {
-                    Directory.Delete(fullFrameworkDirectory, true);
+                    FileUtilities.DeleteWithoutTrailingBackslash(fullFrameworkDirectory, true);
                 }
             }
         }
@@ -16221,7 +16221,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string redistDirectory = Path.GetDirectoryName(fullRedistList);
             if (Directory.Exists(redistDirectory))
             {
-                Directory.Delete(redistDirectory);
+                FileUtilities.DeleteWithoutTrailingBackslash(redistDirectory);
             }
 
             Directory.CreateDirectory(redistDirectory);
@@ -16233,7 +16233,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             redistDirectory = Path.GetDirectoryName(profileRedistList);
             if (Directory.Exists(redistDirectory))
             {
-                Directory.Delete(redistDirectory);
+                FileUtilities.DeleteWithoutTrailingBackslash(redistDirectory);
             }
 
             Directory.CreateDirectory(redistDirectory);

--- a/src/XMakeTasks/UnitTests/ResolveCodeAnalysisRuleSet_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveCodeAnalysisRuleSet_Tests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.UnitTests
 
             public void Dispose()
             {
-                Directory.Delete(_path, recursive: true);
+                FileUtilities.DeleteWithoutTrailingBackslash(_path, recursive: true);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/WriteCodeFragment_Tests.cs
+++ b/src/XMakeTasks/UnitTests/WriteCodeFragment_Tests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(file, task.OutputFile.ItemSpec);
             Assert.Equal(true, File.Exists(file));
 
-            Directory.Delete(folder, true);
+            FileUtilities.DeleteWithoutTrailingBackslash(folder, true);
         }
 
         /// <summary>

--- a/src/XMakeTasks/UnitTests/XamlDataDrivenToolTask_Tests.cs
+++ b/src/XMakeTasks/UnitTests/XamlDataDrivenToolTask_Tests.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Build.UnitTests.XamlDataDrivenToolTask_Tests
             {
                 Environment.SetEnvironmentVariable("TMP", oldTmp);
                 ObjectModelHelpers.DeleteDirectory(newTmp);
-                if (Directory.Exists(newTmp)) Directory.Delete(newTmp);
+                if (Directory.Exists(newTmp)) FileUtilities.DeleteWithoutTrailingBackslash(newTmp);
             }
         }
 

--- a/src/XMakeTasks/UnitTests/XslTransformation_Tests.cs
+++ b/src/XMakeTasks/UnitTests/XslTransformation_Tests.cs
@@ -1124,7 +1124,7 @@ namespace Microsoft.Build.UnitTests
         {
             try
             {
-                Directory.Delete(dir, true);
+                FileUtilities.DeleteWithoutTrailingBackslash(dir, true);
             }
             catch
             {


### PR DESCRIPTION
This is a combination of turning off a bunch of tests that don't work for netcore and fixing a few things here and there.

On my machine, it seems like it should fix all of the test errors except some in the Engine assembly.  However, I'm seeing different behavior after merging with upstream xplat, which I'll attempt to track down now.