### PR TITLE
Override ToString for TaskItem

### DIFF
--- a/src/Utilities/TaskItem.cs
+++ b/src/Utilities/TaskItem.cs
@@ -408,11 +408,7 @@ namespace Microsoft.Build.Utilities
         /// Gets the item-spec.
         /// </summary>
         /// <returns>The item-spec string.</returns>
-#if FEATURE_APPDOMAIN
         public override string ToString()
-#else
-        public string ToString()
-#endif
         {
             return _itemSpec;
         }


### PR DESCRIPTION
This appears to have been accidentally conditionalized away for .NET Core
builds in 70aebd1.

Fixes #378.