### PR TITLE
Avoid ambient node reuse when not requested

### DIFF
--- a/CreatePrivateMSBuildEnvironment.proj
+++ b/CreatePrivateMSBuildEnvironment.proj
@@ -21,6 +21,7 @@
 
     <FreshlyBuiltBinaries Include="$(OutputPath)*.dll" />
     <FreshlyBuiltBinaries Include="$(OutputPath)*.exe" />
+    <FreshlyBuiltBinaries Include="$(OutputPath)*.pdb" />
     <FreshlyBuiltBinaries Include="$(OutputPath)*.exe.config" />
 
     <FreshlyBuiltProjects Include="$(OutputPath)*props" />

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         protected override long GetHostHandshake()
         {
-            return NodeProviderOutOfProc.HostHandshake;
+            return NodeProviderOutOfProc.GetHostHandshake();
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         protected override long GetClientHandshake()
         {
-            return NodeProviderOutOfProc.ClientHandshake;
+            return NodeProviderOutOfProc.GetClientHandshake();
         }
 
         #region Structs

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private IBuildComponentHost _componentHost;
 
+        private readonly bool _enableReuse;
+
         #endregion
 
         #region Constructors and Factories
@@ -46,10 +48,12 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="pipeName">The name of the pipe to which we should connect.</param>
         /// <param name="host">The component host.</param>
-        internal NodeEndpointOutOfProc(string pipeName, IBuildComponentHost host)
+        /// <param name="enableReuse">Whether this node may be reused for a later build.</param>
+        internal NodeEndpointOutOfProc(string pipeName, IBuildComponentHost host, bool enableReuse)
         {
             ErrorUtilities.VerifyThrowArgumentNull(host, "host");
             _componentHost = host;
+            _enableReuse = enableReuse;
 
             InternalConstruct(pipeName);
         }
@@ -61,7 +65,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         protected override long GetHostHandshake()
         {
-            return NodeProviderOutOfProc.GetHostHandshake();
+            return NodeProviderOutOfProc.GetHostHandshake(_enableReuse);
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -115,10 +115,10 @@ namespace Microsoft.Build.BackEnd
             // want to start up just a standard MSBuild out-of-proc node. 
             string commandLineArgs = " /nologo /nodemode:1 ";
 
-            // Enable node re-use if it is set.
-            if (ComponentHost.BuildParameters.EnableNodeReuse)
+            // Disable node re-use if it is not requested (because no argument means enable reuse).
+            if (!ComponentHost.BuildParameters.EnableNodeReuse)
             {
-                commandLineArgs += "/nr";
+                commandLineArgs += "/nodeReuse:false";
             }
 
             // Make it here.

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -9,19 +9,14 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.IO;
 using System.IO.Pipes;
 using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
-using System.Security;
-using System.Security.AccessControl;
 using System.Security.Principal;
-using System.Security.Permissions;
 
 using Microsoft.Build.Shared;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Internal;
 
@@ -309,15 +304,8 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 CommunicationsUtilities.Trace("Writing handshake to pipe {0}", pipeName);
-#if true
                 nodeStream.WriteLongForHandshake(hostHandshake);
-#else
-                // When the 4th and subsequent node start up, we see this taking a long period of time (0.5s or greater.)  This is strictly for debugging purposes.
-                DateTime writeStart = DateTime.UtcNow;
-                nodeStream.WriteLong(HostHandshake);
-                DateTime writeEnd = DateTime.UtcNow;
-                Console.WriteLine("Node ProcessId {0} WriteLong {1}", nodeProcessId, (writeEnd - writeStart).TotalSeconds);
-#endif
+
                 CommunicationsUtilities.Trace("Reading handshake from pipe {0}", pipeName);
                 long handshake = nodeStream.ReadLongForHandshake();
 

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public void ShutdownAllNodes()
         {
-            ShutdownAllNodes(NodeProviderOutOfProc.GetHostHandshake(), NodeProviderOutOfProc.GetClientHandshake(), NodeContextTerminated);
+            ShutdownAllNodes(NodeProviderOutOfProc.GetHostHandshake(ComponentHost.BuildParameters.EnableNodeReuse), NodeProviderOutOfProc.GetClientHandshake(), NodeContextTerminated);
         }
 
         #endregion

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public void ShutdownAllNodes()
         {
-            ShutdownAllNodes(NodeProviderOutOfProc.HostHandshake, NodeProviderOutOfProc.ClientHandshake, NodeContextTerminated);
+            ShutdownAllNodes(NodeProviderOutOfProc.GetHostHandshake(), NodeProviderOutOfProc.GetClientHandshake(), NodeContextTerminated);
         }
 
         #endregion

--- a/src/XMakeBuildEngine/BackEnd/Node/OutOfProcNode.cs
+++ b/src/XMakeBuildEngine/BackEnd/Node/OutOfProcNode.cs
@@ -234,15 +234,28 @@ namespace Microsoft.Build.Execution
 
         /// <summary>
         /// Starts up the node and processes messages until the node is requested to shut down.
+        /// Assumes no node reuse.
         /// </summary>
         /// <param name="shutdownException">The exception which caused shutdown, if any.</param>
         /// <returns>The reason for shutting down.</returns>
         public NodeEngineShutdownReason Run(out Exception shutdownException)
         {
+            return Run(false, out shutdownException);
+        }
+
+
+        /// <summary>
+        /// Starts up the node and processes messages until the node is requested to shut down.
+        /// </summary>
+        /// <param name="enableReuse">Whether this node is eligible for reuse later.</param>
+        /// <param name="shutdownException">The exception which caused shutdown, if any.</param>
+        /// <returns>The reason for shutting down.</returns>
+        public NodeEngineShutdownReason Run(bool enableReuse, out Exception shutdownException)
+        {
             // Console.WriteLine("Run called at {0}", DateTime.Now);
             string pipeName = "MSBuild" + Process.GetCurrentProcess().Id;
 
-            _nodeEndpoint = new NodeEndpointOutOfProc(pipeName, this);
+            _nodeEndpoint = new NodeEndpointOutOfProc(pipeName, this, enableReuse);
             _nodeEndpoint.OnLinkStatusChanged += new LinkStatusChangedDelegate(OnLinkStatusChanged);
             _nodeEndpoint.Listen(this);
 

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1920,13 +1920,13 @@ namespace Microsoft.Build.CommandLine
         private static void StartLocalNode(CommandLineSwitches commandLineSwitches)
         {
             string[] input = commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeMode];
-            int nodeNumber = 0;
+            int nodeModeNumber = 0;
 
             if (input.Length > 0)
             {
                 try
                 {
-                    nodeNumber = int.Parse(input[0], CultureInfo.InvariantCulture);
+                    nodeModeNumber = int.Parse(input[0], CultureInfo.InvariantCulture);
                 }
                 catch (FormatException ex)
                 {
@@ -1937,7 +1937,7 @@ namespace Microsoft.Build.CommandLine
                     CommandLineSwitchException.Throw("InvalidNodeNumberValue", input[0], ex.Message);
                 }
 
-                CommandLineSwitchException.VerifyThrow(nodeNumber >= 0, "InvalidNodeNumberValueIsNegative", input[0]);
+                CommandLineSwitchException.VerifyThrow(nodeModeNumber >= 0, "InvalidNodeNumberValueIsNegative", input[0]);
             }
 
 #if !STANDALONEBUILD
@@ -1950,13 +1950,13 @@ namespace Microsoft.Build.CommandLine
                     Exception nodeException = null;
                     NodeEngineShutdownReason shutdownReason = NodeEngineShutdownReason.Error;
                     // normal OOP node case
-                    if (nodeNumber == 1)
+                    if (nodeModeNumber == 1)
                     {
                         OutOfProcNode node = new OutOfProcNode();
                         shutdownReason = node.Run(out nodeException);
                         FileUtilities.ClearCacheDirectory();
                     }
-                    else if (nodeNumber == 2)
+                    else if (nodeModeNumber == 2)
                     {
                         OutOfProcTaskHostNode node = new OutOfProcTaskHostNode();
                         shutdownReason = node.Run(out nodeException);

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1953,7 +1953,7 @@ namespace Microsoft.Build.CommandLine
                     if (nodeModeNumber == 1)
                     {
                         OutOfProcNode node = new OutOfProcNode();
-                        shutdownReason = node.Run(out nodeException);
+                        shutdownReason = node.Run(ProcessNodeReuseSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.NodeReuse]), out nodeException);
                         FileUtilities.ClearCacheDirectory();
                     }
                     else if (nodeModeNumber == 2)


### PR DESCRIPTION
Resolves #339 by requiring that any node that will be used as a worker have the same value for `nodeReuse` as the coordinator.