### PR TITLE
Osx Build (with xplat based dependencies)

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -14,6 +14,7 @@
     <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
     <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
     <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
+    <add key="myget.org aspnet vnext" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
     <add key="nuget.org v2" value="https://nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/dir.props
+++ b/dir.props
@@ -24,8 +24,8 @@
 
    <!-- Common repo directories -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00115</BuildToolsVersion>
-    <CompilerToolsVersion>1.1.0-rc1</CompilerToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00120</BuildToolsVersion>
+    <CompilerToolsVersion>1.2.0-beta-20151112-01</CompilerToolsVersion>
     <NuSpecReferenceGeneratorVersion>1.3.1</NuSpecReferenceGeneratorVersion>
     <XunitVersion>2.1.0</XunitVersion>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
@@ -35,6 +35,8 @@
     <DnxVersion Condition="'$(OsEnvironment)'=='Windows_NT'">1.0.0-beta8</DnxVersion>
     <DnxDir Condition="'$(OsEnvironment)'=='Unix'">dnx-coreclr-linux-x64</DnxDir>
     <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta8</DnxVersion>
+    <DnxDir Condition="'$(OsEnvironment)'=='OSX'">dnx-coreclr-darwin-x64</DnxDir>
+    <DnxVersion Condition="'$(OsEnvironment)'=='OSX'">1.0.0-rc1-final</DnxVersion>
 
     <!-- Output directories -->
     <BinDir>$(RepoRoot)bin$([System.IO.Path]::DirectorySeparatorChar)</BinDir>
@@ -48,7 +50,18 @@
 
     <DnuToolDir Condition="'$(OsEnvironment)'!='Windows_NT'">$([System.IO.Path]::Combine($(PackagesDir), "$(DnxDir).$(DnxVersion)"))</DnuToolDir>
     <DnuToolPath Condition="'$(OsEnvironment)'=='Windows_NT'">$([System.IO.Path]::Combine($(DnuToolDir), "bin", "dnu.cmd"))</DnuToolPath>
-    <DnuToolPath Condition="'$(OsEnvironment)'=='Unix'">$([System.IO.Path]::Combine($(DnuToolDir), "bin", "dnu"))</DnuToolPath>
+    <DnuToolPath Condition="'$(OsEnvironment)'!='Windows_NT'">$([System.IO.Path]::Combine($(DnuToolDir), "bin", "dnu"))</DnuToolPath>
+    <!-- The DNU package from Nuget does not work on OSX. Using system installed one-->
+    <!-- dnu `dash``dash`version returns:
+          Microsoft .NET Development Utility
+            Version:      1.0.0-rc2-16128
+            Type:         Mono
+            Architecture: x64
+            OS Name:      Darwin
+            OS Version:   10.11
+            Runtime Id:   osx.10.11-x64 -->
+    <DnuToolPath Condition="'$(OsEnvironment)'=='OSX'">dnu</DnuToolPath>
+
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dir.props
+++ b/dir.props
@@ -36,7 +36,7 @@
     <DnxDir Condition="'$(OsEnvironment)'=='Unix'">dnx-coreclr-linux-x64</DnxDir>
     <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta8</DnxVersion>
     <DnxDir Condition="'$(OsEnvironment)'=='OSX'">dnx-coreclr-darwin-x64</DnxDir>
-    <DnxVersion Condition="'$(OsEnvironment)'=='OSX'">1.0.0-rc1-final</DnxVersion>
+    <DnxVersion Condition="'$(OsEnvironment)'=='OSX'">1.0.0-rc2-16177</DnxVersion>
 
     <!-- Output directories -->
     <BinDir>$(RepoRoot)bin$([System.IO.Path]::DirectorySeparatorChar)</BinDir>
@@ -51,16 +51,6 @@
     <DnuToolDir Condition="'$(OsEnvironment)'!='Windows_NT'">$([System.IO.Path]::Combine($(PackagesDir), "$(DnxDir).$(DnxVersion)"))</DnuToolDir>
     <DnuToolPath Condition="'$(OsEnvironment)'=='Windows_NT'">$([System.IO.Path]::Combine($(DnuToolDir), "bin", "dnu.cmd"))</DnuToolPath>
     <DnuToolPath Condition="'$(OsEnvironment)'!='Windows_NT'">$([System.IO.Path]::Combine($(DnuToolDir), "bin", "dnu"))</DnuToolPath>
-    <!-- The DNU package from Nuget does not work on OSX. Using system installed one-->
-    <!-- dnu `dash``dash`version returns:
-          Microsoft .NET Development Utility
-            Version:      1.0.0-rc2-16128
-            Type:         Mono
-            Architecture: x64
-            OS Name:      Darwin
-            OS Version:   10.11
-            Runtime Id:   osx.10.11-x64 -->
-    <DnuToolPath Condition="'$(OsEnvironment)'=='OSX'">dnu</DnuToolPath>
 
   </PropertyGroup>
 

--- a/override.targets
+++ b/override.targets
@@ -24,7 +24,7 @@
     <PrereleaseResolveNuGetPackageAssets Condition="'$(ProjectLockFile)' != ''"
                                AllowFallbackOnTargetSelection="false"
                                IncludeFrameworkReferences="true"
-                               ProjectLanguage="$(Language)"
+                               ProjectLanguage="C#"
                                ProjectLockFile="$(ProjectLockFile)"
                                TargetMonikers="$(NuGetTargetMoniker)"
                                OmitTransitiveCompileReferences="$(_OmitTransitiveReferences)">

--- a/src/.nuget/packageLoad.targets
+++ b/src/.nuget/packageLoad.targets
@@ -39,8 +39,9 @@
     <!-- UNDO: When fixed https://github.com/NuGet/Home/issues/1517 -->
     <NuGetPackageRestoreOptions Condition="'$(OsEnvironment)'!='Windows_NT'">$(NuGetPackageRestoreOptions) -PackagesDirectory "$(PackagesCache)"</NuGetPackageRestoreOptions>
     <NuGetRestoreCommand>$(NuGetToolPath) restore $(NuGetCommonOptions)</NuGetRestoreCommand>
+    <NuGetRestoreCommand Condition="'$(OsEnvironment)'!='Windows_NT'">MONO_THREADS_PER_CPU=2000 mono --server $(NuGetRestoreCommand)</NuGetRestoreCommand>
     <NuGetInstallCommand>$(NuGetToolPath) install $(NuGetCommonOptions)</NuGetInstallCommand>
-    <NuGetInstallCommand Condition="'$(OsEnvironment)'!='Windows_NT' and '$(MonoBuild)' == 'true'">export MONO_THREADS_PER_CPU=2000; mono $(NuGetInstallCommand)</NuGetInstallCommand>
+    <NuGetInstallCommand Condition="'$(OsEnvironment)'!='Windows_NT'">MONO_THREADS_PER_CPU=2000 mono --server $(NuGetInstallCommand)</NuGetInstallCommand>
     <SolutionSemaphore>$(NuGetDir)Solution.semaphore</SolutionSemaphore>
     <NugetDownloadURL>https://dist.nuget.org/win-x86-commandline/v3.2.1-rc/nuget.exe</NugetDownloadURL>
     <DownloadCommand Condition="'$(OsEnvironment)'=='Windows_NT'">powershell -noprofile -nologo -command "(new-object System.Net.WebClient).DownloadFile('$(NugetDownloadURL)', '$(NuGetToolPath)')"</DownloadCommand>
@@ -129,15 +130,19 @@
           Inputs="@(ProjectJsonFile)"
           Outputs="%(ProjectJsonFile.RootDir)%(ProjectJsonFile.Directory)project.lock.json"
           AfterTargets="_RestoreGlobalReferences"
-          Condition="('$(SolutionFile)'=='' or !Exists('$(SolutionFile)')) and '$(OS)'=='Unix'"  >
+          Condition="('$(SolutionFile)'=='' or !Exists('$(SolutionFile)')) and '$(OS)'!='Windows_NT'"  >
     <PropertyGroup>
       <ProjectDirectory>%(ProjectJsonFile.RootDir)%(ProjectJsonFile.Directory)</ProjectDirectory>
     </PropertyGroup>
 
     <Message Importance="High" Text="Restoring in $(ProjectDirectory)" />
 
-    <!-- Restore packages for this directory -->
-    <Exec Command="$(NugetRestoreCommand) $(NuGetPackageRestoreOptions) -PackagesDirectory &quot;$(HOME)/.nuget/packages&quot; &quot;@(ProjectJsonFile)&quot;" />
+    <!-- TODO: Restore back to Nuget once Nuget works -->
+    <!-- Restore packages for this directory using Nuget-->
+    <!-- <Exec Command="$(NugetRestoreCommand) $(NuGetPackageRestoreOptions) -PackagesDirectory &quot;$(HOME)/.nuget/packages&quot; &quot;@(ProjectJsonFile)&quot;" />  -->
+    
+    <!-- Restore packages for this directory using DNU-->
+    <Exec Condition="'$(OsEnvironment)'!='Windows_NT'" Command="$(DnuRestoreCommand) &quot;@(ProjectJsonFile)&quot;" />
   </Target>
 
   <!--

--- a/src/.nuget/packages.OSX.config
+++ b/src/.nuget/packages.OSX.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="dnx-coreclr-darwin-x64" version="1.0.0-rc1-final" />
+</packages>

--- a/src/.nuget/packages.OSX.config
+++ b/src/.nuget/packages.OSX.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dnx-coreclr-darwin-x64" version="1.0.0-rc1-final" />
+  <package id="dnx-coreclr-darwin-x64" version="1.0.0-rc2-16177" />
 </packages>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00115" />
-  <package id="Microsoft.Net.Compilers" version="1.1.0-rc1" targetFramework="net451" userInstalled="true" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00120" />
+  <package id="Microsoft.Net.Compilers" version="1.2.0-beta-20151112-01" targetFramework="net451" userInstalled="true" />
   <package id="xunit.runner.console" version="2.1.0" />
   <package id="NuSpec.ReferenceGenerator" version="1.3.1" />
 </packages>

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "dependencies": {
     "System.Reflection.Metadata": "1.0.23-beta-23406",
-    "System.Runtime.Loader": "4.0.0-beta-23428",
     "System.Threading.Tasks.Dataflow": "4.5.26-beta-23406"
   },
   "frameworks": {
@@ -21,6 +20,7 @@
         "System.Console": "4.0.0-beta-23406",
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23406",
         "System.Runtime.Extensions": "4.0.11-beta-23406",
+        "System.Runtime.Loader": "4.0.0-beta-23406",
         "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23406",
         "System.Diagnostics.Process": "4.1.0-beta-23406",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23406",

--- a/src/XMakeCommandLine/project.json
+++ b/src/XMakeCommandLine/project.json
@@ -16,6 +16,7 @@
         "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23406",
         "System.Diagnostics.Process": "4.1.0-beta-23406",
         "System.Diagnostics.TraceSource": "4.0.0-beta-23406",
+        "System.Runtime.Loader": "4.0.0-beta-23406",
         "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23413",
         "System.Threading.Thread": "4.0.0-beta-23406",
         "System.Threading.ThreadPool": "4.0.10-beta-23413",

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -39,7 +39,7 @@
     <RuntimeProjectJson>$(MSBuildThisFileDirectory)\runtime.project.json</RuntimeProjectJson>
     <RuntimeProjectLockJson>$(MSBuildThisFileDirectory)\runtime.project.lock.json</RuntimeProjectLockJson>
     <RestoreRuntimePackagesCommand>"$(NuGetToolPath)" restore $(RuntimeProjectJson) -Verbosity detailed</RestoreRuntimePackagesCommand>
-    <RestoreRuntimePackagesCommand Condition="'$(OsEnvironment)'!='Windows_NT' and '$(MonoBuild)' == 'true'">export MONO_THREADS_PER_CPU=2000; mono $(RestoreRuntimePackagesCommand)</RestoreRuntimePackagesCommand>
+    <RestoreRuntimePackagesCommand Condition="'$(OsEnvironment)'!='Windows_NT' and '$(MonoBuild)' == 'true'">MONO_THREADS_PER_CPU=2000 mono $(RestoreRuntimePackagesCommand)</RestoreRuntimePackagesCommand>
     <NuGetRuntimeIdentifier>$(RuntimeSystem)-$(RuntimeArchitecture)</NuGetRuntimeIdentifier>
   </PropertyGroup>
 
@@ -65,7 +65,7 @@
                                IncludeFrameworkReferences="false"
                                NuGetPackagesDirectory=""
                                RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
-                               ProjectLanguage=""
+                               ProjectLanguage="C#"
                                ProjectLockFile="$(RuntimeProjectLockJson)"
                                TargetMonikers="$(NuGetTargetMoniker)">
 

--- a/targets/LinuxDeployDependencies.proj
+++ b/targets/LinuxDeployDependencies.proj
@@ -5,8 +5,7 @@
   <Import Project="../override.targets" />
 
   <PropertyGroup>
-    <NuGetRuntimeIdentifier Condition="'$(NetCoreBuild)' == 'true'">ubuntu.14.04-x64</NuGetRuntimeIdentifier>
-    <NuGetRuntimeIdentifier Condition="'$(NetCoreBuild)' != 'true'">win7-x64</NuGetRuntimeIdentifier>
+    <NuGetRuntimeIdentifier>$(RuntimeSystem)-$(RuntimeArchitecture)</NuGetRuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,6 +46,7 @@
           Inputs="@(IntermediateRuntimeProjectJsonLockFile)"
           Outputs="@(RuntimeProjectJsonLockFile)"
           AfterTargets="RestoreRuntimePackagesDnu"
+          BeforeTargets="DeployRuntime"
   >
     <Copy SourceFiles="@(IntermediateRuntimeProjectJsonLockFile)"
           DestinationFiles="@(RuntimeProjectJsonLockFile)"
@@ -63,7 +63,7 @@
           Outputs="@(RuntimeProjectJsonFile->'%(Directory)%(Filename).lock.json')"
           >
 
-    <Exec Condition="'$(OsEnvironment)'!='Windows_NT'" Command="$(DnuRestoreCommand) &quot;%(IntermediateRuntimeProjectJsonFile.FullPath)&quot; --parallel " />
+    <Exec Condition="'$(OsEnvironment)'!='Windows_NT'" Command="$(DnuRestoreCommand) &quot;%(IntermediateRuntimeProjectJsonFile.FullPath)&quot;" />
     
   </Target>
 
@@ -94,11 +94,16 @@
       <_OmitTransitiveReferences Condition="'$(NetCoreBuild)'!='true'">true</_OmitTransitiveReferences>
     </PropertyGroup>
 
-    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="false"
+    <Error
+            Text="'%(RuntimeProjectJsonLockFile.FullPath)' does not exist"
+            Condition="!Exists('%(RuntimeProjectJsonLockFile.FullPath)')" />
+
+
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
                                          IncludeFrameworkReferences="false"
                                          RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
                                          NuGetPackagesDirectory="$(PackagesCache)"
-                                         ProjectLanguage="$(Language)"
+                                         ProjectLanguage="C#"
                                          ProjectLockFile="%(RuntimeProjectJsonLockFile.FullPath)"
                                          TargetMonikers="$(NuGetTargetMoniker)"
                                          OmitTransitiveCompileReferences="$(_OmitTransitiveReferences)">
@@ -106,10 +111,21 @@
 
     </PrereleaseResolveNuGetPackageAssets>
 
+    <!-- Copy the dependencies to both the deployment and the test directories -->
+
     <Copy SourceFiles="@(ResolvedRuntimeFiles)"
-          DestinationFolder="$(RuntimeDirectory)"
+          DestinationFolder="$(DeploymentDir)"
           SkipUnchangedFiles="true"
           />
+
+    <Copy SourceFiles="@(ResolvedRuntimeFiles)"
+          DestinationFolder="$(TestDeploymentDir)"
+          SkipUnchangedFiles="true"
+          />
+
+    <Exec Command="find &quot;$(DeploymentDir)&quot; -type f -a -name &quot;*&quot; -print0 | xargs -0 -I {} chmod a+xr {}" />
+
+    <Exec Command="find &quot;$(TestDeploymentDir)&quot; -type f -a -name &quot;*&quot; -print0 | xargs -0 -I {} chmod a+xr {}" />
 
   </Target>
 

--- a/targets/runtime.project.json
+++ b/targets/runtime.project.json
@@ -36,6 +36,7 @@
         "System.Reflection": "4.1.0-beta-23406",
         "System.Reflection.Metadata": "1.1.0",
         "System.Runtime.Extensions": "4.0.11-beta-23406",
+        "System.Runtime.Loader": "4.0.0-beta-23406",
         "System.Threading.Thread": "4.0.0-beta-23406",
         "System.Threading.ThreadPool": "4.0.10-beta-23413",
         "System.Xml.XmlDocument": "4.0.1-beta-23406",


### PR DESCRIPTION
Continuation of PR #369 
The previous PR included bumped up corefx dependencies which crashed windows tests. For this PR I reset all dependencies to the xplat baseline and only bumped up when necessary for osx compilation.

In addition:
- addressed comments from the previous PR.
- left the xunit VS runner untouched for now. 