### PR TITLE
Fix Compatibility Issues

### DIFF
--- a/CompatBaseline.txt
+++ b/CompatBaseline.txt
@@ -1,2 +1,8 @@
 # This API is marked obsolete and has been removed from the reference assembly
 MembersMustExist : Member 'Microsoft.Build.Utilities.ToolTask.EnvironmentOverride.get()' does not exist in the implementation but it does exist in the contract.
+#These changes will appear in Update 1; They represent added support for Framework 4.6.1 SDK.
+MembersMustExist : Member 'Microsoft.Build.Tasks.GetFrameworkPath.FrameworkVersion461Path.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Utilities.TargetDotNetFrameworkVersion Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.Version461' does not exist in the implementation but it does exist in the contract.
+EnumValuesMustMatch : Enum value 'Microsoft.Build.Utilities.TargetDotNetFrameworkVersion Microsoft.Build.Utilities.TargetDotNetFrameworkVersion.VersionLatest' is (System.Int32)7 in the implementation but (System.Int32)8 in the contract.
+MembersMustExist : Member 'Microsoft.Build.Utilities.ToolLocationHelper.GetPathToDotNetFrameworkSdk()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Utilities.ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(System.String)' does not exist in the implementation but it does exist in the contract.

--- a/src/Utilities/CommandLineBuilder.cs
+++ b/src/Utilities/CommandLineBuilder.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Build.Utilities
 
         #region Appending switches with quoted parameters
 
-        public static string FixCommandLineSwitch(string switchName)
+        internal static string FixCommandLineSwitch(string switchName)
         {
             return !NativeMethodsShared.IsWindows && !string.IsNullOrEmpty(switchName) && switchName.StartsWith("/")
                        ? "-" + switchName.Substring(1)

--- a/src/XMakeTasks/UnitTests/CommandLineBuilderExtension_Tests.cs
+++ b/src/XMakeTasks/UnitTests/CommandLineBuilderExtension_Tests.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Shared;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -94,10 +95,11 @@ namespace Microsoft.Build.UnitTests
                 new string[] { "Name", "HintPath", "Access" },
                 null
             );
+
             Assert.Equal(
-                CommandLineBuilder.FixCommandLineSwitch(@"/myswitch:MySoundEffect.wav,Kenny ")
-                + CommandLineBuilder.FixCommandLineSwitch(@"/myswitch:MySplashScreen.bmp,Cartman,c:\foo,Public"),
-                c.ToString());
+               (NativeMethodsShared.IsWindows ? @"/myswitch:MySoundEffect.wav,Kenny " : @"-myswitch:MySoundEffect.wav,Kenny ")
+               + (NativeMethodsShared.IsWindows ? @"/myswitch:MySplashScreen.bmp,Cartman,c:\foo,Public" : @"-myswitch:MySplashScreen.bmp,Cartman,c:\foo,Public"),
+               c.ToString());
         }
     }
 }


### PR DESCRIPTION
This refers to the compatibility report in issue #299.

Makes FixCommandLineSwitch internal and adjusts a test in order to avoid namespaces conflicts (that would have been caused by an internalVisibleTo)