### PR TITLE
Specifically passing in empty arrays to methods expecting params Arrays to fix build break on corefx caused by upgrade on buildtools.

### DIFF
--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Shared
 #if !CLR2COMPATIBILITY
             if (!Monitor.IsEntered(locker))
             {
-                ThrowInternalError("Lock should already have been taken");
+                ThrowInternalError("Lock should already have been taken", new object[0]);
             }
 #endif
         }

--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Build.Collections
         {
             if (immutable)
             {
-                ErrorUtilities.ThrowInternalError("immutable");
+                ErrorUtilities.ThrowInternalError("immutable", new object[0]);
             }
 
             ErrorUtilities.VerifyThrowInternalNull(dictionary, "dictionary");
@@ -278,7 +278,7 @@ namespace Microsoft.Build.Collections
 
                         if (!constraintInX && !constraintInY)
                         {
-                            ErrorUtilities.ThrowInternalError("Expected to compare to constraint");
+                            ErrorUtilities.ThrowInternalError("Expected to compare to constraint", new object[0]);
                         }
 
                         // Put constrained string in 'y', regular in 'x'
@@ -410,7 +410,7 @@ namespace Microsoft.Build.Collections
         {
             if (immutable)
             {
-                ErrorUtilities.ThrowInternalError("immutable");
+                ErrorUtilities.ThrowInternalError("immutable", new object[0]);
             }
 
             if (startIndex < 0)
@@ -438,7 +438,7 @@ namespace Microsoft.Build.Collections
         {
             if (immutable)
             {
-                ErrorUtilities.ThrowInternalError("immutable");
+                ErrorUtilities.ThrowInternalError("immutable", new object[0]);
             }
 
             lock (lockObject)

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Build
 #if DEBUG
                 if (startIndex + count > target.Length)
                 {
-                    ErrorUtilities.ThrowInternalError("wrong length");
+                    ErrorUtilities.ThrowInternalError("wrong length", new object[0]);
                 }
 #endif
                 _target = target;
@@ -387,7 +387,7 @@ namespace Microsoft.Build
                 {
                     if (index > _startIndex + _count - 1 || index < 0)
                     {
-                        ErrorUtilities.ThrowInternalError("past end");
+                        ErrorUtilities.ThrowInternalError("past end", new object[0]);
                     }
 
                     return _target[index + _startIndex];

--- a/src/Shared/ReadOnlyCollection.cs
+++ b/src/Shared/ReadOnlyCollection.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Add(T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Clear()
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public bool Remove(T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             return false;
         }
 

--- a/src/Shared/ReadOnlyEmptyCollection.cs
+++ b/src/Shared/ReadOnlyEmptyCollection.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Add(T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Clear()
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public bool Remove(T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             return false;
         }
 

--- a/src/Shared/ReadOnlyEmptyDictionary.cs
+++ b/src/Shared/ReadOnlyEmptyDictionary.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Build.Collections
 
             set
             {
-                ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+                ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             }
         }
 
@@ -162,7 +162,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Add(K key, V value)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public bool Remove(K key)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             return false;
         }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Add(KeyValuePair<K, V> item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Clear()
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public bool Remove(KeyValuePair<K, V> item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             return false;
         }
 

--- a/src/Shared/ReadOnlyEmptyList.cs
+++ b/src/Shared/ReadOnlyEmptyList.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Collections
 
             set
             {
-                ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+                ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             }
         }
 
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Insert(int index, T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void RemoveAt(int index)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Add(T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public void Clear()
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         public bool Remove(T item)
         {
-            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection");
+            ErrorUtilities.ThrowInvalidOperation("OM_NotSupportedReadOnlyCollection", new object[0]);
             return false;
         }
 

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Build.Shared
 
                 if (unformattedMessage == null)
                 {
-                    ErrorUtilities.ThrowInternalError("The resource string \"" + resourceName + "\" was not found.");
+                    ErrorUtilities.ThrowInternalError("The resource string \"" + resourceName + "\" was not found.", new object[0]);
                 }
             }
             catch (ArgumentException e)
@@ -299,21 +299,21 @@ namespace Microsoft.Build.Shared
 #if FEATURE_DEBUG_LAUNCH
                 Debug.Fail("The resource string \"" + resourceName + "\" was not found.");
 #endif
-                ErrorUtilities.ThrowInternalError(e.Message);
+                ErrorUtilities.ThrowInternalError(e.Message, new object[0]);
             }
             catch (InvalidOperationException e)
             {
 #if FEATURE_DEBUG_LAUNCH
                 Debug.Fail("The resource string \"" + resourceName + "\" was not found.");
 #endif
-                ErrorUtilities.ThrowInternalError(e.Message);
+                ErrorUtilities.ThrowInternalError(e.Message, new object[0]);
             }
             catch (MissingManifestResourceException e)
             {
 #if FEATURE_DEBUG_LAUNCH
                 Debug.Fail("The resource string \"" + resourceName + "\" was not found.");
 #endif
-                ErrorUtilities.ThrowInternalError(e.Message);
+                ErrorUtilities.ThrowInternalError(e.Message, new object[0]);
             }
 #endif
         }

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -486,7 +486,7 @@ namespace Microsoft.Build.Utilities
             // Debug only because it is in theory legitimate to pass importance as a string format parameter.
             Debug.Assert(messageArgs == null || messageArgs.Length == 0 || messageArgs[0].GetType() != typeof(MessageImportance), "Did you call the wrong overload?");
 
-            LogMessageFromResources(MessageImportance.Normal, messageResourceName, messageArgs);
+            LogMessageFromResources(MessageImportance.Normal, messageResourceName, messageArgs, new object[0]);
         }
 
         /// <summary>
@@ -506,7 +506,7 @@ namespace Microsoft.Build.Utilities
             // global state.
             ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, "messageResourceName");
 
-            LogMessage(importance, FormatResourceString(messageResourceName, messageArgs));
+            LogMessage(importance, FormatResourceString(messageResourceName, messageArgs), new object[0]);
 #if _DEBUG
             // Assert that the message does not contain an error code.  Only errors and warnings
             // should have error codes.
@@ -736,7 +736,7 @@ namespace Microsoft.Build.Utilities
 
             if (subcategoryResourceName != null)
             {
-                subcategory = FormatResourceString(subcategoryResourceName);
+                subcategory = FormatResourceString(subcategoryResourceName, new object[0]);
             }
 
 #if _DEBUG
@@ -759,7 +759,8 @@ namespace Microsoft.Build.Utilities
                 columnNumber,
                 endLineNumber,
                 endColumnNumber,
-                FormatResourceString(messageResourceName, messageArgs)
+                FormatResourceString(messageResourceName, messageArgs),
+                new object[0]
             );
         }
 
@@ -822,7 +823,7 @@ namespace Microsoft.Build.Utilities
 
             if (subcategoryResourceName != null)
             {
-                subcategory = FormatResourceString(subcategoryResourceName);
+                subcategory = FormatResourceString(subcategoryResourceName, new object[0]);
             }
 
             string errorCode;
@@ -845,7 +846,8 @@ namespace Microsoft.Build.Utilities
                 columnNumber,
                 endLineNumber,
                 endColumnNumber,
-                message
+                message, 
+                new object[0]
             );
         }
 
@@ -920,7 +922,7 @@ namespace Microsoft.Build.Utilities
                 message = builder.ToString();
             }
 
-            LogError(null, null, null, file, 0, 0, 0, 0, message);
+            LogError(null, null, null, file, 0, 0, 0, 0, message, new object[0]);
         }
 
         #endregion
@@ -1056,7 +1058,7 @@ namespace Microsoft.Build.Utilities
 
             if (subcategoryResourceName != null)
             {
-                subcategory = FormatResourceString(subcategoryResourceName);
+                subcategory = FormatResourceString(subcategoryResourceName, new object[0]);
             }
 
 #if DEBUG
@@ -1079,7 +1081,8 @@ namespace Microsoft.Build.Utilities
                 columnNumber,
                 endLineNumber,
                 endColumnNumber,
-                FormatResourceString(messageResourceName, messageArgs)
+                FormatResourceString(messageResourceName, messageArgs),
+                new object[0]
             );
         }
 
@@ -1142,7 +1145,7 @@ namespace Microsoft.Build.Utilities
 
             if (subcategoryResourceName != null)
             {
-                subcategory = FormatResourceString(subcategoryResourceName);
+                subcategory = FormatResourceString(subcategoryResourceName, new object[0]);
             }
 
             string warningCode;
@@ -1165,7 +1168,8 @@ namespace Microsoft.Build.Utilities
                 columnNumber,
                 endLineNumber,
                 endColumnNumber,
-                message
+                message,
+                new object[0]
             );
         }
 
@@ -1200,7 +1204,7 @@ namespace Microsoft.Build.Utilities
                 message += Environment.NewLine + exception.StackTrace;
             }
 
-            LogWarning(message);
+            LogWarning(message, new object[0]);
         }
 
         #endregion
@@ -1296,7 +1300,7 @@ namespace Microsoft.Build.Utilities
             if (null == messageParts)
             {
                 // Line was not recognized as a canonical error. Log it as a message.
-                LogMessage(messageImportance, lineOfText);
+                LogMessage(messageImportance, lineOfText, new object[0]);
             }
             else
             {
@@ -1324,7 +1328,8 @@ namespace Microsoft.Build.Utilities
                                 messageParts.column,
                                 messageParts.endLine,
                                 messageParts.endColumn,
-                                messageParts.text
+                                messageParts.text,
+                                new object[0]
                             );
 
                             isError = true;
@@ -1343,7 +1348,8 @@ namespace Microsoft.Build.Utilities
                                 messageParts.column,
                                 messageParts.endLine,
                                 messageParts.endColumn,
-                                messageParts.text
+                                messageParts.text,
+                                new object[0]
                             );
 
                             break;

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -2715,7 +2715,7 @@ namespace Microsoft.Build.Utilities
                 }
                 else
                 {
-                    ErrorUtilities.DebugTraceMessage("GetTargetPlatformMonikerDiskRoots", "Getting default disk roots");
+                    ErrorUtilities.DebugTraceMessage("GetTargetPlatformMonikerDiskRoots", "Getting default disk roots", new object[0]);
                     GetDefaultSDKDiskRoots(sdkDiskRoots);
                 }
             }
@@ -2769,7 +2769,7 @@ namespace Microsoft.Build.Utilities
             }
             else
             {
-                ErrorUtilities.DebugTraceMessage("GetTargetPlatformMonikerRegistryRoots", "MSBUILDDISABLEREGISTRYFORSDKLOOKUP is set registry sdk lookup is disabled");
+                ErrorUtilities.DebugTraceMessage("GetTargetPlatformMonikerRegistryRoots", "MSBUILDDISABLEREGISTRYFORSDKLOOKUP is set registry sdk lookup is disabled", new object[0]);
             }
 
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1227,7 +1227,7 @@ namespace Microsoft.Build.Utilities
                     }
                     else if (LogStandardErrorAsError && queueType == StandardOutputOrErrorQueueType.StandardError)
                     {
-                        Log.LogError(errorOrOutMessage);
+                        Log.LogError(errorOrOutMessage, new object[0]);
                     }
                 }
 
@@ -1722,7 +1722,7 @@ namespace Microsoft.Build.Utilities
         {
             if (!alreadyLoggedEnvironmentHeader)
             {
-                LogPrivate.LogMessageFromResources(MessageImportance.Low, "ToolTask.EnvironmentVariableHeader");
+                LogPrivate.LogMessageFromResources(MessageImportance.Low, "ToolTask.EnvironmentVariableHeader", new object[0]);
                 alreadyLoggedEnvironmentHeader = true;
             }
 

--- a/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/XMakeTasks/AssemblyDependency/AssemblyInformation.cs
@@ -662,7 +662,7 @@ namespace Microsoft.Build.Tasks
 
             return (string[])files.ToArray(typeof(string));
 #else
-            return Array.Empty<string>();
+            return new string[0];
 #endif
         }
 

--- a/src/XMakeTasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/XMakeTasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Tasks
         {
             if (SuggestedRedirects == null || SuggestedRedirects.Length == 0)
             {
-                Log.LogMessageFromResources("GenerateBindingRedirects.NoSuggestedRedirects");
+                Log.LogMessageFromResources("GenerateBindingRedirects.NoSuggestedRedirects", new object[0]);
                 OutputAppConfigFile = null;
                 return true;
             }
@@ -326,7 +326,7 @@ namespace Microsoft.Build.Tasks
                 document = XDocument.Load(appConfigItem.ItemSpec);
                 if (document.Root == null || document.Root.Name != "configuration")
                 {
-                    Log.LogErrorWithCodeFromResources("GenerateBindingRedirects.MissingConfigurationNode");
+                    Log.LogErrorWithCodeFromResources("GenerateBindingRedirects.MissingConfigurationNode", new object[0]);
                     return null;
                 }
             }

--- a/src/XMakeTasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/XMakeTasks/AssemblyDependency/ReferenceTable.cs
@@ -2787,7 +2787,7 @@ namespace Microsoft.Build.Tasks
 
                 if (machineType == NativeMethods.IMAGE_FILE_MACHINE_INVALID)
                 {
-                    throw new BadImageFormatException(ResourceUtilities.FormatResourceString("ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader"));
+                    throw new BadImageFormatException(ResourceUtilities.FormatResourceString("ResolveAssemblyReference.ImplementationDllHasInvalidPEHeader", new object[0]));
                 }
 
                 switch (machineType)

--- a/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1049,7 +1049,7 @@ namespace Microsoft.Build.Tasks
                             {
                                 if (!AutoUnify)
                                 {
-                                    Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects");
+                                    Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.TurnOnAutoGenerateBindingRedirects", new object[0]);
                                 }
                                 // else we'll generate bindingRedirects to address the remappings
                             }
@@ -1065,7 +1065,7 @@ namespace Microsoft.Build.Tasks
                         {
                             // This warning is logged regardless of AutoUnify since it means a conflict existed where the reference
                             // chosen was not the conflict victor in a version comparison, in other words it was older.
-                            Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.FoundConflicts");
+                            Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.FoundConflicts", new object[0]);
                         }
                     }
 
@@ -1518,7 +1518,7 @@ namespace Microsoft.Build.Tasks
                 if (reference.IsPrimary && !dependencyProblem)
                 {
                     // Treat it as a warning
-                    Log.LogWarning(null, warningCode, helpKeyword, null, 0, 0, 0, 0, messageOnly);
+                    Log.LogWarning(null, warningCode, helpKeyword, null, 0, 0, 0, 0, messageOnly, new object[0]);
                 }
                 else
                 {
@@ -1587,7 +1587,7 @@ namespace Microsoft.Build.Tasks
                         Log.LogMessageFromResources(importance, "ResolveAssemblyReference.EightSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.SearchPath", lastSearchPath));
                         if (logAssemblyFoldersMinimal)
                         {
-                            Log.LogMessageFromResources(importance, "ResolveAssemblyReference.EightSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.SearchedAssemblyFoldersEx"));
+                            Log.LogMessageFromResources(importance, "ResolveAssemblyReference.EightSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.SearchedAssemblyFoldersEx", new object[0]));
                         }
                     }
 
@@ -1712,32 +1712,32 @@ namespace Microsoft.Build.Tasks
                         break;
 
                     case CopyLocalState.NoBecausePrerequisite:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecausePrerequisite"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecausePrerequisite", new object[0]));
                         break;
 
                     case CopyLocalState.NoBecauseReferenceItemHadMetadata:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseIncomingItemAttributeOverrode", new object[0]));
                         break;
 
                     case CopyLocalState.NoBecauseFrameworkFile:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseFrameworksFiles", new object[0]));
                         break;
 
                     case CopyLocalState.NoBecauseReferenceResolvedFromGAC:
                     case CopyLocalState.NoBecauseReferenceFoundInGAC:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseReferenceFoundInGAC", new object[0]));
                         break;
 
                     case CopyLocalState.NoBecauseConflictVictim:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseConflictVictim", new object[0]));
                         break;
 
                     case CopyLocalState.NoBecauseEmbedded:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseEmbedded"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NotCopyLocalBecauseEmbedded", new object[0]));
                         break;
 
                     case CopyLocalState.NoBecauseParentReferencesFoundInGAC:
-                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac"));
+                        Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.NoBecauseParentReferencesFoundInGac", new object[0]));
                         break;
 
                     default:
@@ -1759,7 +1759,7 @@ namespace Microsoft.Build.Tasks
 
                 if (reference.IsWinMDFile)
                 {
-                    Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.IsAWinMdFile"));
+                    Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.IsAWinMdFile", new object[0]));
                 }
             }
         }
@@ -1805,7 +1805,7 @@ namespace Microsoft.Build.Tasks
                         // a summary warning later on.
                         string message;
                         string code = Log.ExtractMessageCode(Log.FormatResourceString("ResolveAssemblyReference.ConflictUnsolvable", reference.ConflictVictorName, fusionName), out message);
-                        Log.LogMessage(MessageImportance.High, message);
+                        Log.LogMessage(MessageImportance.High, message, new object[0]);
                     }
                     break;
                 // Can happen if one of the references has a dependency with the same simplename, and version but no publickeytoken and the other does.
@@ -1983,13 +1983,13 @@ namespace Microsoft.Build.Tasks
                             }
                             else
                             {
-                                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoSubsetsFound");
+                                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoSubsetsFound", new object[0]);
                             }
 
                             // Could get into this situation if the redist list files were full of junk and no assemblies were read in.
                             if (blackList == null)
                             {
-                                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList");
+                                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList", new object[0]);
                             }
 
                             subsetOrProfileName = GenerateSubSetName(_targetFrameworkSubsets, _installedAssemblySubsetTables);
@@ -2472,7 +2472,7 @@ namespace Microsoft.Build.Tasks
                 {
                     // Generate the black list by determining what assemblies are in the full framework but not in the profile.
                     // The installedAssemblyTableInfo is the list of xml files for the Client Profile redist, these are the whitelist xml files.
-                    Log.LogMessageFromResources("ResolveAssemblyReference.ProfileExclusionListWillBeGenerated");
+                    Log.LogMessageFromResources("ResolveAssemblyReference.ProfileExclusionListWillBeGenerated", new object[0]);
 
                     // Any errors reading the profile redist list will already be logged, we do not need to re-log the errors here.
                     List<Exception> whiteListErrors = new List<Exception>();
@@ -2483,12 +2483,12 @@ namespace Microsoft.Build.Tasks
                 // Could get into this situation if the redist list files were full of junk and no assemblies were read in.
                 if (blackList == null)
                 {
-                    Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList");
+                    Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoRedistAssembliesToGenerateExclusionList", new object[0]);
                 }
             }
             else
             {
-                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoProfilesFound");
+                Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.NoProfilesFound", new object[0]);
             }
 
             if (fullFrameworkRedistList != null)
@@ -2559,14 +2559,14 @@ namespace Microsoft.Build.Tasks
             // Cannot target a subset and a profile at the same time
             if (targetFrameworkSubsetIsSet && profileIsSet)
             {
-                Log.LogErrorWithCodeFromResources("ResolveAssemblyReference.CannotSetProfileAndSubSet");
+                Log.LogErrorWithCodeFromResources("ResolveAssemblyReference.CannotSetProfileAndSubSet", new object[0]);
                 return false;
             }
 
             // A profile name and either a FullFrameworkFolders or ProfileTableLocation must be set is a profile is being used
             if (profileNameIsSet && (!fullFrameworkFoldersIsSet && !fullFrameworkTableLocationsIsSet))
             {
-                Log.LogErrorWithCodeFromResources("ResolveAssemblyReference.MustSetProfileNameAndFolderLocations");
+                Log.LogErrorWithCodeFromResources("ResolveAssemblyReference.MustSetProfileNameAndFolderLocations", new object[0]);
                 return false;
             }
 
@@ -2584,9 +2584,9 @@ namespace Microsoft.Build.Tasks
 
                 if (dumpFrameworkSubsetList != null)
                 {
-                    Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkSubsetLogHeader");
+                    Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkSubsetLogHeader", new object[0]);
 
-                    Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkRedistLogHeader");
+                    Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkRedistLogHeader", new object[0]);
                     if (installedAssemblyTableInfo != null)
                     {
                         foreach (AssemblyTableInfo redistInfo in installedAssemblyTableInfo)
@@ -2599,7 +2599,7 @@ namespace Microsoft.Build.Tasks
                     }
 
 
-                    Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader");
+                    Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkWhiteListLogHeader", new object[0]);
                     if (whiteListSubsetTableInfo != null)
                     {
                         foreach (AssemblyTableInfo whiteListInfo in whiteListSubsetTableInfo)
@@ -2613,7 +2613,7 @@ namespace Microsoft.Build.Tasks
 
                     if (referenceTable.ListOfExcludedAssemblies != null)
                     {
-                        Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader");
+                        Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.TargetFrameworkExclusionListLogHeader", new object[0]);
                         foreach (string assemblyFullName in referenceTable.ListOfExcludedAssemblies)
                         {
                             Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.FourSpaceIndent", assemblyFullName);
@@ -2667,7 +2667,7 @@ namespace Microsoft.Build.Tasks
 
             if (!_silent)
             {
-                Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.UsingExclusionList");
+                Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.UsingExclusionList", new object[0]);
             }
             return true;
         }

--- a/src/XMakeTasks/Copy.cs
+++ b/src/XMakeTasks/Copy.cs
@@ -642,7 +642,7 @@ namespace Microsoft.Build.Tasks
                             }
                             else
                             {
-                                LogDiagnostic("Retrying on ERROR_ACCESS_DENIED because MSBUILDALWAYSRETRY = 1");
+                                LogDiagnostic("Retrying on ERROR_ACCESS_DENIED because MSBUILDALWAYSRETRY = 1", new object[0]);
                             }
                         }
                     }

--- a/src/XMakeTasks/CreateManifestResourceName.cs
+++ b/src/XMakeTasks/CreateManifestResourceName.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Tasks
             }
             else
             {
-                Log.LogMessageFromResources(MessageImportance.Low, "CreateManifestResourceName.NoRootNamespace");
+                Log.LogMessageFromResources(MessageImportance.Low, "CreateManifestResourceName.NoRootNamespace", new object[0]);
             }
 
 

--- a/src/XMakeTasks/Error.cs
+++ b/src/XMakeTasks/Error.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Tasks
         {
             if (Text != null || Code != null)
             {
-                Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, (Text == null) ? String.Empty : Text);
+                Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, (Text == null) ? String.Empty : Text, new object[0]);
             }
 
             // careful to return false. Otherwise the build would continue.

--- a/src/XMakeTasks/ErrorFromResources.cs
+++ b/src/XMakeTasks/ErrorFromResources.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Build.Tasks
                 // If the user specifies a code, that should override. 
                 Code = Code ?? errorCode;
 
-                Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, message);
+                Log.LogError(null, Code, HelpKeyword, File, 0, 0, 0, 0, message, new object[0]);
             }
             catch (Exception e)
             {

--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -374,11 +374,11 @@ namespace Microsoft.Build.Tasks
         {
             if (OutputMatchesRegex(singleLine, ref _customErrorRegex))
             {
-                Log.LogError(singleLine);
+                Log.LogError(singleLine, new object[0]);
             }
             else if (OutputMatchesRegex(singleLine, ref _customWarningRegex))
             {
-                Log.LogWarning(singleLine);
+                Log.LogWarning(singleLine, new object[0]);
             }
             else if (_ignoreStandardErrorWarningFormat)
             {
@@ -449,7 +449,7 @@ namespace Microsoft.Build.Tasks
             // Make sure that at least the Command property was set
             if (Command.Trim().Length == 0)
             {
-                Log.LogErrorWithCodeFromResources("Exec.MissingCommandError");
+                Log.LogErrorWithCodeFromResources("Exec.MissingCommandError", new object[0]);
                 return false;
             }
 

--- a/src/XMakeTasks/GenerateResource.cs
+++ b/src/XMakeTasks/GenerateResource.cs
@@ -666,7 +666,7 @@ namespace Microsoft.Build.Tasks
                 // If there are no sources to process, just return (with success) and report the condition.
                 if ((Sources == null) || (Sources.Length == 0))
                 {
-                    Log.LogMessageFromResources(MessageImportance.Low, "GenerateResource.NoSources");
+                    Log.LogMessageFromResources(MessageImportance.Low, "GenerateResource.NoSources", new object[0]);
                     // Indicate we generated nothing
                     OutputResources = null;
                     return true;
@@ -702,7 +702,7 @@ namespace Microsoft.Build.Tasks
                         OutputResources = cachedOutputFiles.ToArray();
                     }
 
-                    Log.LogMessageFromResources("GenerateResource.NothingOutOfDate");
+                    Log.LogMessageFromResources("GenerateResource.NothingOutOfDate", new object[0]);
                 }
                 else
                 {
@@ -970,7 +970,7 @@ namespace Microsoft.Build.Tasks
 
             return resGenSucceeded;
 #else
-            Log.LogError("ResGen.exe not supported on .NET Core MSBuild");
+            Log.LogError("ResGen.exe not supported on .NET Core MSBuild", new object[0]);
             return false;
 #endif
         }
@@ -1182,7 +1182,7 @@ namespace Microsoft.Build.Tasks
                 // STR classes for each input, but then the class name and file name parameters would have to be vectors.
                 if (Sources.Length != 1)
                 {
-                    Log.LogErrorWithCodeFromResources("GenerateResource.STRLanguageButNotExactlyOneSourceFile");
+                    Log.LogErrorWithCodeFromResources("GenerateResource.STRLanguageButNotExactlyOneSourceFile", new object[0]);
                     return false;
                 }
             }
@@ -1192,7 +1192,7 @@ namespace Microsoft.Build.Tasks
                 {
                     // We have no language to generate a STR, but nevertheless the user passed us a class, 
                     // namespace, and/or filename. Let them know that they probably wanted to pass a language too.
-                    Log.LogErrorWithCodeFromResources("GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage");
+                    Log.LogErrorWithCodeFromResources("GenerateResource.STRClassNamespaceOrFilenameWithoutLanguage", new object[0]);
                     return false;
                 }
             }
@@ -1202,7 +1202,7 @@ namespace Microsoft.Build.Tasks
                 // This combination isn't currently supported, because ResGen may produce some not-easily-predictable
                 // set of ResW files and we don't have any logic to get that set of files back into GenerateResource
                 // at the moment.  This could be solved fixed with some engineering effort.
-                Log.LogErrorWithCodeFromResources("GenerateResource.ExecuteAsToolAndExtractResWNotSupported");
+                Log.LogErrorWithCodeFromResources("GenerateResource.ExecuteAsToolAndExtractResWNotSupported", new object[0]);
                 return false;
             }
 
@@ -1620,7 +1620,7 @@ namespace Microsoft.Build.Tasks
         {
             if (NeverLockTypeAssemblies)
             {
-                Log.LogMessageFromResources(MessageImportance.Low, "GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue");
+                Log.LogMessageFromResources(MessageImportance.Low, "GenerateResource.SeparateAppDomainBecauseNeverLockTypeAssembliesTrue", new object[0]);
                 return true;
             }
 
@@ -2866,7 +2866,7 @@ namespace Microsoft.Build.Tasks
 #if FEATURE_ASSEMBLY_LOADFROM
                 ReadAssemblyResources(filename, outFileOrDir);
 #else
-                _logger.LogError("Reading resources from Assembly not supported on .NET Core MSBuild");
+                _logger.LogError("Reading resources from Assembly not supported on .NET Core MSBuild", new object[0]);
 #endif
             }
             else
@@ -2913,7 +2913,7 @@ namespace Microsoft.Build.Tasks
 #if FEATURE_RESX_RESOURCE_READER
                         ReadResources(reader, new ResourceReader(filename), filename); // closes reader for us
 #else
-                        _logger.LogError("ResGen.exe not supported on .NET Core MSBuild");
+                        _logger.LogError("ResGen.exe not supported on .NET Core MSBuild", new object[0]);
 #endif
                         break;
 
@@ -3163,7 +3163,7 @@ namespace Microsoft.Build.Tasks
 #if FEATURE_RESX_RESOURCE_READER
                     WriteResources(reader, new ResXResourceWriter(filename)); // closes writer for us
 #else
-                    _logger.LogError(format.ToString() + " not supported on .NET Core MSBuild");
+                    _logger.LogError(format.ToString() + " not supported on .NET Core MSBuild", new object[0]);
 #endif
                     break;
 
@@ -3254,7 +3254,7 @@ namespace Microsoft.Build.Tasks
             }
 #else
             sourceFile = null;
-            _logger.LogError("Generating strongly typed resource files not currently supported on .NET Core MSBuild");
+            _logger.LogError("Generating strongly typed resource files not currently supported on .NET Core MSBuild", new object[0]);
 #endif
         }
 
@@ -3371,7 +3371,7 @@ namespace Microsoft.Build.Tasks
                     {
                         String skip = sr.ReadLine();
                         if (skip.Equals("strings]"))
-                            _logger.LogWarningWithCodeFromResources(null, fileName, sr.LineNumber - 1, 1, 0, 0, "GenerateResource.ObsoleteStringsTag");
+                            _logger.LogWarningWithCodeFromResources(null, fileName, sr.LineNumber - 1, 1, 0, 0, "GenerateResource.ObsoleteStringsTag", new object[0]);
                         else
                         {
                             throw new TextFileException(_logger.FormatResourceString("GenerateResource.UnexpectedInfBracket", "[" + skip), fileName, sr.LineNumber - 1, 1);
@@ -3393,7 +3393,7 @@ namespace Microsoft.Build.Tasks
                             break;
                     }
                     if (name.Length == 0)
-                        throw new TextFileException(_logger.FormatResourceString("GenerateResource.NoNameInLine"), fileName, sr.LineNumber, sr.LinePosition);
+                        throw new TextFileException(_logger.FormatResourceString("GenerateResource.NoNameInLine", new object[0]), fileName, sr.LineNumber, sr.LinePosition);
 
                     // For the INF file, we must allow a space on both sides of the equals
                     // sign.  Deal with it.

--- a/src/XMakeTasks/MSBuild.cs
+++ b/src/XMakeTasks/MSBuild.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Build.Tasks
 
             // Parse the global properties into a hashtable.
             Hashtable propertiesTable;
-            if (!PropertyParser.GetTableWithEscaping(Log, ResourceUtilities.FormatResourceString("General.GlobalProperties"), "Properties", this.Properties, out propertiesTable))
+            if (!PropertyParser.GetTableWithEscaping(Log, ResourceUtilities.FormatResourceString("General.GlobalProperties", new object[0]), "Properties", this.Properties, out propertiesTable))
             {
                 return false;
             }
@@ -400,7 +400,7 @@ namespace Microsoft.Build.Tasks
             string[] undefinePropertiesArray = null;
             if (!String.IsNullOrEmpty(_undefineProperties))
             {
-                Log.LogMessageFromResources(MessageImportance.Low, "General.UndefineProperties");
+                Log.LogMessageFromResources(MessageImportance.Low, "General.UndefineProperties", new object[0]);
                 undefinePropertiesArray = _undefineProperties.Split(new char[] { ';' });
                 foreach (string property in undefinePropertiesArray)
                 {
@@ -415,7 +415,7 @@ namespace Microsoft.Build.Tasks
             if (!isRunningMultipleNodes && _stopOnFirstFailure && _buildInParallel)
             {
                 _buildInParallel = false;
-                Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.NotBuildingInParallel");
+                Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.NotBuildingInParallel", new object[0]);
             }
 
             // When the condition below is met, provide an information message indicating stopOnFirstFailure
@@ -425,7 +425,7 @@ namespace Microsoft.Build.Tasks
             // therefore the first failure seen will be the only failure seen.
             if (isRunningMultipleNodes && _buildInParallel && _stopOnFirstFailure && !_runEachTargetSeparately)
             {
-                Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.NoStopOnFirstFailure");
+                Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.NoStopOnFirstFailure", new object[0]);
             }
 
             // This is a list of string[].  That is, each element in the list is a string[].  Each
@@ -466,7 +466,7 @@ namespace Microsoft.Build.Tasks
                 if (_stopOnFirstFailure && !success)
                 {
                     // Inform the user that we skipped the remaining projects because StopOnFirstFailure=true.
-                    Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.SkippingRemainingProjects");
+                    Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.SkippingRemainingProjects", new object[0]);
 
                     // We have encountered a failure.  Caller has requested that we not 
                     // continue with remaining projects.
@@ -790,7 +790,7 @@ namespace Microsoft.Build.Tasks
                 if (stopOnFirstFailure && !success)
                 {
                     // Inform the user that we skipped the remaining targets StopOnFirstFailure=true.
-                    log.LogMessageFromResources(MessageImportance.Low, "MSBuild.SkippingRemainingTargets");
+                    log.LogMessageFromResources(MessageImportance.Low, "MSBuild.SkippingRemainingTargets", new object[0]);
 
                     // We have encountered a failure.  Caller has requested that we not 
                     // continue with remaining targets.

--- a/src/XMakeTasks/ResolveKeySource.cs
+++ b/src/XMakeTasks/ResolveKeySource.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
 #else
-                        Log.LogError("PFX signing not supported on .NET Core");
+                        Log.LogError("PFX signing not supported on .NET Core", new object[0]);
                         pfxSuccess = false;
 #endif
                     }
@@ -262,7 +262,7 @@ namespace Microsoft.Build.Tasks
                 }
                 if (!certSuccess)
                 {
-                    Log.LogWarningWithCodeFromResources("ResolveKeySource.ResolvedThumbprintEmpty");
+                    Log.LogWarningWithCodeFromResources("ResolveKeySource.ResolvedThumbprintEmpty", new object[0]);
                 }
             }
 
@@ -272,7 +272,7 @@ namespace Microsoft.Build.Tasks
                 // if the cert isn't on disk, we can't import it
                 if (!File.Exists(CertificateFile))
                 {
-                    Log.LogErrorWithCodeFromResources("ResolveKeySource.CertificateNotInStore");
+                    Log.LogErrorWithCodeFromResources("ResolveKeySource.CertificateNotInStore", new object[0]);
                 }
                 else
                 {
@@ -331,13 +331,13 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 #else
-                Log.LogError("Certificate signing not supported on .NET Core");
+                Log.LogError("Certificate signing not supported on .NET Core", new object[0]);
 #endif
             }
             else if (!certInStore && !string.IsNullOrEmpty(CertificateFile) && !string.IsNullOrEmpty(CertificateThumbprint))
             {
                 // no file and not in store, error out
-                Log.LogErrorWithCodeFromResources("ResolveKeySource.CertificateNotInStore");
+                Log.LogErrorWithCodeFromResources("ResolveKeySource.CertificateNotInStore", new object[0]);
                 certSuccess = false;
             }
             else

--- a/src/XMakeTasks/Warning.cs
+++ b/src/XMakeTasks/Warning.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Tasks
         {
             if (Text != null || Code != null)
             {
-                Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, (Text == null) ? String.Empty : Text);
+                Log.LogWarning(null, Code, HelpKeyword, File, 0, 0, 0, 0, (Text == null) ? String.Empty : Text, new object[0]);
             }
 
             return true;

--- a/src/XMakeTasks/WriteCodeFragment.cs
+++ b/src/XMakeTasks/WriteCodeFragment.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Tasks
 
             if (OutputFile == null && OutputDirectory == null)
             {
-                Log.LogErrorWithCodeFromResources("WriteCodeFragment.MustSpecifyLocation");
+                Log.LogErrorWithCodeFromResources("WriteCodeFragment.MustSpecifyLocation", new object[0]);
                 return false;
             }
 
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Tasks
 
             if (code.Length == 0)
             {
-                Log.LogMessageFromResources(MessageImportance.Low, "WriteCodeFragment.NoWorkToDo");
+                Log.LogMessageFromResources(MessageImportance.Low, "WriteCodeFragment.NoWorkToDo", new object[0]);
                 OutputFile = null;
                 return true;
             }
@@ -311,7 +311,7 @@ namespace Microsoft.Build.Tasks
                         string args = GetAttributeArguments(attributeItem, "=");
                         if (args == null) return null;
 
-                        code.AppendLine(string.Format($"[assembly: {attributeItem.ItemSpec}({args})];"));
+                        code.AppendLine(string.Format($"[assembly: {attributeItem.ItemSpec}({args})];", new object[0]));
                         haveGeneratedContent = true;
                     }
 
@@ -334,7 +334,7 @@ namespace Microsoft.Build.Tasks
                         string args = GetAttributeArguments(attributeItem, ":=");
                         if (args == null) return null;
 
-                        code.AppendLine(string.Format($"<Assembly: {attributeItem.ItemSpec}({args})>"));
+                        code.AppendLine(string.Format($"<Assembly: {attributeItem.ItemSpec}({args})>", new object[0]));
                         haveGeneratedContent = true;
                     }
                     break;


### PR DESCRIPTION
Specifically passing in empty arrays to methods expecting params Arrays to fix build break on corefx caused by upgrade on buildtools.

Whenever a method expects:
```cs
public void myMethod(params object[])... 
```
and nothing gets passed in, the compiler will by default add a:
```cs
Array.Empty<object>()
```
which is not supported on frameworks lower than 4.6 or Mono msbuild. Given a recent change in buildtools to consume the nuget package "Microsoft.Build.Tasks.Core" (version: 0.1.0-preview-00005), builds in Razzle (uses .Net Framework 4.5) and linux are broken when trying to consume buildtools. The ask is to submit this code to generate a new package for Microsoft.Build.Tasks.Core and then reference that back from buildtools so that the build break is fixed.