### PR TITLE
Insert Executable path as first element of args

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_GET_COMMANDLINE
                 Environment.CommandLine
 #else
-                args
+                ConstructArrayArg(args)
 #endif
                 ) == ExitType.Success) ? 0 : 1);
 
@@ -223,6 +223,21 @@ namespace Microsoft.Build.CommandLine
             }
 
             return exitCode;
+        }
+
+        /// <summary>
+        /// Insert the command executable path as the first element of the args array.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static string[] ConstructArrayArg(string[] args)
+        {
+            string[] newArgArray = new string[args.Length + 1];
+
+            newArgArray[0] = FileUtilities.CurrentExecutablePath;
+            Array.Copy(args, 0, newArgArray, 1, args.Length);
+
+            return newArgArray;
         }
 
         /// <summary>
@@ -1321,7 +1336,7 @@ namespace Microsoft.Build.CommandLine
 #else
             ArrayList commandLineArgs = new ArrayList(commandLine);
 
-            s_exeName = FileUtilities.FixFilePath(Process.GetCurrentProcess().MainModule.FileName);
+            s_exeName = FileUtilities.CurrentExecutablePath;
 #endif
 
             if (!s_exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
MSBuild originally used Environment.commandline to get the command line
arguments.
However, .Net Core removed the commandline property.
In consequence, the first element of the new args array has to contain
the executable path so as not to break downstream code. 

MSBuildApp.GatherAllSwitches expects the first argument to be the executable name. It then stores it separately into a field and deletes it from the args list. 
If the executable is not there,  the first valid argument is stored as the executable name and gets deleted.

Therefore main has to ensure that the first argument is the executable.


@AndyGerlicher @dsplaisted @rainersigwald 