### PR TITLE
Update CommandLine tests that invoke msbuild.exe to invoke it through corerun.exe

### DIFF
--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -699,8 +699,8 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Run msbuild.exe within corerun.exe
-        /// It concatenates the given msbuild path to the given parameters and sends it to corerun.
+        /// Invoke msbuild.exe with the given parameters and return the stdout and stderr.
+        /// This method may invoke msbuild via other runtimes.
         /// </summary>
         private string ExecMSBuild(string pathToMsBuildExe, string msbuildParameters, bool expectSuccess = true)
         {

--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -707,12 +707,22 @@ namespace Microsoft.Build.UnitTests
 #if FEATURE_RUN_EXE_IN_TESTS
             var pathToExecutable = pathToMsBuildExe;
 #else
-            var pathToExecutable = Path.Combine(FileUtilities.CurrentExecutableDirectory, "CoreRun.exe");
+            var pathToExecutable = ResolveRuntimeExecutableName();
             msbuildParameters = "\"" + pathToMsBuildExe + "\"" + " " + msbuildParameters;
 #endif
 
             return RunProcessAndGetOutput(pathToExecutable, msbuildParameters, expectSuccess);
         }
+
+#if !FEATURE_RUN_EXE_IN_TESTS
+        /// <summary>
+        /// Resolve the platform specific path to the runtime executable that msbuild.exe needs to be run in (unix-mono, {unix, windows}-corerun).
+        /// </summary>
+        private static string ResolveRuntimeExecutableName()
+        {
+            return NativeMethodsShared.IsMono ? "mono" : Path.Combine(FileUtilities.CurrentExecutableDirectory, "CoreRun");
+        }
+#endif
 
         /// <summary>
         /// Run the process and get stdout and stderr


### PR DESCRIPTION
Fixes #261 

I added a wrapper method runMSBuildWithinCoreRun that is now called by all the "MSBuild.exe" calling tests.
After talking to Daniel, it seems that in the future msbuild might be called from within other runtimes as well. The above mentioned wrapper should make it easier to generalize those tests to run in any runtime.

@AndyGerlicher @rainersigwald @dsplaisted 