### PR TITLE
Modifying CodeTaskFactory to create the TMP folder.

### DIFF
--- a/src/XMakeTasks/CodeTaskFactory.cs
+++ b/src/XMakeTasks/CodeTaskFactory.cs
@@ -771,6 +771,12 @@ namespace Microsoft.Build.Tasks
                 if (!s_compiledTaskCache.TryGetValue(fullSpec, out existingAssembly))
                 {
                     // Invokes compilation. 
+
+                    // Note: CompileAssemblyFromSource uses Path.GetTempPath() directory, but will not create it. In some cases 
+                    // this will throw inside CompileAssemblyFromSource. To work around this, ensure the temp directory exists. 
+                    // See: https://github.com/Microsoft/msbuild/issues/328
+                    Directory.CreateDirectory(Path.GetTempPath());
+
                     CompilerResults compilerResults = provider.CompileAssemblyFromSource(compilerParameters, fullCode);
 
                     string outputPath = null;


### PR DESCRIPTION
 - Check to see if the TMP folder exists before calling CompileAssemblyFromSource.
 - Added unit test to cover scenario where the TMP path doesn't exist.
Closes #328 