### PR TITLE
Add "Restore NuGet packages" build step to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ To get started on **Visual Studio 2015**:
 [install  Visual Studio 2015](http://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs), 
 or grab a [prebuilt Azure VM image](http://blogs.msdn.com/b/visualstudioalm/archive/2014/06/04/visual-studio-14-ctp-now-available-in-the-virtual-machine-azure-gallery.aspx).
 2. Clone the source code (see above).
-3. Open src/MSBuild.sln solution in Visual Studio 2015.
+3. Restore NuGet packages: `msbuild /t:BulkRestoreNugetPackages build.proj`
+4. Open src/MSBuild.sln solution in Visual Studio 2015.
  
 ## How to Engage, Contribute and Provide Feedback
 Before you contribute, please read through the contributing and developer guides to get an idea of what kinds of pull requests we will or won't accept.


### PR DESCRIPTION
Visual Studio seems to get cranky if you don't restore packages before
opening src/MSBuild.sln, so tell users how to do that.

I'm not sure this is the best approach, but at least it seems to work.

<strike>A similar change is also needed to <https://github.com/Microsoft/msbuild/wiki/Building-Testing-and-Debugging>, but unfortunately github wikis do not support pull requests, so someone with write access to the wiki will have to take care of that.</strike>

Er, wait, your wiki is actually wiki, unlike most github wikis, so I made the wiki edit already!  Hooray for the broken link in RebuildWithLocalMSBuild.cmd, which made me notice this (by virtue of presenting me with a big fat edit box instead of an error message).