### PR TITLE
Changes that allow MSBuild to run on Linux

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -209,74 +209,78 @@ namespace Microsoft.Build.Internal
         {
             Dictionary<string, string> table = new Dictionary<string, string>(200, StringComparer.OrdinalIgnoreCase); // Razzle has 150 environment variables
 
-#if !MONO
-            char[] block = GetEnvironmentCharArray();
-
-            // Copy strings out, parsing into pairs and inserting into the table.
-            // The first few environment variable entries start with an '='!
-            // The current working directory of every drive (except for those drives
-            // you haven't cd'ed into in your DOS window) are stored in the 
-            // environment block (as =C:=pwd) and the program's exit code is 
-            // as well (=ExitCode=00000000)  Skip all that start with =.
-            // Read docs about Environment Blocks on MSDN's CreateProcess page.
-
-            // Format for GetEnvironmentStrings is:
-            // (=HiddenVar=value\0 | Variable=value\0)* \0
-            // See the description of Environment Blocks in MSDN's
-            // CreateProcess page (null-terminated array of null-terminated strings).
-            // Note the =HiddenVar's aren't always at the beginning.
-            for (int i = 0; i < block.Length; i++)
+            if (NativeMethodsShared.IsWindows)
             {
-                int startKey = i;
+                char[] block = GetEnvironmentCharArray();
 
-                // Skip to key
-                // On some old OS, the environment block can be corrupted. 
-                // Someline will not have '=', so we need to check for '\0'. 
-                while (block[i] != '=' && block[i] != '\0')
-                {
-                    i++;
-                }
+                // Copy strings out, parsing into pairs and inserting into the table.
+                // The first few environment variable entries start with an '='!
+                // The current working directory of every drive (except for those drives
+                // you haven't cd'ed into in your DOS window) are stored in the 
+                // environment block (as =C:=pwd) and the program's exit code is 
+                // as well (=ExitCode=00000000)  Skip all that start with =.
+                // Read docs about Environment Blocks on MSDN's CreateProcess page.
 
-                if (block[i] == '\0')
+                // Format for GetEnvironmentStrings is:
+                // (=HiddenVar=value\0 | Variable=value\0)* \0
+                // See the description of Environment Blocks in MSDN's
+                // CreateProcess page (null-terminated array of null-terminated strings).
+                // Note the =HiddenVar's aren't always at the beginning.
+                for (int i = 0; i < block.Length; i++)
                 {
-                    continue;
-                }
+                    int startKey = i;
 
-                // Skip over environment variables starting with '='
-                if (i - startKey == 0)
-                {
-                    while (block[i] != 0)
+                    // Skip to key
+                    // On some old OS, the environment block can be corrupted. 
+                    // Some lines will not have '=', so we need to check for '\0'. 
+                    while (block[i] != '=' && block[i] != '\0')
                     {
                         i++;
                     }
 
-                    continue;
-                }
+                    if (block[i] == '\0')
+                    {
+                        continue;
+                    }
 
-                string key = new string(block, startKey, i - startKey);
-                i++;
+                    // Skip over environment variables starting with '='
+                    if (i - startKey == 0)
+                    {
+                        while (block[i] != 0)
+                        {
+                            i++;
+                        }
 
-                // skip over '='
-                int startValue = i;
+                        continue;
+                    }
 
-                while (block[i] != 0)
-                {
-                    // Read to end of this entry 
+                    string key = new string(block, startKey, i - startKey);
                     i++;
+
+                    // skip over '='
+                    int startValue = i;
+
+                    while (block[i] != 0)
+                    {
+                        // Read to end of this entry
+                        i++;
+                    }
+
+                    string value = new string(block, startValue, i - startValue);
+
+                    // skip over 0 handled by for loop's i++
+                    table[key] = value;
                 }
-
-                string value = new string(block, startValue, i - startValue);
-
-                // skip over 0 handled by for loop's i++
-                table[key] = value;
             }
-#else
-            var vars = Environment.GetEnvironmentVariables();
-            foreach (var key in vars.Keys)
+            else
             {
-                table[(string)key] = (string)vars[key];
+                var vars = Environment.GetEnvironmentVariables();
+                foreach (var key in vars.Keys)
+                {
+                    table[(string)key] = (string)vars[key];
+                }
             }
-#endif
+
             return table;
         }
 

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -684,22 +684,27 @@ namespace Microsoft.Build.Shared
 
             return path;
         }
-#if !MONO
+
         /// <summary>
         /// Retrieves the current global memory status.
         /// </summary>
         internal static MemoryStatus GetMemoryStatus()
         {
-            MemoryStatus status = new MemoryStatus();
-            bool returnValue = NativeMethodsShared.GlobalMemoryStatusEx(status);
-            if (!returnValue)
+            if (NativeMethodsShared.IsWindows)
             {
-                return null;
+                MemoryStatus status = new MemoryStatus();
+                bool returnValue = NativeMethodsShared.GlobalMemoryStatusEx(status);
+                if (!returnValue)
+                {
+                    return null;
+                }
+
+                return status;
             }
 
-            return status;
+            return null;
         }
-#endif
+
         /// <summary>
         /// Get the last write time of the fullpath to the file. 
         /// If the file does not exist, then DateTime.MinValue is returned

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -750,8 +750,13 @@ namespace Microsoft.Build.Utilities
             startInfo.StandardErrorEncoding = StandardErrorEncoding;
             startInfo.StandardOutputEncoding = StandardOutputEncoding;
 
-            // Some applications such as xcopy.exe fail without error if there's no stdin stream.
-            startInfo.RedirectStandardInput = true;
+            if (NativeMethodsShared.IsWindows)
+            {
+                // Some applications such as xcopy.exe fail without error if there's no stdin stream.
+                // We only do it under Windows, we get Pipe Broken IO exception on other systems if
+                // the program terminates very fast.
+                startInfo.RedirectStandardInput = true;
+            }
 
             // Generally we won't set a working directory, and it will use the current directory
             string workingDirectory = GetWorkingDirectory();
@@ -855,7 +860,10 @@ namespace Microsoft.Build.Utilities
 
                 // Close the input stream. This is done to prevent commands from
                 // blocking the build waiting for input from the user.
-                proc.StandardInput.Dispose();
+                if (NativeMethodsShared.IsWindows)
+                {
+                    proc.StandardInput.Dispose();
+                }
 
                 // sign up for stderr callbacks
                 proc.BeginErrorReadLine();

--- a/src/Utilities/UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities/UnitTests/ToolTask_Tests.cs
@@ -172,11 +172,10 @@ namespace Microsoft.Build.UnitTests
                 // "cmd.exe" croaks big-time when given a very long command-line.  It pops up a message box on
                 // Windows XP.  We can't have that!  So use "attrib.exe" for this exercise instead.
 #if FEATURE_SPECIAL_FOLDERS
-                t.FullToolName = NativeMethodsShared.IsWindows ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "attrib.exe") :
+                t.FullToolName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), NativeMethodsShared.IsWindows ? "attrib.exe" : "ps");
 #else
-                t.FullToolName = NativeMethodsShared.IsWindows ? Path.Combine(FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.System), "attrib.exe") :
+                t.FullToolName = Path.Combine(FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.System), NativeMethodsShared.IsWindows ? "attrib.exe" : "ps");
 #endif
-                    "/bin/ps";
 
                 t.MockCommandLineCommands = new String('x', 32001);
 

--- a/src/XMakeBuildEngine/Logging/ConsoleLogger.cs
+++ b/src/XMakeBuildEngine/Logging/ConsoleLogger.cs
@@ -486,7 +486,7 @@ namespace Microsoft.Build.Logging
             try
             {
                 Console.ForegroundColor =
-                            TransformColor(c, Console.BackgroundColor);
+                            TransformColor(c, BaseConsoleLogger.BackgroundColor);
             }
             catch (IOException)
             {

--- a/src/XMakeBuildEngine/Utilities/Utilities.cs
+++ b/src/XMakeBuildEngine/Utilities/Utilities.cs
@@ -539,6 +539,12 @@ namespace Microsoft.Build.Internal
 #endif
             }
 
+            if (String.IsNullOrEmpty(localAppData))
+            {
+                localAppData = FileUtilities.CurrentExecutableDirectory;
+            }
+
+
             environmentProperties.Set(ProjectPropertyInstance.Create(ReservedPropertyNames.localAppData, localAppData));
 
             // Add MSBuildUserExtensionsPath at $(LocalAppData)\Microsoft\MSBuild

--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -579,7 +579,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         protected override string ToolName
         {
-            get { return "cmd.exe"; }
+            get { return NativeMethodsShared.IsWindows ? "cmd.exe" : "sh"; }
         }
 
         /// <summary>

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -25,9 +25,8 @@
       <group targetFramework="dotnet">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="System.IO.FileSystem.DriveInfo" version="4.0.0-beta-23302" />
-        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23406" />
-        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1-beta-23225" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.0" />
+        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23406" />
         <dependency id="System.Collections" version="4.0.11-beta-23406" />
         <dependency id="System.Collections.Concurrent" version="4.0.11-beta-23225" />
         <dependency id="System.Collections.NonGeneric" version="4.0.0" />
@@ -56,6 +55,7 @@
         <dependency id="System.Text.RegularExpressions" version="4.0.11-beta-23225" />
         <dependency id="System.Threading" version="4.0.11-beta-23406" />
         <dependency id="System.Threading.Tasks" version="4.0.11-beta-23406" />
+        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1-beta-23225" />
         <dependency id="System.Threading.Thread" version="4.0.0-beta-23406" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.11-beta-23225" />
         <dependency id="System.Xml.XDocument" version="4.0.11-beta-23225" />

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -24,8 +24,8 @@
       </group>
       <group targetFramework="dotnet">
         <dependency id="Microsoft.Build.Framework" />
-        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23406" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.0" />
+        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23406" />
         <dependency id="System.Collections" version="4.0.11-beta-23406" />
         <dependency id="System.Collections.Concurrent" version="4.0.11-beta-23225" />
         <dependency id="System.Collections.NonGeneric" version="4.0.0" />

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -25,8 +25,8 @@
       <group targetFramework="dotnet">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="Microsoft.Tpl.Dataflow" version="4.5.24" />
-        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23406" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.0" />
+        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23406" />
         <dependency id="System.Collections" version="4.0.11-beta-23406" />
         <dependency id="System.Collections.Concurrent" version="4.0.11-beta-23225" />
         <dependency id="System.Collections.NonGeneric" version="4.0.0" />

--- a/targets/runtime.project.json
+++ b/targets/runtime.project.json
@@ -21,6 +21,7 @@
         "System.Resources.ReaderWriter": "4.0.0-beta-23406",
         "System.Reflection.Metadata": "1.0.23-beta-23406",
         "System.Threading.Thread": "4.0.0-beta-23406",
+        "System.Threading.ThreadPool": "4.0.10-beta-23409",
         "System.Xml.XmlDocument": "4.0.1-beta-23225",
         "System.Xml.XPath.XmlDocument": "4.0.1-beta-23225",
         "System.Xml.ReaderWriter": "4.0.11-beta-23225",

--- a/targets/runtime.project.lock.json
+++ b/targets/runtime.project.lock.json
@@ -1287,7 +1287,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23225": {
+      "System.Threading.ThreadPool/4.0.10-beta-23409": {
         "dependencies": {
           "System.Runtime": "[4.0.0, )",
           "System.Runtime.InteropServices": "[4.0.0, )"
@@ -3028,7 +3028,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23406": {
+      "System.Threading.ThreadPool/4.0.10-beta-23409": {
         "dependencies": {
           "System.Runtime": "[4.0.0, )",
           "System.Runtime.InteropServices": "[4.0.0, )"
@@ -4915,7 +4915,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23406": {
+      "System.Threading.ThreadPool/4.0.10-beta-23409": {
         "dependencies": {
           "System.Runtime": "[4.0.0, )",
           "System.Runtime.InteropServices": "[4.0.0, )"
@@ -6802,7 +6802,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23406": {
+      "System.Threading.ThreadPool/4.0.10-beta-23409": {
         "dependencies": {
           "System.Runtime": "[4.0.0, )",
           "System.Runtime.InteropServices": "[4.0.0, )"
@@ -10294,8 +10294,8 @@
         "System.Threading.Thread.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23225": {
-      "sha512": "QX+0t6MbaSJ+NedX9HhT8inVFkuaCM3OQioPw6+Ma6SVS9kJoWY4K8H280wssZSjVB7+tv5qUqTYtJ/wodvSTg==",
+    "System.Threading.ThreadPool/4.0.10-beta-23409": {
+      "sha512": "XeD7mDWCdLEWPGmX9zJ2XP/D9qe7g2JDxOcjPz9iOarHm/RriQWEAVLtOkQj/6WhosfYt2E8Q4okTB+mPNUhCA==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",
@@ -10306,29 +10306,7 @@
         "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "package/services/metadata/core-properties/695bff32a368442591a4fc898390a650.psmdcp",
-        "ref/dotnet/System.Threading.ThreadPool.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.nuspec"
-      ]
-    },
-    "System.Threading.ThreadPool/4.0.10-beta-23406": {
-      "sha512": "RecPtfLTq0bnlrrJCZmiFsK28zEg6b30rbqFlPRlA8MaiyQ1u1L2jRcl7k/IGlg03odR2LJ5UUn0qOplHEon9w==",
-      "type": "Package",
-      "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e49ffcc53eb94ed7ab79c8796ac0763d.psmdcp",
+        "package/services/metadata/core-properties/3d0d96fbe4ca49c99f5efa2e5791cbfc.psmdcp",
         "ref/dotnet/System.Threading.ThreadPool.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
@@ -10656,6 +10634,7 @@
       "System.Resources.ReaderWriter >= 4.0.0-beta-23406",
       "System.Runtime.InteropServices.RuntimeInformation >= 4.0.0-beta-23406",
       "System.Threading.Thread >= 4.0.0-beta-23406",
+      "System.Threading.ThreadPool >= 4.0.10-beta-23409",
       "System.Xml.ReaderWriter >= 4.0.11-beta-23225",
       "System.Xml.XmlDocument >= 4.0.1-beta-23225",
       "System.Xml.XPath.XmlDocument >= 4.0.1-beta-23225",


### PR DESCRIPTION
These changes resolve a number of issues MSBuild encounters on startup. All of them are pretty minor.
Note, that when the compilers are copied into the output directory, the System.Collections.Immutable.dll and System.Reflection.Metadata.dll may get overwritten with earlier versions (depends on file dates). This is a separate issue, but if correct versions are present, the result can build a simple project.