### PR TITLE
Implement xplat Processor Architecture query

### DIFF
--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// The processor architecture on which we are running, but default it will be x86
         /// </summary>
-        private static ushort s_runningProcessorArchitecture = NativeMethodsShared.PROCESSOR_ARCHITECTURE_INTEL;
+        private static NativeMethodsShared.ProcessorArchitectures s_runningProcessorArchitecture = NativeMethodsShared.ProcessorArchitectures.X86;
 
         /// <summary>
         /// Object used to lock the internal state s.t. we know that only one person is modifying
@@ -77,18 +77,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         static MSBuildNameIgnoreCaseComparer()
         {
-            if (NativeMethodsShared.IsWindows)
-            {
-                NativeMethodsShared.SYSTEM_INFO systemInfo = new NativeMethodsShared.SYSTEM_INFO();
-
-                NativeMethodsShared.GetSystemInfo(ref systemInfo);
-
-                s_runningProcessorArchitecture = systemInfo.wProcessorArchitecture;
-            }
-            else
-            {
-                s_runningProcessorArchitecture = 0; //x86
-            }
+            s_runningProcessorArchitecture = NativeMethodsShared.ProcessorArchitecture;
         }
 
         /// <summary>
@@ -136,7 +125,8 @@ namespace Microsoft.Build.Collections
             }
 
 #if RETAIL
-            if ((s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64) && (s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM))
+            if ((s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.Architecture_IA64)
+                && (s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.Architecture_ARM))
             {
                 // The use of unsafe here is quite a bit faster than the regular
                 // mechanism in the BCL. This is because we can make assumptions
@@ -355,7 +345,8 @@ namespace Microsoft.Build.Collections
                 }
             }
 #if RETAIL
-            if ((s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64) && (s_runningProcessorArchitecture != NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM))
+            if ((s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.Architecture_IA64)
+                && (s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.Architecture_ARM))
             {
                 unsafe
                 {

--- a/src/Utilities/ProcessorArchitecture.cs
+++ b/src/Utilities/ProcessorArchitecture.cs
@@ -28,9 +28,6 @@ namespace Microsoft.Build.Utilities
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "ARM", Justification = "This is the correct casing for ProcessorArchitecture")]
         public const string ARM = "ARM";
 
-        static private string s_currentProcessArchitecture = null;
-        static private bool s_currentProcessArchitectureInitialized = false;
-
         /// <summary>
         /// Lazy-initted property for getting the architecture of the currently running process
         /// </summary>
@@ -38,20 +35,7 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-                if (!NativeMethodsShared.IsWindows)
-                {
-                    return String.Empty;
-                }
-
-                if (s_currentProcessArchitectureInitialized)
-                {
-                    return s_currentProcessArchitecture;
-                }
-
-                s_currentProcessArchitectureInitialized = true;
-                s_currentProcessArchitecture = ProcessorArchitecture.GetCurrentProcessArchitecture();
-
-                return s_currentProcessArchitecture;
+                return ProcessorArchitecture.GetCurrentProcessArchitecture();
             }
         }
 
@@ -64,27 +48,23 @@ namespace Microsoft.Build.Utilities
         /// <returns>null if unknown architecture or error, one of the known architectures otherwise</returns>
         static private string GetCurrentProcessArchitecture()
         {
-            string architecture = null;
+            string architecture;
 
-            NativeMethodsShared.SYSTEM_INFO systemInfo = new NativeMethodsShared.SYSTEM_INFO();
-
-            NativeMethodsShared.GetSystemInfo(ref systemInfo);
-
-            switch (systemInfo.wProcessorArchitecture)
+            switch (NativeMethodsShared.ProcessorArchitecture)
             {
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_INTEL:
+                case NativeMethodsShared.ProcessorArchitectures.X86:
                     architecture = ProcessorArchitecture.X86;
                     break;
 
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_AMD64:
+                case NativeMethodsShared.ProcessorArchitectures.X64:
                     architecture = ProcessorArchitecture.AMD64;
                     break;
 
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64:
+                case NativeMethodsShared.ProcessorArchitectures.IA64:
                     architecture = ProcessorArchitecture.IA64;
                     break;
 
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM:
+                case NativeMethodsShared.ProcessorArchitectures.ARM:
                     architecture = ProcessorArchitecture.ARM;
                     break;
 

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -3173,12 +3173,6 @@ namespace Microsoft.Build.Utilities
         /// <returns></returns>
         internal static string ConvertDotNetFrameworkArchitectureToProcessorArchitecture(DotNetFrameworkArchitecture architecture)
         {
-            // TODO: Find real architecture on Unix
-            if (NativeMethodsShared.IsUnixLike)
-            {
-                return ProcessorArchitecture.X86;
-            }
-
             switch (architecture)
             {
                 case DotNetFrameworkArchitecture.Bitness32:
@@ -3189,20 +3183,17 @@ namespace Microsoft.Build.Utilities
                     return ProcessorArchitecture.X86;
                 case DotNetFrameworkArchitecture.Bitness64:
                     // We need to know which 64-bit architecture we're on.
-                    NativeMethodsShared.SYSTEM_INFO systemInfo = new NativeMethodsShared.SYSTEM_INFO();
-                    NativeMethodsShared.GetNativeSystemInfo(ref systemInfo);
-
-                    switch (systemInfo.wProcessorArchitecture)
+                    switch (NativeMethodsShared.ProcessorArchitectureNative)
                     {
-                        case NativeMethodsShared.PROCESSOR_ARCHITECTURE_AMD64:
+                        case NativeMethodsShared.ProcessorArchitectures.X64:
                             return ProcessorArchitecture.AMD64;
-                        case NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64:
+                        case NativeMethodsShared.ProcessorArchitectures.IA64:
                             return ProcessorArchitecture.IA64;
-                        // Errr, OK, we're trying to get the 64-bit path on a 32-bit machine.  
+                        // Error, OK, we're trying to get the 64-bit path on a 32-bit machine.
                         // That ... doesn't make sense. 
-                        case NativeMethodsShared.PROCESSOR_ARCHITECTURE_INTEL:
+                        case NativeMethodsShared.ProcessorArchitectures.X86:
                             return null;
-                        case NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM:
+                        case NativeMethodsShared.ProcessorArchitectures.ARM:
                             return null;
                         // unknown architecture? return null
                         default:

--- a/src/Utilities/UnitTests/ProcessorArchitecture_Tests.cs
+++ b/src/Utilities/UnitTests/ProcessorArchitecture_Tests.cs
@@ -16,20 +16,20 @@ namespace Microsoft.Build.UnitTests
 {
     public class ProcessorArchitectureTests
     {
-        internal static string ProcessorArchitectureIntToString(NativeMethodsShared.SYSTEM_INFO systemInfo)
+        internal static string ProcessorArchitectureIntToString()
         {
-            switch (systemInfo.wProcessorArchitecture)
+            switch (NativeMethodsShared.ProcessorArchitecture)
             {
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_INTEL:
+                case NativeMethodsShared.ProcessorArchitectures.X86:
                     return BuildUtilities.ProcessorArchitecture.X86;
 
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_AMD64:
+                case NativeMethodsShared.ProcessorArchitectures.X64:
                     return BuildUtilities.ProcessorArchitecture.AMD64;
 
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_IA64:
+                case NativeMethodsShared.ProcessorArchitectures.IA64:
                     return BuildUtilities.ProcessorArchitecture.IA64;
 
-                case NativeMethodsShared.PROCESSOR_ARCHITECTURE_ARM:
+                case NativeMethodsShared.ProcessorArchitectures.ARM:
                     return BuildUtilities.ProcessorArchitecture.ARM;
 
                 // unknown architecture? return null
@@ -52,9 +52,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void ValidateCurrentProcessorArchitectureCall()
         {
-            NativeMethodsShared.SYSTEM_INFO systemInfo = new NativeMethodsShared.SYSTEM_INFO();
-            NativeMethodsShared.GetSystemInfo(ref systemInfo);
-            Assert.Equal(ProcessorArchitectureIntToString(systemInfo), BuildUtilities.ProcessorArchitecture.CurrentProcessArchitecture); // "BuildUtilities.ProcessorArchitecture.CurrentProcessArchitecture returned an invalid match"
+            Assert.Equal(ProcessorArchitectureIntToString(), BuildUtilities.ProcessorArchitecture.CurrentProcessArchitecture); // "BuildUtilities.ProcessorArchitecture.CurrentProcessArchitecture returned an invalid match"
         }
 
         [Fact]


### PR DESCRIPTION
GetSystemInfo from in kernel32.dll was used for one purpose - to
obtain processor architecture. Refactor code to query for processor
architecture instead of the system info. Added appropriate property
to NativeMethodsShared and implemented equivalent for Unix (common
for Linux & OSX).