### PR TITLE
#360 - MSBuild accidentally enumerates *.sln* when searching for solutions

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -2082,7 +2082,7 @@ namespace Microsoft.Build.CommandLine
                 {
                     foreach (string s in potentialSolutionFiles)
                     {
-                        if (s.EndsWith("~", true, CultureInfo.CurrentCulture))
+                        if (!FileUtilities.IsSolutionFilename(s))
                         {
                             extensionsToIgnore.Add(Path.GetExtension(s));
                         }


### PR DESCRIPTION
Extra check if file is really a solution file.
Because the Windows API has legacy behavior, the searchpattern *.sln will be converted to *.sln*.