### PR TITLE
Improve CI diagnosability

### DIFF
--- a/BuildAndCopy.cmd
+++ b/BuildAndCopy.cmd
@@ -25,14 +25,25 @@ echo ** Additional Build Parameters:%AdditionalBuildCommand%
 echo.
 :: Build MSBuild
 call "%~dp0build.cmd" /t:Rebuild %AdditionalBuildCommand%
+set BUILDERRORLEVEL=%ERRORLEVEL%
 
 :: Kill Roslyn, which may have handles open to files we want
 taskkill /F /IM vbcscompiler.exe
 
+if %BUILDERRORLEVEL% NEQ 0 (
+    echo.
+    echo Failed to build with errorlevel %BUILDERRORLEVEL% 1>&2
+    exit /b %BUILDERRORLEVEL%
+)
+
 :: Make a copy of our build
 echo ** Copying bootstrapped MSBuild to the bootstrap folder
-msbuild /v:m CreatePrivateMSBuildEnvironment.proj
-echo.
+msbuild /verbosity:minimal CreatePrivateMSBuildEnvironment.proj
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo Failed building CreatePrivateMSBuildEnvironment.proj with error %ERRORLEVEL%
+    exit /b %ERRORLEVEL%
+)
 
 echo.
 echo ** Packaging complete.

--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -10,14 +10,38 @@ set MSBuildTempPath=%~dp0bin\MSBuild
 
 :: Check prerequisites
 if not defined VS140COMNTOOLS (
-    echo Error: This script should be run from a Visual Studio 2015 Command Prompt.  
+    echo Error: This script should be run from a Visual Studio 2015 Command Prompt.
     echo        Please see https://github.com/Microsoft/msbuild/wiki/Building-Testing-and-Debugging for build instructions.
     exit /b 1
 )
 
 :: Build and copy output to bin\bootstrap
 call "%~dp0BuildAndCopy.cmd"
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo BuildAndCopy.cmd failed with errorlevel %ERRORLEVEL% 1>&2
+    goto :error
+)
 
 :: Rebuild with bootstrapped msbuild
 set MSBUILDCUSTOMPATH="%~dp0\bin\Bootstrap\14.1\Bin\MSBuild.exe"
 "%~dp0build.cmd" /t:RebuildAndTest /p:BootstrappedMSBuild=true
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo build.cmd with bootstrapped MSBuild failed with errorlevel %ERRORLEVEL% 1>&2
+    goto :error
+)
+
+echo.
+echo ++++++++++++++++
+echo + SUCCESS  :-) +
+echo ++++++++++++++++
+echo.
+exit /b 0
+
+:error
+echo.
+echo ---------------------------------------
+echo - RebuildWithLocalMSBuild.cmd FAILED. -
+echo ---------------------------------------
+exit /b 1

--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -16,6 +16,7 @@ if not defined VS140COMNTOOLS (
 )
 
 :: Build and copy output to bin\bootstrap
+set MSBUILDLOGPATH=%~dp0msbuild_bootstrap.log
 call "%~dp0BuildAndCopy.cmd"
 if %ERRORLEVEL% NEQ 0 (
     echo.
@@ -24,6 +25,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 :: Rebuild with bootstrapped msbuild
+set MSBUILDLOGPATH=%~dp0msbuild_local.log
 set MSBUILDCUSTOMPATH="%~dp0\bin\Bootstrap\14.1\Bin\MSBuild.exe"
 "%~dp0build.cmd" /t:RebuildAndTest /p:BootstrappedMSBuild=true
 if %ERRORLEVEL% NEQ 0 (

--- a/build.cmd
+++ b/build.cmd
@@ -13,12 +13,16 @@ if not defined MSBUILDCUSTOMPATH (
     set MSBUILDCUSTOMPATH=MSBuild.exe
 )
 
+if not defined MSBUILDLOGPATH (
+    set MSBUILDLOGPATH=%~dp0msbuild.log
+)
+
 echo ** MSBuild Path: %MSBUILDCUSTOMPATH%
 echo ** Building all sources
 
 :: Call MSBuild
 echo ** "%MSBUILDCUSTOMPATH%" "%~dp0build.proj" /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log" %*
-"%MSBUILDCUSTOMPATH%" "%~dp0build.proj" /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log" %*
+"%MSBUILDCUSTOMPATH%" "%~dp0build.proj" /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%MSBUILDLOGPATH%" %*
 set BUILDERRORLEVEL=%ERRORLEVEL%
 echo.
 

--- a/build.cmd
+++ b/build.cmd
@@ -21,13 +21,13 @@ echo ** MSBuild Path: %MSBUILDCUSTOMPATH%
 echo ** Building all sources
 
 :: Call MSBuild
-echo ** "%MSBUILDCUSTOMPATH%" "%~dp0build.proj" /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%~dp0msbuild.log" %*
+echo ** "%MSBUILDCUSTOMPATH%" "%~dp0build.proj" /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%MSBUILDLOGPATH%" %*
 "%MSBUILDCUSTOMPATH%" "%~dp0build.proj" /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%MSBUILDLOGPATH%" %*
 set BUILDERRORLEVEL=%ERRORLEVEL%
 echo.
 
 :: Pull the build summary from the log file
 findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%~dp0msbuild.log"
-echo ** Build completed. Exit code: %BUILDERRORLEVEL%
+echo ** Build completed. Log: %MSBUILDLOGPATH% Exit code: %BUILDERRORLEVEL%
 
 exit /b %BUILDERRORLEVEL%

--- a/netci.groovy
+++ b/netci.groovy
@@ -61,7 +61,7 @@ def project = GithubProject
         Utilities.setMachineAffinity(newJob, osName)
         Utilities.standardJobSetup(newJob, project, isPR, branch)
         // Add archiving of logs
-        Utilities.addArchival(newJob, 'msbuild.log')
+        Utilities.addArchival(newJob, 'msbuild*.log')
         // Add trigger
         if (isPR) {
             Utilities.addGithubPRTrigger(newJob, "${osName} Build")


### PR DESCRIPTION
I was looking at enabling CI for full-framework builds in xplat and noticed again that we don't reliably fail the script on intermediate step failures.  This has caused some confusion in the past and it's clearly just a bad idea.