### PR TITLE
Fix some issues in DeployDependencies.proj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -225,3 +225,7 @@ ApiPort/
 *.xlsx
 ref/
 Differences.txt
+# "stamp" files, dummy outputs that exist only to hold timestamps
+*.stamp
+# output for "MSBUILDEMITSOLUTION=1"
+*.metaproj

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -59,7 +59,7 @@
           >
     <ResolveNuGetPackageAssets AllowFallbackOnTargetSelection="false"
                                IncludeFrameworkReferences="false"
-                               NuGetPackagesDirectory=""
+                               NuGetPackagesDirectory="$(NuGetDir)"
                                RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
                                ProjectLanguage=""
                                ProjectLockFile="$(RuntimeProjectLockJson)"

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -27,18 +27,30 @@
     <RuntimeProjectLockJson>$(MSBuildThisFileDirectory)\runtime.project.lock.json</RuntimeProjectLockJson>
     <RestoreRuntimePackagesCommand>"$(NuGetToolPath)" restore $(RuntimeProjectJson)</RestoreRuntimePackagesCommand>
     <RuntimeDirectory Condition="'$(RuntimeDirectory)' ==''">$(OutputPath)</RuntimeDirectory>
+    <!-- Put $(RuntimeStamp) in $(RuntimeDir) to make deleting the directory
+         do the right thing.
+    -->
+    <RuntimeStamp>$(RuntimeDirectory)\runtime.stamp</RuntimeStamp>
     <NuGetRuntimeIdentifier>$(RuntimeSystem)-$(RuntimeArchitecture)</NuGetRuntimeIdentifier>
   </PropertyGroup>
 
   <Target Name="RestoreRuntimePackages"
           Inputs="$(NuGetToolPath);$(RuntimeProjectJson)"
-          Outputs="$(RuntimeProjectLockJson)"
+          Outputs="$(RuntimeStamp)"
           >
+
+    <Message Importance="High" Text="Restoring NuGet packages..." />
     <Exec Command="$(RestoreRuntimePackagesCommand)" StandardOutputImportance="Low" />
 
-    <!-- It appears that NuGet doesn't re-write the project.lock.json file if the contents would be the same. This can mess up incremental builds
-        if you make a non-significant change to project.json.  To avoid that, update the timestamp of the lock file here. -->
-    <Touch Files="$(RuntimeProjectLockJson)" />
+    <!-- This is just a "stamp" file, serving no purpose besides indicating
+         that the target has been run since $(RuntimeProjectJson) was last
+         updated.  The reason we can't use $(RuntimeProjectLockJson) for this
+         is that, since $(RuntimeProjectJson) and $(RuntimeProjectLockJson)
+         are both under version control, their timestamps are left in an
+         indeterminate order by various operations, such as "git clone",
+         "git pull", and "git checkout".
+    -->
+    <Touch Files="$(RuntimeStamp)" AlwaysCreate="true" />
   </Target>
 
   <Target Name="DeployRuntime"

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="DeployDependencies" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
+  <Import Project="..\src\.nuget\packageLoad.targets" />
 
   <Target Name="CopyPackageContent">
     <ItemGroup>
@@ -25,7 +26,7 @@
   <PropertyGroup>
     <RuntimeProjectJson>$(MSBuildThisFileDirectory)\runtime.project.json</RuntimeProjectJson>
     <RuntimeProjectLockJson>$(MSBuildThisFileDirectory)\runtime.project.lock.json</RuntimeProjectLockJson>
-    <RestoreRuntimePackagesCommand>"$(NuGetToolPath)" restore $(RuntimeProjectJson)</RestoreRuntimePackagesCommand>
+    <RestoreRuntimePackagesCommand>$(NugetRestoreCommand) $(NuGetPackageInstallOptions) $(RuntimeProjectJson)</RestoreRuntimePackagesCommand>
     <RuntimeDirectory Condition="'$(RuntimeDirectory)' ==''">$(OutputPath)</RuntimeDirectory>
     <!-- Put $(RuntimeStamp) in $(RuntimeDir) to make deleting the directory
          do the right thing.


### PR DESCRIPTION
The xplat branch didn't seem to build for me with VS 2015 before, but with these changes it does.

Mostly because NuGet has a much easier time finding all the packages it's supposed to grab if it uses the repositories listed in MSBuild's NuGet.Config rather than relying on ~/.nuget/NuGet.Config or the defaults.