### PR TITLE
Fix test failures due to Exec and FileLogger encoding issues

### DIFF
--- a/src/XMakeBuildEngine/Logging/FileLogger.cs
+++ b/src/XMakeBuildEngine/Logging/FileLogger.cs
@@ -242,11 +242,17 @@ namespace Microsoft.Build.Logging
         /// </summary>
         private bool _autoFlush = true;
 
+#if FEATURE_ENCODING_DEFAULT
         /// <summary>
         /// Encoding for the output. Defaults to ANSI.
         /// </summary>
-        private Encoding _encoding = Encoding.GetEncoding(0);
-
+        private Encoding _encoding = Encoding.Default;
+#else
+        /// <summary>
+        /// Encoding for the output. Defaults to UTF-8.
+        /// </summary>
+        private Encoding _encoding = Encoding.UTF8;
+#endif
         /// <summary>
         /// File logger parameters delimiters.
         /// </summary>

--- a/src/XMakeBuildEngine/UnitTests/FileLogger_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/FileLogger_Tests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.UnitTests
         /// Basic case of logging a message to a file
         /// Verify it logs and encoding is ANSI
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/pull/246")]
+        [Fact]
         public void BasicNoExistingFile()
         {
             string log = null;
@@ -65,9 +65,15 @@ namespace Microsoft.Build.UnitTests
                 SetUpFileLoggerAndLogMessage("logfile=" + log, new BuildMessageEventArgs("message here", null, null, MessageImportance.High));
                 VerifyFileContent(log, "message here");
 
-                // Verify no BOM (ANSI encoding)
+                
                 byte[] content = ReadRawBytes(log);
+#if FEATURE_ENCODING_DEFAULT
+                // Verify no BOM (ANSI encoding)
                 Assert.Equal((byte)109, content[0]); // 'm'
+#else
+                // Verify BOM (UTF-8 encoding)
+                Assert.Equal((byte)109, content[3]); // 'm'
+#endif
             }
             finally
             {

--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -220,12 +220,9 @@ namespace Microsoft.Build.Tasks
                     sw.WriteLine("set errorlevel=dummy");
                     sw.WriteLine("set errorlevel=");
 
-                    // We probably have to change the code page to UTF8 (65001) for non-ansi characters to work.
-                    if (EncodingUtilities.CurrentSystemOemEncoding.CodePage != sw.Encoding.CodePage)
-                    {
-                        // Output to nul so we don't change output and logs.
-                        sw.WriteLine(string.Format(@"%SystemRoot%\System32\chcp.com {0}>nul", sw.Encoding.CodePage));
-                    }
+                    // set the console to use the stream writer's encoding
+                    // Output to nul so we don't change output and logs.
+                    sw.WriteLine(string.Format(@"%SystemRoot%\System32\chcp.com {0}>nul", sw.Encoding.CodePage));
 
                     // if the working directory is a UNC path, bracket the exec command with pushd and popd, because pushd
                     // automatically maps the network path to a drive letter, and then popd disconnects it
@@ -265,6 +262,7 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                 }
+
                 sw.WriteLine(Command);
 
                 if (!isUnix)
@@ -553,21 +551,40 @@ namespace Microsoft.Build.Tasks
 
             string batchFileForCommandLine = _batchFile;
 
-            if (NativeMethodsShared.IsWindows)
+            // Unix consoles cannot have their encodings changed in place (like chcp on windows).
+            // Instead, unix scripts receive encoding information via environment variables before invocation.
+            // In consequence, encoding setup has to be performed outside the script, not inside it.
+            if (NativeMethodsShared.IsUnixLike)
             {
-                commandLine.AppendSwitch("/Q");      // echo off
-                commandLine.AppendSwitch("/C");      // run then terminate
-
-                // If for some crazy reason the path has a & character and a space in it
-                // then get the short path of the temp path, which should not have spaces in it
-                // and then escape the &
-                if (batchFileForCommandLine.Contains("&") && !batchFileForCommandLine.Contains("^&"))
-                {
-                    batchFileForCommandLine = NativeMethodsShared.GetShortFilePath(batchFileForCommandLine);
-                    batchFileForCommandLine = batchFileForCommandLine.Replace("&", "^&");
-                }
+                commandLine.AppendSwitch("-c");
+                commandLine.AppendTextUnquoted(" '");
+                commandLine.AppendTextUnquoted("(");
+                commandLine.AppendTextUnquoted("export $LANG=en_US.UTF-8 export LC_ALL=$LANG");
+                commandLine.AppendTextUnquoted(";");
+                commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
+                commandLine.AppendTextUnquoted(")");
+                commandLine.AppendTextUnquoted("'");
             }
-            commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
+            else
+            {
+                if (NativeMethodsShared.IsWindows)
+                {
+                    commandLine.AppendSwitch("/Q"); // echo off
+                    commandLine.AppendSwitch("/C"); // run then terminate
+
+                    // If for some crazy reason the path has a & character and a space in it
+                    // then get the short path of the temp path, which should not have spaces in it
+                    // and then escape the &
+                    if (batchFileForCommandLine.Contains("&") && !batchFileForCommandLine.Contains("^&"))
+                    {
+                        batchFileForCommandLine = NativeMethodsShared.GetShortFilePath(batchFileForCommandLine);
+                        batchFileForCommandLine = batchFileForCommandLine.Replace("&", "^&");
+                    }
+                }
+
+                commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
+            }
+            
         }
 
         #endregion
@@ -616,11 +633,6 @@ namespace Microsoft.Build.Tasks
         /// <returns>Encoding to use</returns>
         private Encoding GetEncodingWithOsFallback()
         {
-            if (Path.DirectorySeparatorChar == '/')
-            {
-                return Encoding.ASCII;
-            }
-
 #if FEATURE_OSVERSION
             // Windows 7 (6.1) or greater
             var windows7 = new Version(6, 1);

--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Tests that Exec still executes properly when there's a non-ansi character in the command
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/251")]
+        [Fact]
         public void ExecTaskUnicodeCharacterInCommand()
         {
             string nonAnsiCharacters = "\u521B\u5EFA";


### PR DESCRIPTION
Fixes #251 
Will conflict with concurrent PR #246 

Exec task:
- the default encoding is UTF-8
- the windows and unix consoles are forced to use utf-8

Filelogger:
- default encoding is UTF-8 with BOM headings

@ValMenn @AndyGerlicher @rainersigwald 