### PR TITLE
Fix Exec tasks & tests for *nix

### DIFF
--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Build.Tasks
             {
                 commandLine.AppendSwitch("-c");
                 commandLine.AppendTextUnquoted(" \"\"\"");
-                commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; ");
+                commandLine.AppendTextUnquoted("export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; . ");
                 commandLine.AppendFileNameIfNotNull(batchFileForCommandLine);
                 commandLine.AppendTextUnquoted("\"\"\"");
             }
@@ -631,6 +631,11 @@ namespace Microsoft.Build.Tasks
         private Encoding GetEncodingWithOsFallback()
         {
 #if FEATURE_OSVERSION
+            if (!NativeMethodsShared.IsWindows)
+            {
+                return s_utf8WithoutBom;
+            }
+
             // Windows 7 (6.1) or greater
             var windows7 = new Version(6, 1);
 


### PR DESCRIPTION
* Use source (.) to run shell scripts -- no need for exec permission
* Fix encoding on Linux so that scripts don't have a BOM
* Since exit code on failure is always 1 on Linux added additional checks.
* A test that checks the exit code is fixed to account for the fact that Linux exit codes are byte-wide