### PR TITLE
Fix argument coercion in property functions

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Expander.cs
+++ b/src/XMakeBuildEngine/Evaluation/Expander.cs
@@ -3592,13 +3592,11 @@ namespace Microsoft.Build.Evaluation
                 MethodBase memberInfo = null;
 
                 // First let's try for a method where all arguments are strings..
-#if FEATURE_TYPE_INVOKEMEMBER
                 Type[] types = new Type[_arguments.Length];
                 for (int n = 0; n < _arguments.Length; n++)
                 {
                     types[n] = typeof(string);
                 }
-#endif
 
                 if (isConstructor)
                 {
@@ -3612,15 +3610,7 @@ namespace Microsoft.Build.Evaluation
                 }
                 else
                 {
-#if FEATURE_TYPE_INVOKEMEMBER
                     memberInfo = _objectType.GetMethod(_name, bindingFlags, null, types, null);
-#else
-                    StringComparison nameComparison =
-                        ((_bindingFlags & BindingFlags.IgnoreCase) == BindingFlags.IgnoreCase) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-                    memberInfo = _objectType.GetMethods(bindingFlags)
-                        .Where(method => method.Name.Equals(_name, nameComparison) && ParametersBindToNStringArguments(method.GetParameters(), args.Length))
-                        .FirstOrDefault();
-#endif
                 }
 
                 // If we didn't get a match on all string arguments,

--- a/src/XMakeBuildEngine/Resources/Constants.cs
+++ b/src/XMakeBuildEngine/Resources/Constants.cs
@@ -309,6 +309,7 @@ namespace Microsoft.Build.Internal
                     s_availableStaticMethods.TryAdd("System.IO.File::ReadAllText", fileType);
 
                     s_availableStaticMethods.TryAdd("System.Globalization.CultureInfo::GetCultureInfo", new Tuple<string, Type>(null, typeof(System.Globalization.CultureInfo))); // user request
+                    s_availableStaticMethods.TryAdd("System.Globalization.CultureInfo::new", new Tuple<string, Type>(null, typeof(System.Globalization.CultureInfo))); // user request
                     s_availableStaticMethods.TryAdd("System.Globalization.CultureInfo::CurrentUICulture", new Tuple<string, Type>(null, typeof(System.Globalization.CultureInfo))); // user request
 
                     // All static methods of the following are available (Assembly qualified type names are supported):

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -622,7 +622,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// /// Expand an item vector function that is an itemspec modifier
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void ExpandItemVectorFunctionsItemSpecModifier2()
         {
             ProjectInstance project = ProjectHelpers.CreateEmptyProjectInstance();
@@ -1912,7 +1912,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function that returns an array
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionArrayReturn()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2223,14 +2223,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function that is only available when MSBUILDENABLEALLPROPERTYFUNCTIONS=1
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyStaticFunctionAllEnabled()
         {
-            if (!NativeMethodsShared.IsWindows)
-            {
-                return; // "VB is only for Windows"
-            }
-
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
@@ -2240,10 +2235,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
             try
             {
                 Environment.SetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS", "1");
+                
+                string result = expander.ExpandIntoStringLeaveEscaped("$([System.Type]::GetType(`System.Type`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
-                string result = expander.ExpandIntoStringLeaveEscaped("$([Microsoft.VisualBasic.FileIO.FileSystem]::CurrentDirectory)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
-
-                Assert.Equal(0, String.Compare(Directory.GetCurrentDirectory(), result, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal(0, String.Compare("System.Type", result, StringComparison.OrdinalIgnoreCase));
             }
             finally
             {
@@ -2251,7 +2246,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 AvailableStaticMethods.Reset_ForUnitTestsOnly();
             }
         }
-
 
         /// <summary>
         /// Expand property function that is only available when MSBUILDENABLEALLPROPERTYFUNCTIONS=1, but cannot be found
@@ -2513,14 +2507,18 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function calls GetCultureInfo
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionStaticMethodGetCultureInfo()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
 
+#if FEATURE_CULTUREINFO_GETCULTURES
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.Globalization.CultureInfo]::GetCultureInfo(`en-US`).ToString())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+#else
+            string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.Globalization.CultureInfo]::new(`en-US`).ToString())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+#endif
 
             Assert.Equal(new CultureInfo("en-US").ToString(), result);
         }
@@ -2528,7 +2526,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function calls a static arithmetic method
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionStaticMethodArithmeticAddInt32()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2543,7 +2541,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function calls a static arithmetic method
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionStaticMethodArithmeticAddDouble()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2597,10 +2595,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Assert.Equal("43", result);
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Expand property function that tests for existence of the task host
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionDoesTaskHostExist()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2616,7 +2615,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function that tests for existence of the task host
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionDoesTaskHostExist_Whitespace()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2628,6 +2627,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             // This is the current, so it had better be true!
             Assert.True(String.Equals("true", result, StringComparison.OrdinalIgnoreCase));
         }
+#endif
 
         /// <summary>
         /// Expand property function that tests for existence of the task host
@@ -2649,10 +2649,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
            );
         }
 
+#if FEATURE_APPDOMAIN
         /// <summary>
         /// Expand property function that tests for existence of the task host
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionDoesTaskHostExist_Evaluated()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2667,6 +2668,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             // This is the current, so it had better be true!
             Assert.True(String.Equals("true", result, StringComparison.OrdinalIgnoreCase));
         }
+#endif
 
 #if FEATURE_APPDOMAIN
         /// <summary>
@@ -2701,7 +2703,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand property function calls a static bitwise method to retrieve file attribute
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionStaticMethodFileAttributes()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
@@ -2727,7 +2729,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <summary>
         /// Expand intrinsic property function calls a static arithmetic method
         /// </summary>
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/281")]
+        [Fact]
         public void PropertyFunctionStaticMethodIntrinsicMaths()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();


### PR DESCRIPTION
Fixes #281, and should also fix issues encountered trying to self-build or build corefx where property functions (such as those calling `String.TrimEnd()`) would fail.

The root cause of the issue was that in porting to .NET Core, I replaced a call to Type.GetMethod with logic that was more strict, requiring all argument types to be assignable to the parameter types, which didn't allow for argument coercion.  This change pulls in more of the reflection code from `RuntimeType` and `DefaultBinder` to more closely match full Framework MSBuild's behavior.