### PR TITLE
Don't use frameworkAssembly references in NuGet packages for .NET Framework

### DIFF
--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,5 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
+  <Import Project="BuildValues.props" />
 
   <ItemGroup>
     <Project Include="Framework\Microsoft.Build.Framework.csproj" />

--- a/src/nuget/Microsoft.Build.Framework.nuspec
+++ b/src/nuget/Microsoft.Build.Framework.nuspec
@@ -15,11 +15,7 @@
       This package includes APIs that support writing MSBuild tasks.
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.Build.Framework" targetFramework="net45" />
-    </frameworkAssemblies>
     <dependencies>
-      <group targetFramework="net45" />
       <group targetFramework="dotnet">
         <dependency id="System.Collections" version="4.0.11-beta-23406" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11-beta-23406" />
@@ -33,6 +29,5 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.Framework.dll" target="lib\dotnet" />
-    <file src="_._" target="lib\net45" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -15,13 +15,7 @@
       This package includes APIs that support writing MSBuild tasks.
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.Build.Tasks.Core" targetFramework="net45" />
-    </frameworkAssemblies>
     <dependencies>
-      <group targetFramework="net45">
-        <dependency id="Microsoft.Build.Framework" />
-      </group>
       <group targetFramework="dotnet">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="System.IO.FileSystem.DriveInfo" version="4.0.0-beta-23302" />
@@ -65,6 +59,5 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.Tasks.Core.dll" target="lib\dotnet" />
-    <file src="_._" target="lib\net45" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -15,13 +15,7 @@
       This package includes APIs that support writing MSBuild tasks.
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.Build.Utilities.Core" targetFramework="net45" />
-    </frameworkAssemblies>
     <dependencies>
-      <group targetFramework="net45">
-        <dependency id="Microsoft.Build.Framework" />
-      </group>
       <group targetFramework="dotnet">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.0" />
@@ -59,6 +53,5 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.Utilities.Core.dll" target="lib\dotnet" />
-    <file src="_._" target="lib\net45" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -15,13 +15,7 @@
       This package includes APIs that support writing MSBuild tasks.
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.Build" targetFramework="net45" />
-    </frameworkAssemblies>
     <dependencies>
-      <group targetFramework="net45">
-        <dependency id="Microsoft.Build.Framework" />
-      </group>
       <group targetFramework="dotnet">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="Microsoft.Tpl.Dataflow" version="4.5.24" />
@@ -73,6 +67,5 @@
   </metadata>
   <files>
     <file src="Microsoft.Build.dll" target="lib\dotnet" />
-    <file src="_._" target="lib\net45" />
   </files>
 </package>


### PR DESCRIPTION
Currently the NuGet packages have '<frameworkAssembly/>' elements in them which causes the in-box reference assembly version of the DLL to be referenced instead of the one in the NuGet package when compiling on .NET Framework.

This wasn't working when compiling with the .NET CLI, so this PR changes the NuGet packages so that the DLLs in the packages will now be used when compiling for .NET Framework.