### PR TITLE
Fix repository path in NuGet.Config, add option to skip bulk restore

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,6 +6,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="myget.org roslyn nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
     <add key="myget.org buildtools v3" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="myget.org nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="myget.org dotnet-core v3" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
@@ -15,7 +16,4 @@
     <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
     <add key="nuget.org v2" value="https://nuget.org/api/v2/" />
   </packageSources>
-  <config>
-    <add key="repositoryPath" value="..\packages" />
-  </config>
 </configuration>

--- a/build.proj
+++ b/build.proj
@@ -19,7 +19,7 @@
   <Target Name="BulkRestoreNugetPackages"
           BeforeTargets="Build;BuildAllProjects"
           DependsOnTargets="_RestoreBuildTools"
-          Condition="'$(SolutionFile)'!='' and Exists('$(SolutionFile)')">
+          Condition="'$(SolutionFile)'!='' and Exists('$(SolutionFile)') and '$(SkipBulkRestore)' != 'true'">
     <Message Importance="High" Text="Restoring NuGet packages..." />
     <Exec Command="$(NugetToolPath) restore &quot;$(SolutionFile)&quot;" StandardOutputImportance="Low" Condition="'$(OsEnvironment)'=='Windows_NT'" />
   </Target>


### PR DESCRIPTION
- Update NuGet.Config so that packages will be restored to packages folder in repo root, instead of one level up
- Add build option to skip bulk package restore, since this isn't needed if you haven't changed the packages, but seems to be slow anyway