### PR TITLE
Work In Progress: CI script for Linux and OSX

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@
 *.vcxproj	wintext
 *.filters	wintext
 *.cd	wintext
+cibuild.sh text eol=lf
 
 # Sources (Managed)
 *.cs	wintext

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -11,6 +11,7 @@ usage()
 downloadMSBuild(){
     if [ ! -e "$MSBUILD_EXE" ]
     then
+        mkdir -p $PACKAGES_DIR # Create packages dir if it doesn't exist.
         echo "Downloading MSBUILD from $MSBUILD_DOWNLOAD_URL"
         curl -sL "$MSBUILD_DOWNLOAD_URL" | tar xz -C "$PACKAGES_DIR"
     fi
@@ -28,8 +29,8 @@ build()
 }
 
 THIS_SCRIPT_PATH="`dirname \"$0\"`"
-PACKAGES_DIR="$THIS_SCRIPT_PATH"/"packages"
-MSBUILD_EXE="$PACKAGES_DIR"/mono-msbuild/bin/Unix/Debug-MONO/MSBuild.exe
+PACKAGES_DIR="$THIS_SCRIPT_PATH/packages"
+MSBUILD_EXE="$PACKAGES_DIR/mono-msbuild/bin/Unix/Debug-MONO/MSBuild.exe"
 MSBUILD_DOWNLOAD_URL="https://github.com/Microsoft/msbuild/releases/download/mono-hosted-msbuild-v0.1/mono-msbuild.zip"
 
 #Default build arguments

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+set -e
+
+usage()
+{
+    echo "Options"
+    echo "  --scope <scope>                Scope of the build (Compile / Test)"
+}
+
+downloadMSBuild(){
+    if [ ! -e "$MSBUILD_EXE" ]
+    then
+        echo "Downloading MSBUILD from $MSBUILD_DOWNLOAD_URL"
+        curl -sL "$MSBUILD_DOWNLOAD_URL" | tar xz -C "$PACKAGES_DIR"
+    fi
+}
+
+build()
+{
+	echo Build Command: "mono $MONO_ARGS"
+
+	mono $MONO_ARGS
+
+	echo Build completed. Exit code: $?
+	egrep "Warning\(s\)|Error\(s\)|Time Elapsed" "$LOG_PATH_ARG"
+	echo "Log: $LOG_PATH_ARG"
+}
+
+THIS_SCRIPT_PATH="`dirname \"$0\"`"
+PACKAGES_DIR="$THIS_SCRIPT_PATH"/"packages"
+MSBUILD_EXE="$PACKAGES_DIR"/mono-msbuild/bin/Unix/Debug-MONO/MSBuild.exe
+MSBUILD_DOWNLOAD_URL="https://github.com/Microsoft/msbuild/releases/download/mono-hosted-msbuild-v0.1/mono-msbuild.zip"
+
+#Default build arguments
+TARGET_ARG="Build"
+LOG_PATH_ARG="$THIS_SCRIPT_PATH"/"msbuild.log"
+PROJECT_FILE_ARG="$THIS_SCRIPT_PATH"/"build.proj"
+
+#parse command line args
+while [[ $# > 0 ]]
+do
+    opt="$1"
+    case $opt in
+        -h|--help)
+        usage
+        exit 1
+        ;;
+
+        --scope)
+        SCOPE=$2
+        shift 2
+        ;;
+
+        *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+#determine OS
+OS_NAME=$(uname -s)
+case $OS_NAME in
+    Darwin)
+        OS_ARG="OSX"
+        ;;
+
+    Linux)
+        OS_ARG="Unix"
+        ;;
+
+    *)
+        echo "Unsupported OS $OS_NAME detected, configuring as if for Linux"
+        OS_ARG="Unix"
+        ;;
+esac
+
+if [[ "$SCOPE" = "Compile" ]]; then
+	TARGET_ARG="Build"
+elif [[ "$SCOPE" = "Test" ]]; then
+	TARGET_ARG="BuildAndTest"
+fi
+
+MSBUILD_ARGS="$PROJECT_FILE_ARG /t:$TARGET_ARG /p:OS=$OS_ARG /p:Configuration=Debug-Netcore /verbosity:minimal"' "'"/fileloggerparameters:Verbosity=diag;LogFile=$LOG_PATH_ARG"'"'
+
+MONO_ARGS="$MSBUILD_EXE $MSBUILD_ARGS"
+
+downloadMSBuild
+
+build

--- a/netci.groovy
+++ b/netci.groovy
@@ -6,38 +6,60 @@ def project = GithubProject
 
 // Generate the builds for branches: xplat, master and PRs (which aren't branch specific)
 ['*/master', '*/xplat', 'pr'].each { branch ->
-    def isPR = false
-    def newJobName = ''
-    if (branch == 'pr') {
-        isPR = true
-        newJobName = Utilities.getFullJobName(project, '', isPR)
-    } else {
-        newJobName = Utilities.getFullJobName(project, "innerloop_${branch.substring(2)}", isPR)
-    }
-        
-    // Define build string.
-    def buildString = "call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" && RebuildWithLocalMSBuild.cmd"
+    ['Windows_NT', 'OSX', 'Ubuntu'].each {osName ->
+        def isPR = false
+        def newJobName = ''
 
-    // Create a new job with the specified name.  The brace opens a new closure
-    // and calls made within that closure apply to the newly created job.
-    def newJob = job(newJobName) {    
-        // This opens the set of build steps that will be run.
-        steps {
-            // Indicates that a batch script should be run with the build string (see above)
-            batchFile(buildString)
+        if (branch == 'pr') {
+            isPR = true
+            newJobName = Utilities.getFullJobName(project, "_${osName}", isPR)
+        } else {
+            newJobName = Utilities.getFullJobName(project, "innerloop_${branch.substring(2)}_${osName}", isPR)
+        }
+
+        // Create a new job with the specified name.  The brace opens a new closure
+        // and calls made within that closure apply to the newly created job.
+        def newJob = job(newJobName) {
+            description('')
+        }
+        
+        // Define job.
+        switch(osName) {
+            case 'Windows_NT':
+                newJob.with{
+                    steps{
+                        batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" && RebuildWithLocalMSBuild.cmd")
+                    }
+                }
+                break;
+            case 'OSX':
+                newJob.with{
+                    steps{
+                        shell("./cibuild.sh --scope Compile")
+                    }
+                }
+                break;
+            case 'Ubuntu':
+                newJob.with{
+                    steps{
+                        shell("./cibuild.sh --scope Compile")
+                    }
+                }
+                break;
+        }
+        
+        Utilities.setMachineAffinity(newJob, osName)
+        Utilities.standardJobSetup(newJob, project, isPR, branch)
+        // Add xunit result archiving
+        Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml')
+        // Add archiving of logs
+        Utilities.addArchival(newJob, 'msbuild.log')
+        // Add trigger
+        if (isPR) {
+            Utilities.addGithubPRTrigger(newJob, "${osName} Build")
+        } else {
+            Utilities.addGithubPushTrigger(newJob)
         }
     }
-        
-    Utilities.setMachineAffinity(newJob, 'Windows_NT')
-    Utilities.standardJobSetup(newJob, project, isPR, branch)
-    // Add xunit result archiving
-    Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml')
-    // Add archiving of logs
-    Utilities.addArchival(newJob, 'msbuild.log')
-    // Add trigger
-    if (isPR) {
-        Utilities.addGithubPRTrigger(newJob, 'Windows Build')
-    } else {
-        Utilities.addGithubPushTrigger(newJob)
-    }
+    
 }


### PR DESCRIPTION
- Added shell script for Linux and OSX. It has two scopes, compilation and testing.
- Updated netci.groovy script to account for Linux and OSX. Linux is currently switched off.

@mmitche 

Items left:
- [x] update cibuild.sh to download zip with mono build of msbuild
