### PR TITLE
No universal indent size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,13 +4,16 @@ http://EditorConfig.org
 # top-most EditorConfig file
 root = true
 
-# Default settings:
-# Use 4 spaces as indentation
+# Don't use tabs for indentation.
 [*]
 indent_style = space
-indent_size = 4
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+# Code files
+[*.cs,*.csx,*.vb,*.vbx]
+indent_size = 4
 
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
@@ -18,4 +21,8 @@ indent_size = 2
 
 # Xml config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
 indent_size = 2

--- a/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.CommonTypes.xsd
@@ -2,168 +2,214 @@
 <xs:schema targetNamespace="http://schemas.microsoft.com/developer/msbuild/2003" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msb="http://schemas.microsoft.com/developer/msbuild/2003"
 elementFormDefault="qualified">
 
-    <!-- =================== INCLUDE COMMON SCHEMA =========================== -->
-    <xs:include schemaLocation="Microsoft.Build.Core.xsd"/>
-    
-    <!-- ======================== ITEMS =====================================-->
-    <!-- Possible Types include SimpleItemType (no meta-data subelements), GenericItemType (any meta-data), or something more specific.-->
-    <xs:element name="Reference" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Reference" _locComment="" -->Reference to an assembly</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="HintPath">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_HintPath" _locComment="" -->Relative or absolute path to the assembly (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Name">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_Name" _locComment="" -->Friendly display name (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="FusionName">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_FusionName" _locComment="" -->Fusion name of the assembly (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                            
-                            <xs:element name="SpecificVersion">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_SpecificVersion" _locComment="" -->Whether only the version in the fusion name should be referenced (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Aliases">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_Aliases" _locComment="" -->Aliases for the reference (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Private">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_Private" _locComment="" -->Whether the reference should be copied to the output folder (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                          <xs:element name="EmbedInteropTypes" type="msb:boolean">
-                            <xs:annotation>
-                              <xs:documentation><!-- _locID_text="Reference_EmbedInteropTypes" _locComment="" -->Whether the types in this reference need to embedded into the target assembly - interop asemblies only (optional, boolean)</xs:documentation>
-                            </xs:annotation>
-                          </xs:element>
-                          <xs:element name="RequiredTargetFramework">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_RequiredTargetFramework" _locComment="" -->The minimum required target framework version in order to use this assembly as a reference</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="Reference_Include" _locComment="" -->Assembly name or filename</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="SDKReference" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="SDKReference" _locComment="" -->Reference to an extension SDK</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Name">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_Name" _locComment="" -->Friendly display name (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="Reference_Include" _locComment="" -->Name and version moniker representing an extension SDK</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="COMReference" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="COMReference" _locComment="" -->Reference to a COM component</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Name">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_Name" _locComment="" -->Friendly display name (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Guid">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_Guid" _locComment="" -->GUID in the form {00000000-0000-0000-0000-000000000000}</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="VersionMajor">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_VersionMajor" _locComment="" -->Major part of the version number</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="VersionMinor">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_VersionMinor" _locComment="" -->Minor part of the version number</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Lcid">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_Lcid" _locComment="" -->Locale ID</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="WrapperTool">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_WrapperTool" _locComment="" -->Wrapper tool, such as tlbimp</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Isolated">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="COMReference_Isolated" _locComment="" -->Is it isolated (boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                          <xs:element name="EmbedInteropTypes" type="msb:boolean">
-                            <xs:annotation>
-                              <xs:documentation><!-- _locID_text="COMReference_EmbedInteropTypes" _locComment="" -->Whether the types in this reference need to embedded into the target assembly - interop asemblies only (optional, boolean)</xs:documentation>
-                            </xs:annotation>
-                          </xs:element>
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="COMReference_Include" _locComment="" -->COM component name</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="COMFileReference" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="WrapperTool"/>
-                        </xs:choice>
-                    </xs:sequence>
+  <!-- =================== INCLUDE COMMON SCHEMA =========================== -->
+  <xs:include schemaLocation="Microsoft.Build.Core.xsd"/>
+
+  <!-- ======================== ITEMS =====================================-->
+  <!-- Possible Types include SimpleItemType (no meta-data subelements), GenericItemType (any meta-data), or something more specific.-->
+  <xs:element name="Reference" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Reference" _locComment="" -->Reference to an assembly
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="HintPath">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_HintPath" _locComment="" -->Relative or absolute path to the assembly (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Name">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_Name" _locComment="" -->Friendly display name (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="FusionName">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_FusionName" _locComment="" -->Fusion name of the assembly (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="SpecificVersion">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_SpecificVersion" _locComment="" -->Whether only the version in the fusion name should be referenced (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Aliases">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_Aliases" _locComment="" -->Aliases for the reference (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Private">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_Private" _locComment="" -->Whether the reference should be copied to the output folder (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="EmbedInteropTypes" type="msb:boolean">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_EmbedInteropTypes" _locComment="" -->Whether the types in this reference need to embedded into the target assembly - interop asemblies only (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="RequiredTargetFramework">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_RequiredTargetFramework" _locComment="" -->The minimum required target framework version in order to use this assembly as a reference
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Reference_Include" _locComment="" -->Assembly name or filename
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SDKReference" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="SDKReference" _locComment="" -->Reference to an extension SDK
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Name">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_Name" _locComment="" -->Friendly display name (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Reference_Include" _locComment="" -->Name and version moniker representing an extension SDK
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="COMReference" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="COMReference" _locComment="" -->Reference to a COM component
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Name">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_Name" _locComment="" -->Friendly display name (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Guid">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_Guid" _locComment="" -->GUID in the form {00000000-0000-0000-0000-000000000000}
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="VersionMajor">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_VersionMajor" _locComment="" -->Major part of the version number
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="VersionMinor">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_VersionMinor" _locComment="" -->Minor part of the version number
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Lcid">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_Lcid" _locComment="" -->Locale ID
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="WrapperTool">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_WrapperTool" _locComment="" -->Wrapper tool, such as tlbimp
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Isolated">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_Isolated" _locComment="" -->Is it isolated (boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="EmbedInteropTypes" type="msb:boolean">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="COMReference_EmbedInteropTypes" _locComment="" -->Whether the types in this reference need to embedded into the target assembly - interop asemblies only (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="COMReference_Include" _locComment="" -->COM component name
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="COMFileReference" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="WrapperTool"/>
+            </xs:choice>
+          </xs:sequence>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -209,7 +255,7 @@ elementFormDefault="qualified">
                 <xs:simpleContent>
                   <xs:extension base="xs:string">
                     <xs:attribute name="Condition" use="optional"></xs:attribute>
-                </xs:extension>
+                  </xs:extension>
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
@@ -252,12 +298,12 @@ elementFormDefault="qualified">
             <xs:element name="ShowIncludes" />
             <xs:element name="UseFullPaths" />
             <xs:element name="OmitDefaultLibName" />
-           <xs:element name="TreatSpecificWarningsAsErrors" />
-         </xs:choice>
-       </xs:extension>
+            <xs:element name="TreatSpecificWarningsAsErrors" />
+          </xs:choice>
+        </xs:extension>
       </xs:complexContent>
-     </xs:complexType>
-   </xs:element>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="ClInclude" substitutionGroup="msb:Item">
     <xs:complexType>
       <xs:complexContent>
@@ -412,4621 +458,5188 @@ elementFormDefault="qualified">
     </xs:annotation>
   </xs:element>
   <xs:element name="NativeReference" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="NativeReference" _locComment="" -->Reference to a native manifest file, or to a file that contains a native manifest</xs:documentation>
-        </xs:annotation>        
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Name">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="NativeReference_Name" _locComment="" -->Base name of manifest file</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="HintPath">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="NativeReference_HintPath" _locComment="" -->Relative path to manifest file</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="NativeReference_Include" _locComment="" -->Reference full name</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>                    
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ProjectReference" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ProjectReference" _locComment="" -->Reference to another project</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Name">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ProjectReference_Name" _locComment="" -->Friendly display name (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Project">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ProjectReference_Project" _locComment="" -->Project GUID, in the form {00000000-0000-0000-0000-000000000000}</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="ReferenceOutputAssembly" type="msb:boolean">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ProjectReference_Reference" _locComment="" -->Boolean specifying whether the outputs of the project referenced should be passed to the compiler. Default is true.</xs:documentation>
-                                </xs:annotation>
-                            </xs:element> 
-                            <xs:element name="SpecificVersion">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Reference_SpecificVersion" _locComment="" -->Whether the exact version of the assembly should be used.</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                            
-                            <xs:element name="Targets">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ProjectReference_Targets" _locComment="" -->Semicolon separated list of targets in the referenced projects that should be built. Default is the value of $(ProjectReferenceBuildTargets) whose default is blank, indicating the default targets.</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="OutputItemType">
-                             <xs:annotation>
-                               <xs:documentation>
-                                 <!-- _locID_text="ProjectReference_OutputItemType" _locComment="" -->Item type to emit target outputs into. Default is blank. If the Reference metadata is set to "true" (default) then target outputs will become references for the compiler.
-                               </xs:documentation>
-                              </xs:annotation>
-                            </xs:element>
-                            <xs:element name="Package"/>
-                            <xs:element name="EmbedInteropTypes" type="msb:boolean">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ProjectReference_EmbedInteropTypes" _locComment="" -->Whether the types in this reference need to embedded into the target assembly - interop asemblies only (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="ProjectReference_Package" _locComment="" -->Path to project file</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>    
-    <xs:element name="Compile" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Compile" _locComment="" -->Source files for compiler</xs:documentation>
-        </xs:annotation>        
-        <xs:complexType>           
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">                       
-                        <xs:choice>
-                            <xs:element name="SubType"/>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="AutoGen">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Compile_AutoGen" _locComment="" -->Whether file was generated from another file (boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                 
-                            <xs:element name="DesignTime"/>
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Compile_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="DesignTimeSharedInput"/>
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Compile_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="CopyToOutputDirectory"/>
-                            <xs:element name="VBMyExtensionTemplateID"/>
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="Compile_Include" _locComment="" -->Semi-colon separated list of source files (wildcards are allowed)</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>                    
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="EmbeddedResource" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="EmbeddedResource" _locComment="" -->Resources to be embedded in the generated assembly</xs:documentation>
-        </xs:annotation>        
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="Generator">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="EmbeddedResource_Generator" _locComment="" -->Name of any file generator that is run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                               
-                            <xs:element name="LastGenOutput">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="EmbeddedResource_LastGenOutput" _locComment="" -->File that was created by any file generator that was run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                 
-                            <xs:element name="CustomToolNamespace">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="EmbeddedResource_CustomToolNamespace" _locComment="" -->Namespace into which any file generator that is run on this item should create code</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="EmbeddedResource_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="EmbeddedResource_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory"/>
-                            <xs:element name="LogicalName"/>
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="EmbeddedResource_Include" _locComment="" -->Semi-colon separated list of resource files (wildcards are allowed)</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>                    
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Content" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Content" _locComment="" -->Files that are not compiled, but may be embedded or published</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="Generator">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_Generator" _locComment="" -->Name of any file generator that is run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                  
-                            <xs:element name="LastGenOutput"/>
-                            <xs:element name="CustomToolNamespace"/>
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Group"/>
-                            <xs:element name="PublishState">
-                               <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_PublishState" _locComment="" -->Default, Included, Excluded, DataFile, or Prerequisite</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="IsAssembly"/>
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Content_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                    
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="Content_Include" _locComment="" -->Semi-colon separated list of content files (wildcards are allowed)</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>    
-    <xs:element name="Page" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Page" _locComment="" -->XAML files that are converted to binary and compiled into the assembly</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="Generator">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Page_Generator" _locComment="" -->Name of any file generator that is run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                  
-                            <xs:element name="LastGenOutput"/>
-                            <xs:element name="CustomToolNamespace"/>
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Page_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Group"/>
-                            <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Page_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                    
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="Page_Include" _locComment="" -->Semi-colon separated list of XAML files (wildcards are allowed)</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>    
-    <xs:element name="Resource" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Resource" _locComment="" -->File that is compiled into the assembly</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="Generator">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Resource_Generator" _locComment="" -->Name of any file generator that is run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                  
-                            <xs:element name="LastGenOutput"/>
-                            <xs:element name="CustomToolNamespace"/>
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Resource_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Group"/>
-                            <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="Resource_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                    
-                        </xs:choice>
-                    </xs:sequence>
-                    <!-- redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="Resource_Include" _locComment="" -->Semi-colon separated list of files (wildcards are allowed)</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>    
-    <xs:element name="ApplicationDefinition" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ApplicationDefinition" _locComment="" -->XAML file that contains the application definition, only one can be defined</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="Generator">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ApplicationDefinition_Generator" _locComment="" -->Name of any file generator that is run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                  
-                            <xs:element name="LastGenOutput"/>
-                            <xs:element name="CustomToolNamespace"/>
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ApplicationDefinition_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Group"/>
-                            <xs:element name="SubType"/>
-                            <xs:element name="CopyToOutputDirectory">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="ApplicationDefinition_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                    
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>   
-    <xs:element name="None" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="None" _locComment="" -->Files that should have no role in the build process</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="DependentUpon"/>
-                            <xs:element name="Generator">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="None_Generator" _locComment="" -->Name of any file generator that is run on this item</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                  
-                            <xs:element name="LastGenOutput"/>
-                            <xs:element name="CustomToolNamespace"/>
-                            <xs:element name="Link">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="None_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="None_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="CopyToOutputDirectory"/>                            
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="BaseApplicationManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="BaseApplicationManifest" _locComment="" -->The base application manifest for the build. Contains ClickOnce security information.</xs:documentation>
-        </xs:annotation>
-    </xs:element>  
-    <xs:element name="Folder" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Folder" _locComment="" -->Folder on disk</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="Import" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Import" _locComment="" -->Assemblies whose namespaces should be imported by the Visual Basic compiler</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="Service" type="msb:SimpleItemType" substitutionGroup="msb:Item"/>
-    <xs:element name="WebReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="WebReferences" _locComment="" -->Name of Web References folder to display in user interface</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="WebReferenceUrl" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="WebReferenceUrl" _locComment="" -->Represents a reference to a web service</xs:documentation>
-        </xs:annotation>        
-            <xs:complexType>
-                <xs:complexContent>
-                    <xs:extension base="msb:SimpleItemType">
-                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                            <xs:choice>
-                                <xs:element name="UrlBehavior"/>
-                                <xs:element name="RelPath"/>
-                                <xs:element name="UpdateFromURL"/>
-                                <xs:element name="ServiceLocationURL"/>
-                                <xs:element name="CachedDynamicPropName"/>
-                                <xs:element name="CachedAppSettingsObjectName"/>
-                                <xs:element name="CachedSettingsPropName"/>
-                            </xs:choice>
-                        </xs:sequence>
-                        <!-- redefine Include just to give a specific description -->
-                        <xs:attribute name="Include" type="xs:string" use="optional">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="WebReferenceUrl_Include" _locComment="" -->URL to web service</xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>                        
-                    </xs:extension>
-                </xs:complexContent>
-            </xs:complexType>
-    </xs:element>
-    <xs:element name="FileAssociation" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="FileAssociation_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="DefaultIcon"/>
-                            <xs:element name="Description"/>
-                            <xs:element name="Progid"/>
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="BootstrapperFile" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="BootstrapperFile_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="ProductName"/>
-                            <xs:element name="Install"/>
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="PublishFile" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:choice>
-                            <xs:element name="Visible">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="PublishFile_InProject" _locComment="" -->Display in user interface (optional, boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                                
-                            <xs:element name="Group"/>
-                            <xs:element name="IncludeHash">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="PublishFile_IncludeHash" _locComment="" -->(boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="IsAssembly">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="PublishFile_IsAssembly" _locComment="" -->(boolean)</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>
-                            <xs:element name="PublishState">
-                                <xs:annotation>
-                                    <xs:documentation><!-- _locID_text="PublishFile_PublishState" _locComment="" -->Default, Included, Excluded, DataFile, ManifestEntryPoint, or Prerequisite</xs:documentation>
-                                </xs:annotation>
-                            </xs:element>                            
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="TargetPlatform" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation>
-                <!-- _locID_text="TargetPlatform" _locComment="" -->Target platform in the form of "[Identifier], Version=[Version]", for example, "Windows, Version=8.0"
-            </xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="Analyzer" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation>
-                <!-- _locID_text="Analyzer" _locComment="" -->An assembly containing diagnostic analyzers
-            </xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <!-- redefine Include to make it required, and to give a specific description. -->
-                    <xs:attribute name="Include" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation>
-                                <!-- _locID_text="Analyzer_Include" _locComment="" -->Relative or absolute path to the assembly (required)
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <!-- ======================== PROPERTIES =====================================-->
-    <!-- Possible Types include StringPropertyType (text with no subelements), GenericPropertyType (any content), or something more specific.-->
-    
-    <xs:element name="VisualStudioVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="MinimumVisualStudioVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AdditionalFileItemNames" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AllowUnsafeBlocks" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AppConfigForCompiler" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ApplicationIcon" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ApplicationRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ApplicationRevision" _locComment="" -->integer</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="ApplicationVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ApplicationVersion" _locComment="" -->Matches the expression "\d\.\d\.\d\.(\d|\*)"</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="AppDesignerFolder" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppDesignerFolder" _locComment="" -->Name of folder for Application Designer</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="AspNetConfiguration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AssemblyKeyContainerName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AssemblyKeyProviderName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AssemblyName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AssemblyName" _locComment="" -->Name of output assembly</xs:documentation>
-        </xs:annotation>
-    </xs:element>           
-    <xs:element name="AssemblyOriginatorKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AssemblyOriginatorKeyFileType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AssemblyOriginatorKeyMode" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AssemblyType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="AutoGenerateBindingRedirects" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AutorunEnabled" _locComment="" -->Indicates whether BindingRedirect elements should be automatically generated for referenced assemblies.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="AutorunEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AutorunEnabled" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>         
-    <xs:element name="BaseAddress" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="BootstrapperComponentsLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="BootstrapperComponentsLocation" _locComment="" -->HomeSite, Relative, or Absolute</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="BootstrapperComponentsUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="BootstrapperEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="BootstrapperEnabled" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CharacterSet" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="CheckForOverflowUnderflow" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="CLRSupport" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UseDebugLibraries" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="CodePage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="Configuration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ConfigurationName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ConfigurationOverrideFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="CreateDesktopShortcut" type="msb:boolean" substitutionGroup="msb:Property" />
-    <xs:element name="CreateWebPageOnPublish" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CreateWebPageOnPublish" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CurrentSolutionConfigurationContents" type="msb:GenericPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DebugSecurityZoneURL" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DebugSymbols" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DebugSymbols" _locComment="" -->Whether to emit symbols (boolean)</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="DebugType" type="msb:StringPropertyType" substitutionGroup="msb:Property">   
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, or full</xs:documentation>
-        </xs:annotation>
-    </xs:element>         
-    <xs:element name="DefaultClientScript" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DefaultHTMLPageLayout" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DefaultTargetSchema" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DefineConstants" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DefineDebug" type="msb:StringPropertyType" substitutionGroup="msb:Property">   
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DefineDebug" _locComment="" -->Whether DEBUG is defined (boolean)</xs:documentation>
-        </xs:annotation>
-    </xs:element>          
-    <xs:element name="DefineTrace" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DefineTrace" _locComment="" -->Whether TRACE is defined (boolean)</xs:documentation>
-        </xs:annotation>
-    </xs:element>          
-    <xs:element name="DelaySign" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DisableLangXtns" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DisallowUrlActivation" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DisallowUrlActivation" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisAdditionalOptions" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisAdditionalOptions" _locComment="" -->Additional options to pass to the Code Analysis command line tool.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisApplyLogFileXsl" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisApplyLogFileXsl" _locComment="" -->Indicates whether to apply the XSL style sheet specified in $(CodeAnalysisLogFileXsl) to the Code Analysis report. This report is specified in $(CodeAnalysisLogFile). The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>    
-    <xs:element name="CodeAnalysisConsoleXsl" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisConsoleXsl" _locComment="" -->Path to the XSL style sheet that will be applied to the Code Analysis console output. The default is an empty string (''), which causes Code Analysis to use its default console output.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisCulture" _locComment="" -->Culture to use for Code Analysis spelling rules, for example, 'en-US' or 'en-AU'. The default is the current user interface language for Windows.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisDependentAssemblyPaths" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisDependentAssemblyPaths" _locComment="" -->Additional reference assembly paths to pass to the Code Analysis command line tool.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <!-- Redefine Include to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="CodeAnalysisDependentAssemblyPaths_Include" _locComment="" -->A fully qualified path to a directory containing reference assemblies to be used by Code Analysis.</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CodeAnalysisDictionary" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisDictionary" _locComment="" -->Code Analysis custom dictionaries.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <!-- Redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="CodeAnalysisDictionary_Include" _locComment="" -->Semicolon-separated list of Code Analysis custom dictionaries. Wildcards are allowed.</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CodeAnalysisFailOnMissingRules" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisFailOnMissingRules" _locComment="" -->Indicates whether Code Analysis should fail if a rule or rule set is missing. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisForceOutput" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisForceOutput" _locComment="" -->Indicates whether Code Analysis generates a report file, even when there are no active warnings or errors. The default is true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisGenerateSuccessFile" type="msb:boolean" substitutionGroup="msb:Property">
-          <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisGenerateSuccessFile" _locComment="" -->Indicates whether Code Analysis generates a '$(CodeAnalysisInputAssembly).lastcodeanalysissucceeded' file in the output folder when no build-breaking errors occur. The default is true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisIgnoreBuiltInRules" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisIgnoreBuiltInRules" _locComment="" -->Indicates whether Code Analysis will ignore the default rule directories when searching for rules. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisIgnoreBuiltInRuleSets" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisIgnoreBuiltInRuleSets" _locComment="" -->Indicates whether Code Analysis will ignore the default rule set directories when searching for rule sets. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisIgnoreInvalidTargets" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisIgnoreInvalidTargets" _locComment="" -->Indicates whether Code Analysis should silently fail when analyzing invalid assemblies, such as those without managed code. The default is true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisIgnoreGeneratedCode" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisIgnoreGeneratedCode" _locComment="" -->Indicates whether Code Analysis should fail silently when it analyzes invalid assemblies, such as those without managed code. The default is true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisImport" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisImport" _locComment="" -->Code Analysis projects (*.fxcop) or reports to import.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <!-- Redefine Include just to give a specific description -->
-                    <xs:attribute name="Include" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation>
-                                <!-- _locID_text="CodeAnalysisImport_Include" _locComment="" -->Semicolon-separated list of Code Analysis projects (*.fxcop) or reports to import. Wildcards are allowed.</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CodeAnalysisInputAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisInputAssembly" _locComment="" -->Path to the assembly to be analyzed by Code Analysis. The default is '$(OutDir)$(TargetName)$(TargetExt)'.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisLogFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisLogFile" _locComment="" -->Path to the output file for the Code Analysis report. The default is '$(CodeAnalysisInputAssembly).CodeAnalysisLog.xml'.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisLogFileXsl" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisLogFileXsl" _locComment="" -->Path to the XSL style sheet to reference in the Code Analysis output report. This report is specified in $(CodeAnalysisLogFile). The default is an empty string ('').</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisModuleSuppressionsFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisModuleSuppressionsFile" _locComment="" -->Name of the file, without the path, where Code Analysis project-level suppressions are stored. The default is 'GlobalSuppressions$(DefaultLanguageSourceExtension)'.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisOverrideRuleVisibilities" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisOverrideRuleVisibilities" _locComment="" -->Indicates whether to run all overridable Code Analysis rules against all targets. This will cause specific rules, such as those within the Design and Naming categories, to run against both public and internal APIs, instead of only public APIs. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisOutputToConsole" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisOutputToConsole" _locComment="" -->Indicates whether to output Code Analysis warnings and errors to the console. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisVerbose" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisVerbose" _locComment="" -->Indicates whether to output verbose Code Analysis diagnostic info to the console. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisPath" _locComment="" -->Path to the Code Analysis installation folder. The default is '$(VSINSTALLDIR)\Team Tools\Static Analysis Tools\FxCop'.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisPlatformPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisPlatformPath" _locComment="" -->Path to the .NET Framework folder that contains platform assemblies, such as mscorlib.dll and System.dll. The default is an empty string ('').</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisProject" type="msb:StringPropertyType"  substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisProject" _locComment="" -->Path to the Code Analysis project (*.fxcop) to load. The default is an empty string ('').</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisQuiet" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisQuiet" _locComment="" -->Indicates whether to suppress all Code Analysis console output other than errors and warnings. This applies when $(CodeAnalysisOutputToConsole) is true. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisRuleAssemblies" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisRuleAssemblies" _locComment="" -->Semicolon-separated list of paths either to Code Analysis rule assemblies or to folders that contain Code Analysis rule assemblies. The paths are in the form '[+|-][!][file|folder]', where '+' enables all rules in rule assembly, '-' disables all rules in rule assembly, and '!' causes all rules in rule assembly to be treated as errors. For example '+D:\Projects\Rules\NamingRules.dll;+!D:\Projects\Rules\SecurityRules.dll'. The default is '$(CodeAnalysisPath)\Rules'.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisRuleDirectories" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-         <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisRuleDirectories" _locComment="" -->Semicolon-separated list of directories in which to search for rules when resolving a rule set. The default is '$(CodeAnalysisPath)\Rules' unless the CodeAnalysisIgnoreBuiltInRules property is set to true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisRules" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-         <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisRules" _locComment="" -->Semicolon-separated list of Code Analysis rules. The rules are in the form '[+|-][!]Category#CheckId', where '+' enables the rule, '-' disables the rule, and '!' causes the rule to be treated as an error. For example, '-Microsoft.Naming#CA1700;+!Microsoft.Naming#CA1701'. The default is an empty string ('') which enables all rules.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisRuleSet" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-         <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisRuleSet" _locComment="" -->A .ruleset file which contains a list of rules to run during analysis. The string can be a full path, a path relative to the project file, or a file name. If a file name is specified, the CodeAnalysisRuleSetDirectories property will be searched to find the file. The default is an empty string ('').</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisRuleSetDirectories" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-         <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisRuleSetDirectories" _locComment="" -->Semicolon-separated list of directories in which to search for rule sets. The default is '$(VSINSTALLDIR)\Team Tools\Static Analysis Tools\Rule Sets' unless the CodeAnalysisIgnoreBuiltInRuleSets property is set to true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisSaveMessagesToReport" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisSaveMessagesToReport" _locComment="" -->Comma-separated list of the type ('Active', 'Excluded', or 'Absent') of warnings and errors to save to the output report file. The default is 'Active'.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisSearchGlobalAssemblyCache" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisSearchGlobalAssemblyCache" _locComment="" -->Indicates whether Code Analysis should search the Global Assembly Cache (GAC) for missing references that are encountered during analysis. The default is true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisSummary" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisSummary" _locComment="" -->Indicates whether to output a Code Analysis summary to the console after analysis. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisTimeout" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisTimeout" _locComment="" -->The time, in seconds, that Code Analysis should wait for analysis of a single item to complete before it aborts analysis. Specify 0 to cause Code Analysis to wait indefinitely. The default is 120.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisTreatWarningsAsErrors" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisTreatWarningsAsErrors" _locComment="" -->Indicates whether to treat all Code Analysis warnings as errors. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisUpdateProject" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisUpdateProject" _locComment="" -->Indicates whether to update the Code Analysis project (*.fxcop) specified in $(CodeAnalysisProject). This applies when there are changes during analysis. The default is false.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="CodeAnalysisUseTypeNameInSuppression" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="CodeAnalysisUseTypeNameInSuppression" _locComment="" -->Indicates whether to include the name of the rule when Code Analysis emits a suppression. The default is true.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="ConfigurationType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DeployDirSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="DisableFastUpToDateCheck" type="msb:boolean" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DisableFastUpToDateCheck" _locComment="" -->Whether Visual Studio should do its own faster up-to-date check before Building, rather than invoke MSBuild to do a possibly more accurate one. You would set this to false if you have a heavily customized build process and builds in Visual Studio are not occurring when they should.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="DocumentationFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EnableASPDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EnableASPXDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EnableSQLServerDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EnableSecurityDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EnableUnmanagedDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ErrorLog" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ErrorReport" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="EmbedManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ErrorReportUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ExcludeDeploymentUrl" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="ExcludedPermissions" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="FallbackCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="FileAlignment" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="FileUpgradeFlags" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="FormFactorID" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="FrameworkPathOverride" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="FrameworkPathOverride" _locComment="" -->Sets the /sdkpath switch for a VB project to the specified value</xs:documentation>
-        </xs:annotation>
-    </xs:element>     
-    <xs:element name="GenerateManifests" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="GenerateLibraryLayout" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="DisableXbfGeneration" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="SuppressXamlWarnings" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="XamlRootsLog" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="XamlSavedStateFilePath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="GenerateSerializationAssemblies" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="HostInBrowser" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="IgnoreImportLibrary" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="Install" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="InstallFrom" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="InstallFrom" _locComment="" -->Web, Unc, or Disk</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="InstallUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="IsCodeSharingProject" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="IsWebBootstrapper" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="JCPA" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="Keyword" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="LangVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="VBRuntime" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="Prefer32Bit" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="HighEntropyVA" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="LinkIncremental" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ManifestCertificateThumbprint" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ManifestKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="MapFileExtensions" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="MapFileExtensions" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>                
-    <xs:element name="MinimumRequiredVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="MinimumRequiredVersion" _locComment="" -->Matches the expression "\d\.\d\.\d\.\d"</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="MyType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="MSBuildAllProjects" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="NoConfig" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
-    <xs:element name="NoStandardLibraries" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="NoStdLib" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="NoStdLib" _locComment="" -->Whether standard libraries (such as mscorlib) should be referenced automatically (boolean)</xs:documentation>
-        </xs:annotation>
-    </xs:element>          
-    <xs:element name="NoWarn" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="NoWarn" _locComment="" -->Comma separated list of disabled warnings</xs:documentation>
-        </xs:annotation>
-    </xs:element>   
-    <xs:element name="OldToolsVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>     
-    <xs:element name="OutDir" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TargetExt" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TargetName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="OpenBrowserOnPublish" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OpenBrowserOnPublish" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>                
-    <xs:element name="Optimize" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="Optimize" _locComment="" -->Should compiler optimize output (boolean)</xs:documentation>
-        </xs:annotation>
-    </xs:element>     
-    <xs:element name="OptionCompare" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OptionCompare" _locComment="" -->Option Compare setting (Text or Binary)</xs:documentation>
-        </xs:annotation>
-    </xs:element>         
-    <xs:element name="OptionExplicit" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OptionExplicit" _locComment="" -->Should Option Explicit be set (On or Off)</xs:documentation>
-        </xs:annotation>
-    </xs:element>         
-    <xs:element name="OptionStrict" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OptionStrict" _locComment="" -->Should Option Strict be set (On or Off)</xs:documentation>
-        </xs:annotation>
-    </xs:element>       
-    <xs:element name="OptionInfer" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OptionInfer" _locComment="" -->Should Option Infer be set (On or Off)</xs:documentation>
-        </xs:annotation>
-    </xs:element>            
-    <xs:element name="OSVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="OutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OutputPath" _locComment="" -->Path to output folder, with trailing slash</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="OutputType" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OutputType" _locComment="" -->Type of output to generate (WinExe, Exe, or Library)</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="Platform" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="PlatformName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="PlatformFamilyName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
-    <xs:element name="PlatformID" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
-    <xs:element name="PlatformTarget" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="PlatformToolset" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="PostBuildEvent" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PostBuildEvent" _locComment="" -->Command line to be run at the end of build</xs:documentation>
-        </xs:annotation>
-    </xs:element>          
-    <xs:element name="PreBuildEvent" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PreBuildEvent" _locComment="" -->Command line to be run at the start of build</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="ProductName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ProductVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ProjectGuid" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ProjectType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ProjectTypeGuids" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="PublisherName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="PublishUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="RecursePath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ReferencePath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ReferencePath" _locComment="" -->Semi-colon separated list of folders to search during reference resolution</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="RegisterForComInterop" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="RemoteDebugEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="RemoteDebugMachine" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="RemoveIntegerChecks" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ReportAnalyzer" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="ResponseFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="RootNamespace" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SccProjectName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SccLocalPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SccProvider" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="RunCodeAnalysis" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="RunCodeAnalysis" _locComment="" -->Indicates whether to run Code Analysis during the build.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="RunPostBuildEvent" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SchemaVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SecureScoping" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SignAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SignManifests" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SolutionDir" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SolutionExt" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SolutionFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SolutionName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SolutionPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartAction" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartArguments" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartPage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartProgram" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartURL" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartWithIE" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartWorkingDirectory" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="StartupObject" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="StartupObject" _locComment="" -->Type that contains the main entry point</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="SuiteName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="SupportUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TargetFrameworkProfile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TargetCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TargetFrameworkVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
-    <xs:element name="TargetPlatformIdentifier" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>  
-    <xs:element name="TargetPlatformVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>   
-    <xs:element name="TargetZone" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TreatWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="TrustUrlParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="TrustUrlParameters" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>                
-    <xs:element name="TypeComplianceDiagnostics" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UICulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UpgradeBackupLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>     
-    <xs:element name="UpdateEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UpdateEnabled" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>                
-    <xs:element name="UpdateInterval" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UpdateIntervalUnits" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UpdateIntervalUnits" _locComment="" -->Hours, Days, or Weeks</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="UpdateMode" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UpdateMode" _locComment="" -->Foreground or Background</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="UpdatePeriodically" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UpdatePeriodically" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="UpdateRequired" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UpdateRequired" _locComment="" -->boolean</xs:documentation>
-        </xs:annotation>
-    </xs:element>                
-    <xs:element name="UpdateUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>    
-    <xs:element name="UseAppConfigForCompiler" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="UseApplicationTrust" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UseOfMfc" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UseOfAtl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UseVSHostingProcess" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="UTF8OutPut" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="VCTargetsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="VSTO_TrustAssembliesLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="WarningLevel" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="WarningLevel" _locComment="" -->integer between 0 and 4 inclusive</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-    <xs:element name="WarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="WarningsAsErrors" _locComment="" -->Comma separated list of warning numbers to treat as errors</xs:documentation>
-        </xs:annotation>
-    </xs:element>          
-    <xs:element name="WebPage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="Win32ResourceFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="WholeProgramOptimization" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-
-    <!-- ======================== TASKS =====================================-->
-    <xs:element name="AL" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AlgorithmId" />
-                    <xs:attribute name="BaseAddress" />
-                    <xs:attribute name="CompanyName" />
-                    <xs:attribute name="Configuration" />
-                    <xs:attribute name="Copyright" />
-                    <xs:attribute name="Culture" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="Description" />
-                    <xs:attribute name="EmbedResources" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="EvidenceFile" />
-                    <xs:attribute name="FileVersion" />
-                    <xs:attribute name="Flags" />
-                    <xs:attribute name="GenerateFullPaths" type="msb:boolean" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LinkResources" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MainEntryPoint" />
-                    <xs:attribute name="OutputAssembly" use="required" />
-                    <xs:attribute name="Platform" />
-                    <xs:attribute name="ProductName" />
-                    <xs:attribute name="ProductVersion" />
-                    <xs:attribute name="ResponseFiles" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="SourceModules" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="TargetType" />
-                    <xs:attribute name="TemplateFile" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="Title" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="Trademark" />
-                    <xs:attribute name="Version" />
-                    <xs:attribute name="Win32Icon" />
-                    <xs:attribute name="Win32Resource" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="AspNetCompiler" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AllowPartiallyTrustedCallers" type="msb:boolean" />
-                    <xs:attribute name="Clean" type="msb:boolean" />
-                    <xs:attribute name="Debug" type="msb:boolean" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="FixedNames" type="msb:boolean" />
-                    <xs:attribute name="Force" type="msb:boolean" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MetabasePath" />
-                    <xs:attribute name="PhysicalPath" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="TargetFrameworkMoniker" />
-                    <xs:attribute name="TargetPath" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="Updateable" type="msb:boolean" />
-                    <xs:attribute name="VirtualPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="AssignCulture" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Files" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="AssignProjectConfiguration" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AssignedProjects" />
-                    <xs:attribute name="CurrentProjectConfiguration" />
-                    <xs:attribute name="CurrentProjectPlatform" />
-                    <xs:attribute name="DefaultToVcxPlatformMapping" />
-                    <xs:attribute name="ProjectReferences" use="required" />
-                    <xs:attribute name="ResolveConfigurationPlatformUsingMappings" type="msb:boolean" />
-                    <xs:attribute name="SolutionConfigurationContents" />
-                    <xs:attribute name="UnassignedProjects" />
-                    <xs:attribute name="VcxToDefaultPlatformMapping" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="AssignTargetPath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Files" />
-                    <xs:attribute name="RootFolder" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="AxImp" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ActiveXControlName" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="GenerateSource" type="msb:boolean" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="NoLogo" type="msb:boolean" />
-                    <xs:attribute name="OutputAssembly" />
-                    <xs:attribute name="RuntimeCallableWrapperAssembly" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="Silent" type="msb:boolean" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="Verbose" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CallTarget" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="RunEachTargetSeparately" type="msb:boolean" />
-                    <xs:attribute name="Targets" />
-                    <xs:attribute name="UseResultsCache" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CombinePath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="BasePath" />
-                    <xs:attribute name="CombinedPaths" />
-                    <xs:attribute name="Paths" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ConvertToAbsolutePath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AbsolutePaths" />
-                    <xs:attribute name="Paths" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Copy" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DestinationFiles" />
-                    <xs:attribute name="DestinationFolder" />
-                    <xs:attribute name="OverwriteReadOnlyFiles" type="msb:boolean" />
-                    <xs:attribute name="Retries" />
-                    <xs:attribute name="RetryDelayMilliseconds" />
-                    <xs:attribute name="SkipUnchangedFiles" type="msb:boolean" />
-                    <xs:attribute name="UseHardlinksIfPossible" type="msb:boolean" />
-                    <xs:attribute name="SourceFiles" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CreateCSharpManifestResourceName" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="PrependCultureAsDirectory" type="msb:boolean" />
-                    <xs:attribute name="ResourceFiles" use="required" />
-                    <xs:attribute name="ResourceFilesWithManifestResourceNames" />
-                    <xs:attribute name="RootNamespace" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CreateItem" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AdditionalMetadata" />
-                    <xs:attribute name="Exclude" />
-                    <xs:attribute name="Include" />
-                    <xs:attribute name="PreserveExistingMetadata" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CreateProperty" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Value" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CreateVisualBasicManifestResourceName" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="PrependCultureAsDirectory" type="msb:boolean" />
-                    <xs:attribute name="ResourceFiles" use="required" />
-                    <xs:attribute name="ResourceFilesWithManifestResourceNames" />
-                    <xs:attribute name="RootNamespace" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Csc" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AdditionalLibPaths" />
-                    <xs:attribute name="AddModules" />
-                    <xs:attribute name="AllowUnsafeBlocks" type="msb:boolean" />
-                    <xs:attribute name="BaseAddress" />
-                    <xs:attribute name="CheckForOverflowUnderflow" type="msb:boolean" />
-                    <xs:attribute name="CodePage" />
-                    <xs:attribute name="DebugType" />
-                    <xs:attribute name="DefineConstants" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="DisabledWarnings" />
-                    <xs:attribute name="DocumentationFile" />
-                    <xs:attribute name="EmitDebugInformation" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ErrorReport" />
-                    <xs:attribute name="FileAlignment" />
-                    <xs:attribute name="GenerateFullPaths" type="msb:boolean" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LangVersion" />
-                    <xs:attribute name="LinkResources" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MainEntryPoint" />
-                    <xs:attribute name="ModuleAssemblyName" />
-                    <xs:attribute name="NoConfig" type="msb:boolean" />
-                    <xs:attribute name="NoLogo" type="msb:boolean" />
-                    <xs:attribute name="NoStandardLib" type="msb:boolean" />
-                    <xs:attribute name="NoWin32Manifest" type="msb:boolean" />
-                    <xs:attribute name="Optimize" type="msb:boolean" />
-                    <xs:attribute name="OutputAssembly" />
-                    <xs:attribute name="PdbFile" />
-                    <xs:attribute name="Platform" />
-                    <xs:attribute name="References" />
-                    <xs:attribute name="Resources" />
-                    <xs:attribute name="ResponseFiles" />
-                    <xs:attribute name="Sources" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="TargetType" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TreatWarningsAsErrors" type="msb:boolean" />
-                    <xs:attribute name="UseHostCompilerIfAvailable" type="msb:boolean" />
-                    <xs:attribute name="Utf8Output" type="msb:boolean" />
-                    <xs:attribute name="WarningLevel" />
-                    <xs:attribute name="WarningsAsErrors" />
-                    <xs:attribute name="WarningsNotAsErrors" />
-                    <xs:attribute name="Win32Icon" />
-                    <xs:attribute name="Win32Manifest" />
-                    <xs:attribute name="Win32Resource" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Delete" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DeletedFiles" />
-                    <xs:attribute name="Files" use="required" />
-                    <xs:attribute name="TreatErrorsAsWarnings" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Error" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Code" />
-                    <xs:attribute name="File" />
-                    <xs:attribute name="HelpKeyword" />
-                    <xs:attribute name="Text" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Exec" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Command" use="required" />
-                    <xs:attribute name="CustomErrorRegularExpression" />
-                    <xs:attribute name="CustomWarningRegularExpression" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="IgnoreExitCode" type="msb:boolean" />
-                    <xs:attribute name="IgnoreStandardErrorWarningFormat" type="msb:boolean" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="Outputs" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="StdErrEncoding" />
-                    <xs:attribute name="StdOutEncoding" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="WorkingDirectory" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="FindAppConfigFile" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AppConfigFile" />
-                    <xs:attribute name="PrimaryList" use="required" />
-                    <xs:attribute name="SecondaryList" use="required" />
-                    <xs:attribute name="TargetPath" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="FindInList" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="CaseSensitive" type="msb:boolean" />
-                    <xs:attribute name="FindLastMatch" type="msb:boolean" />
-                    <xs:attribute name="ItemFound" />
-                    <xs:attribute name="ItemSpecToFind" use="required" />
-                    <xs:attribute name="List" use="required" />
-                    <xs:attribute name="MatchFileNameOnly" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="FindUnderPath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Files" />
-                    <xs:attribute name="InPath" />
-                    <xs:attribute name="OutOfPath" />
-                    <xs:attribute name="Path" use="required" />
-                    <xs:attribute name="UpdateToAbsolutePaths" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="FormatUrl" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="InputUrl" />
-                    <xs:attribute name="OutputUrl" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="FormatVersion" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="FormatType" />
-                    <xs:attribute name="OutputVersion" />
-                    <xs:attribute name="Revision" />
-                    <xs:attribute name="Version" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GenerateApplicationManifest" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AssemblyName" />
-                    <xs:attribute name="AssemblyVersion" />
-                    <xs:attribute name="ClrVersion" />
-                    <xs:attribute name="ConfigFile" />
-                    <xs:attribute name="Dependencies" />
-                    <xs:attribute name="Description" />
-                    <xs:attribute name="EntryPoint" />
-                    <xs:attribute name="ErrorReportUrl" />
-                    <xs:attribute name="FileAssociations" />
-                    <xs:attribute name="Files" />
-                    <xs:attribute name="HostInBrowser" type="msb:boolean" />
-                    <xs:attribute name="IconFile" />
-                    <xs:attribute name="InputManifest" />
-                    <xs:attribute name="IsolatedComReferences" />
-                    <xs:attribute name="ManifestType" />
-                    <xs:attribute name="MaxTargetPath" />
-                    <xs:attribute name="OSVersion" />
-                    <xs:attribute name="OutputManifest" />
-                    <xs:attribute name="Platform" />
-                    <xs:attribute name="Product" />
-                    <xs:attribute name="Publisher" />
-                    <xs:attribute name="RequiresMinimumFramework35SP1" type="msb:boolean" />
-                    <xs:attribute name="SuiteName" />
-                    <xs:attribute name="SupportUrl" />
-                    <xs:attribute name="TargetCulture" />
-                    <xs:attribute name="TargetFrameworkMoniker" />
-                    <xs:attribute name="TargetFrameworkProfile" />
-                    <xs:attribute name="TargetFrameworkSubset" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                    <xs:attribute name="TrustInfoFile" />
-                    <xs:attribute name="UseApplicationTrust" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GenerateBootstrapper" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ApplicationFile" />
-                    <xs:attribute name="ApplicationName" />
-                    <xs:attribute name="ApplicationRequiresElevation" type="msb:boolean" />
-                    <xs:attribute name="ApplicationUrl" />
-                    <xs:attribute name="BootstrapperComponentFiles" />
-                    <xs:attribute name="BootstrapperItems" />
-                    <xs:attribute name="BootstrapperKeyFile" />
-                    <xs:attribute name="ComponentsLocation" />
-                    <xs:attribute name="ComponentsUrl" />
-                    <xs:attribute name="CopyComponents" type="msb:boolean" />
-                    <xs:attribute name="Culture" />
-                    <xs:attribute name="FallbackCulture" />
-                    <xs:attribute name="OutputPath" />
-                    <xs:attribute name="Path" />
-                    <xs:attribute name="SupportUrl" />
-                    <xs:attribute name="Validate" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GenerateDeploymentManifest" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AssemblyName" />
-                    <xs:attribute name="AssemblyVersion" />
-                    <xs:attribute name="CreateDesktopShortcut" type="msb:boolean" />
-                    <xs:attribute name="DeploymentUrl" />
-                    <xs:attribute name="Description" />
-                    <xs:attribute name="DisallowUrlActivation" type="msb:boolean" />
-                    <xs:attribute name="EntryPoint" />
-                    <xs:attribute name="ErrorReportUrl" />
-                    <xs:attribute name="InputManifest" />
-                    <xs:attribute name="Install" type="msb:boolean" />
-                    <xs:attribute name="MapFileExtensions" type="msb:boolean" />
-                    <xs:attribute name="MaxTargetPath" />
-                    <xs:attribute name="MinimumRequiredVersion" />
-                    <xs:attribute name="OutputManifest" />
-                    <xs:attribute name="Platform" />
-                    <xs:attribute name="Product" />
-                    <xs:attribute name="Publisher" />
-                    <xs:attribute name="SuiteName" />
-                    <xs:attribute name="SupportUrl" />
-                    <xs:attribute name="TargetCulture" />
-                    <xs:attribute name="TargetFrameworkMoniker" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                    <xs:attribute name="TrustUrlParameters" type="msb:boolean" />
-                    <xs:attribute name="UpdateEnabled" type="msb:boolean" />
-                    <xs:attribute name="UpdateInterval" />
-                    <xs:attribute name="UpdateMode" />
-                    <xs:attribute name="UpdateUnit" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GenerateResource" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AdditionalInputs" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="ExecuteAsTool" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="NeverLockTypeAssemblies" type="msb:boolean" />
-                    <xs:attribute name="OutputResources" />
-                    <xs:attribute name="PublicClass" type="msb:boolean" />
-                    <xs:attribute name="References" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="StateFile" />
-                    <xs:attribute name="StronglyTypedClassName" />
-                    <xs:attribute name="StronglyTypedFileName" />
-                    <xs:attribute name="StronglyTypedLanguage" />
-                    <xs:attribute name="StronglyTypedManifestPrefix" />
-                    <xs:attribute name="StronglyTypedNamespace" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="UseSourcePath" type="msb:boolean" />
-                    <xs:attribute name="ExtractResWFiles" type="msb:boolean" />
-                    <xs:attribute name="OutputDirectory" />
-                    <xs:attribute name="MSBuildRuntime" />
-                    <xs:attribute name="MSBuildArchitecture" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GenerateTrustInfo" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ApplicationDependencies" />
-                    <xs:attribute name="BaseManifest" />
-                    <xs:attribute name="ExcludedPermissions" />
-                    <xs:attribute name="TargetFrameworkMoniker" />
-                    <xs:attribute name="TargetZone" />
-                    <xs:attribute name="TrustInfoFile" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GetAssemblyIdentity" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Assemblies" />
-                    <xs:attribute name="AssemblyFiles" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GetFrameworkPath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Path" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GetFrameworkSdkPath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Path" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GetReferenceAssemblyPaths" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="RootPath" />
-                    <xs:attribute name="TargetFrameworkMoniker" />
-                    <xs:attribute name="TargetFrameworkMonikerDisplayName" />
-                    <xs:attribute name="BypassFrameworkInstallChecks" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="LC" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="LicenseTarget" use="required" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="NoLogo" type="msb:boolean" />
-                    <xs:attribute name="OutputDirectory" />
-                    <xs:attribute name="OutputLicense" />
-                    <xs:attribute name="ReferencedAssemblies" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="MakeDir" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Directories" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Message" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Importance" type="msb:importance" />
-                    <xs:attribute name="Text" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Move" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DestinationFiles" />
-                    <xs:attribute name="DestinationFolder" />
-                    <xs:attribute name="OverwriteReadOnlyFiles" type="msb:boolean" />
-                    <xs:attribute name="SourceFiles" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="MSBuild" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="BuildInParallel" type="msb:boolean" />
-                    <xs:attribute name="Projects" use="required" />
-                    <xs:attribute name="Properties" />
-                    <xs:attribute name="RebaseOutputs" type="msb:boolean" />
-                    <xs:attribute name="RunEachTargetSeparately" type="msb:boolean" />
-                    <xs:attribute name="SkipNonexistentProjects" type="msb:boolean" />
-                    <xs:attribute name="StopOnFirstFailure" type="msb:boolean" />
-                    <xs:attribute name="TargetAndPropertyListSeparators" />
-                    <xs:attribute name="Targets" />
-                    <xs:attribute name="ToolsVersion" />
-                    <xs:attribute name="UnloadProjectsOnCompletion" type="msb:boolean" />
-                    <xs:attribute name="UseResultsCache" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ReadLinesFromFile" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="File" use="required" />
-                    <xs:attribute name="Lines" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="RegisterAssembly" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Assemblies" use="required" />
-                    <xs:attribute name="AssemblyListFile" />
-                    <xs:attribute name="CreateCodeBase" type="msb:boolean" />
-                    <xs:attribute name="TypeLibFiles" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="RemoveDir" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Directories" use="required" />
-                    <xs:attribute name="RemovedDirectories" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="RemoveDuplicates" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Filtered" />
-                    <xs:attribute name="Inputs" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="RequiresFramework35SP1Assembly" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Assemblies" />
-                    <xs:attribute name="CreateDesktopShortcut" type="msb:boolean" />
-                    <xs:attribute name="DeploymentManifestEntryPoint" />
-                    <xs:attribute name="EntryPoint" />
-                    <xs:attribute name="ErrorReportUrl" />
-                    <xs:attribute name="Files" />
-                    <xs:attribute name="ReferencedAssemblies" />
-                    <xs:attribute name="RequiresMinimumFramework35SP1" type="msb:boolean" />
-                    <xs:attribute name="SigningManifests" type="msb:boolean" />
-                    <xs:attribute name="SuiteName" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ResolveAssemblyReference" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AllowedAssemblyExtensions" />
-                    <xs:attribute name="AllowedGlobalAssemblyNamePrefix" />
-                    <xs:attribute name="AllowedRelatedFileExtensions" />
-                    <xs:attribute name="AppConfigFile" />
-                    <xs:attribute name="Assemblies" />
-                    <xs:attribute name="AssemblyFiles" />
-                    <xs:attribute name="AutoUnify" type="msb:boolean" />
-                    <xs:attribute name="CandidateAssemblyFiles" />
-                    <xs:attribute name="FilesWritten" />
-                    <xs:attribute name="FindDependencies" type="msb:boolean" />
-                    <xs:attribute name="FindRelatedFiles" type="msb:boolean" />
-                    <xs:attribute name="FindSatellites" type="msb:boolean" />
-                    <xs:attribute name="FindSerializationAssemblies" type="msb:boolean" />
-                    <xs:attribute name="FullFrameworkAssemblyTables" />
-                    <xs:attribute name="FullFrameworkFolders" />
-                    <xs:attribute name="FullTargetFrameworkSubsetNames" />
-                    <xs:attribute name="IgnoreDefaultInstalledAssemblySubsetTables" type="msb:boolean" />
-                    <xs:attribute name="IgnoreDefaultInstalledAssemblyTables" type="msb:boolean" />
-                    <xs:attribute name="InstalledAssemblySubsetTables" />
-                    <xs:attribute name="InstalledAssemblyTables" />
-                    <xs:attribute name="ProfileName" />
-                    <xs:attribute name="PublicKeysRestrictedForGlobalLocation" />
-                    <xs:attribute name="SearchPaths" use="required" />
-                    <xs:attribute name="Silent" type="msb:boolean" />
-                    <xs:attribute name="StateFile" />
-                    <xs:attribute name="TargetedRuntimeVersion" />
-                    <xs:attribute name="TargetFrameworkDirectories" />
-                    <xs:attribute name="TargetFrameworkMoniker" />
-                    <xs:attribute name="TargetFrameworkMonikerDisplayName" />
-                    <xs:attribute name="TargetFrameworkSubsets" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                    <xs:attribute name="TargetProcessorArchitecture" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ResolveComReference" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="ExecuteAsTool" type="msb:boolean" />
-                    <xs:attribute name="IncludeVersionInInteropName" type="msb:boolean" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="NoClassMembers" type="msb:boolean" />
-                    <xs:attribute name="ResolvedAssemblyReferences" />
-                    <xs:attribute name="ResolvedFiles" />
-                    <xs:attribute name="ResolvedModules" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="StateFile" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                    <xs:attribute name="TargetProcessorArchitecture" />
-                    <xs:attribute name="TypeLibFiles" />
-                    <xs:attribute name="TypeLibNames" />
-                    <xs:attribute name="WrapperOutputDirectory" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ResolveKeySource" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AutoClosePasswordPromptShow" />
-                    <xs:attribute name="AutoClosePasswordPromptTimeout" />
-                    <xs:attribute name="CertificateFile" />
-                    <xs:attribute name="CertificateThumbprint" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="ResolvedKeyContainer" />
-                    <xs:attribute name="ResolvedKeyFile" />
-                    <xs:attribute name="ResolvedThumbprint" />
-                    <xs:attribute name="ShowImportDialogDespitePreviousFailures" type="msb:boolean" />
-                    <xs:attribute name="SuppressAutoClosePasswordPrompt" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ResolveManifestFiles" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DeploymentManifestEntryPoint" />
-                    <xs:attribute name="EntryPoint" />
-                    <xs:attribute name="ExtraFiles" />
-                    <xs:attribute name="Files" />
-                    <xs:attribute name="ManagedAssemblies" />
-                    <xs:attribute name="NativeAssemblies" />
-                    <xs:attribute name="OutputAssemblies" />
-                    <xs:attribute name="OutputDeploymentManifestEntryPoint" />
-                    <xs:attribute name="OutputEntryPoint" />
-                    <xs:attribute name="OutputFiles" />
-                    <xs:attribute name="PublishFiles" />
-                    <xs:attribute name="SatelliteAssemblies" />
-                    <xs:attribute name="SigningManifests" type="msb:boolean" />
-                    <xs:attribute name="TargetCulture" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ResolveNativeReference" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AdditionalSearchPaths" use="required" />
-                    <xs:attribute name="ContainedComComponents" />
-                    <xs:attribute name="ContainedLooseEtcFiles" />
-                    <xs:attribute name="ContainedLooseTlbFiles" />
-                    <xs:attribute name="ContainedPrerequisiteAssemblies" />
-                    <xs:attribute name="ContainedTypeLibraries" />
-                    <xs:attribute name="ContainingReferenceFiles" />
-                    <xs:attribute name="NativeReferences" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="ResolveNonMSBuildProjectOutput" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="PreresolvedProjectOutputs" />
-                    <xs:attribute name="ProjectReferences" use="required" />
-                    <xs:attribute name="ResolvedOutputPaths" />
-                    <xs:attribute name="UnresolvedProjectReferences" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="SGen" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="BuildAssemblyName" use="required" />
-                    <xs:attribute name="BuildAssemblyPath" use="required" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="References" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="SerializationAssembly" />
-                    <xs:attribute name="ShouldGenerateSerializer" use="required" type="msb:boolean" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="UseProxyTypes" use="required" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="SignFile" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="CertificateThumbprint" use="required" />
-                    <xs:attribute name="SigningTarget" use="required" />
-                    <xs:attribute name="TimestampUrl" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="TlbImp" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AssemblyNamespace" />
-                    <xs:attribute name="AssemblyVersion" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="NoLogo" type="msb:boolean" />
-                    <xs:attribute name="OutputAssembly" />
-                    <xs:attribute name="PreventClassMembers" type="msb:boolean" />
-                    <xs:attribute name="SafeArrayAsSystemArray" type="msb:boolean" />
-                    <xs:attribute name="SdkToolsPath" />
-                    <xs:attribute name="Silent" type="msb:boolean" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="Transform" />
-                    <xs:attribute name="TypeLibName" />
-                    <xs:attribute name="Verbose" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Touch" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AlwaysCreate" type="msb:boolean" />
-                    <xs:attribute name="Files" use="required" />
-                    <xs:attribute name="ForceTouch" type="msb:boolean" />
-                    <xs:attribute name="Time" />
-                    <xs:attribute name="TouchedFiles" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="UnregisterAssembly" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Assemblies" />
-                    <xs:attribute name="AssemblyListFile" />
-                    <xs:attribute name="TypeLibFiles" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="UpdateManifest" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ApplicationManifest" use="required" />
-                    <xs:attribute name="TargetFrameworkVersion" />
-                    <xs:attribute name="ApplicationPath" use="required" />
-                    <xs:attribute name="InputManifest" use="required" />
-                    <xs:attribute name="OutputManifest" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Vbc" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AdditionalLibPaths" />
-                    <xs:attribute name="AddModules" />
-                    <xs:attribute name="BaseAddress" />
-                    <xs:attribute name="CodePage" />
-                    <xs:attribute name="DebugType" />
-                    <xs:attribute name="DefineConstants" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="DisabledWarnings" />
-                    <xs:attribute name="DocumentationFile" />
-                    <xs:attribute name="EmitDebugInformation" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ErrorReport" />
-                    <xs:attribute name="FileAlignment" />
-                    <xs:attribute name="GenerateDocumentation" type="msb:boolean" />
-                    <xs:attribute name="Imports" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LangVersion" />
-                    <xs:attribute name="VBRuntime" />
-                    <xs:attribute name="LinkResources" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MainEntryPoint" />
-                    <xs:attribute name="ModuleAssemblyName" />
-                    <xs:attribute name="NoConfig" type="msb:boolean" />
-                    <xs:attribute name="NoLogo" type="msb:boolean" />
-                    <xs:attribute name="NoStandardLib" type="msb:boolean" />
-                    <xs:attribute name="NoVBRuntimeReference" type="msb:boolean" />
-                    <xs:attribute name="NoWarnings" type="msb:boolean" />
-                    <xs:attribute name="NoWin32Manifest" type="msb:boolean" />
-                    <xs:attribute name="Optimize" type="msb:boolean" />
-                    <xs:attribute name="OptionCompare" />
-                    <xs:attribute name="OptionExplicit" type="msb:boolean" />
-                    <xs:attribute name="OptionInfer" type="msb:boolean" />
-                    <xs:attribute name="OptionStrict" type="msb:boolean" />
-                    <xs:attribute name="OptionStrictType" />
-                    <xs:attribute name="OutputAssembly" />
-                    <xs:attribute name="Platform" />
-                    <xs:attribute name="References" />
-                    <xs:attribute name="RemoveIntegerChecks" type="msb:boolean" />
-                    <xs:attribute name="Resources" />
-                    <xs:attribute name="ResponseFiles" />
-                    <xs:attribute name="RootNamespace" />
-                    <xs:attribute name="SdkPath" />
-                    <xs:attribute name="Sources" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="TargetCompactFramework" type="msb:boolean" />
-                    <xs:attribute name="TargetType" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TreatWarningsAsErrors" type="msb:boolean" />
-                    <xs:attribute name="UseHostCompilerIfAvailable" type="msb:boolean" />
-                    <xs:attribute name="Utf8Output" type="msb:boolean" />
-                    <xs:attribute name="Verbosity" />
-                    <xs:attribute name="WarningsAsErrors" />
-                    <xs:attribute name="WarningsNotAsErrors" />
-                    <xs:attribute name="Win32Icon" />
-                    <xs:attribute name="Win32Manifest" />
-                    <xs:attribute name="Win32Resource" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="VCBuild" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AdditionalLibPaths" />
-                    <xs:attribute name="AdditionalLinkLibraryPaths" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="Clean" type="msb:boolean" />
-                    <xs:attribute name="Configuration" />
-                    <xs:attribute name="Override" />
-                    <xs:attribute name="Platform" />
-                    <xs:attribute name="Projects" use="required" />
-                    <xs:attribute name="Rebuild" type="msb:boolean" />
-                    <xs:attribute name="SolutionFile" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="UseEnvironment" type="msb:boolean" />
-                    <!-- OBSOLETE: Will be removed in a future version. Use UseEnvironment instead -->
-                    <xs:attribute name="UserEnvironment" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Warning" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Code" />
-                    <xs:attribute name="File" />
-                    <xs:attribute name="HelpKeyword" />
-                    <xs:attribute name="Text" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="WcfConfigValidationEnabled" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenCollectionTypes" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenEnabled" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenEnableDataBinding" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenGenerateAsynchronousOperations" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenGenerateDataTypesOnly" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenGenerateInternalTypes" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenGenerateMessageContract" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenGenerateSerializableTypes" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenNamespaceMappings" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenImportXmlTypes" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenReuseTypesFlag" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenReuseTypesMode" substitutionGroup="msb:Property">
-        <xs:simpleType>
-            <xs:restriction base="xs:string">
-                <xs:enumeration value="All" />
-                <xs:enumeration value="Partial" />
-            </xs:restriction>
-        </xs:simpleType>
-    </xs:element>
-    <xs:element name="WsdlXsdCodeGenSerializerMode" substitutionGroup="msb:Property">
-        <xs:simpleType>
-            <xs:restriction base="xs:string">
-                <xs:enumeration value="XmlSerializer" />
-                <xs:enumeration value="DataContractSerializer" />
-            </xs:restriction>
-        </xs:simpleType>
-    </xs:element>
-    <xs:element name="WsdlXsdCodeGenUseSerializerForFaults" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WsdlXsdCodeGenWrapped" type="msb:boolean" substitutionGroup="msb:Property"/>
-    <xs:element name="WriteCodeFragment" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AssemblyAttributes" />
-                    <xs:attribute name="Language" use="required" />
-                    <xs:attribute name="OutputDirectory" />
-                    <xs:attribute name="OutputFile" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="WriteLinesToFile" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Encoding" />
-                    <xs:attribute name="File" use="required" />
-                    <xs:attribute name="Lines" />
-                    <xs:attribute name="Overwrite" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="XslTransformation" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="OutputPaths" use="required" />
-                    <xs:attribute name="Parameters" />
-                    <xs:attribute name="XmlContent" />
-                    <xs:attribute name="XmlInputPaths" />
-                    <xs:attribute name="XslCompiledDllPath" />
-                    <xs:attribute name="XslContent" />
-                    <xs:attribute name="XslInputPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CodeAnalysis" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AlternativeToolName" />
-                    <xs:attribute name="AnalysisTimeout" />
-                    <xs:attribute name="ApplyLogFileXsl" type="msb:boolean" />
-                    <xs:attribute name="Assemblies" />
-                    <xs:attribute name="ConsoleXsl" />
-                    <xs:attribute name="Culture" />
-                    <xs:attribute name="DependentAssemblyPaths" />
-                    <xs:attribute name="Dictionaries" />
-                    <xs:attribute name="FilesWritten" />
-                    <xs:attribute name="ForceOutput" type="msb:boolean"/>
-                    <xs:attribute name="GenerateSuccessFile" type="msb:boolean" />
-                    <xs:attribute name="IgnoreInvalidTargets" type="msb:boolean" />
-                    <xs:attribute name="IgnoreGeneratedCode" type="msb:boolean" />
-                    <xs:attribute name="Imports" />
-                    <xs:attribute name="LogFile" />
-                    <xs:attribute name="LogFileXsl" />
-                    <xs:attribute name="OutputToConsole" type="msb:boolean" />
-                    <xs:attribute name="OverrideRuleVisibilities" type="msb:boolean" />
-                    <xs:attribute name="PlatformPath" />
-                    <xs:attribute name="Project" />
-                    <xs:attribute name="Quiet" type="msb:boolean" />
-                    <xs:attribute name="References" />
-                    <xs:attribute name="RuleAssemblies" />
-                    <xs:attribute name="Rules" />
-                    <xs:attribute name="SaveMessagesToReport" />
-                    <xs:attribute name="SearchGlobalAssemblyCache" type="msb:boolean" />
-                    <xs:attribute name="Summary" type="msb:boolean" />
-                    <xs:attribute name="SuccessFile" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TreatWarningsAsErrors" type="msb:boolean" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="UpdateProject" type="msb:boolean" />                    
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <!-- ==================== NATIVE CL/LINK TASKS ==========================-->
-    <xs:element name="CL" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalIncludeDirectories" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="AdditionalUsingDirectories" />
-                    <xs:attribute name="AssemblerListingLocation" />
-                    <xs:attribute name="AssemblerOutput" />
-                    <xs:attribute name="BasicRuntimeChecks" />
-                    <xs:attribute name="BrowseInformation" type="msb:boolean" />
-                    <xs:attribute name="BrowseInformationFile" />
-                    <xs:attribute name="BufferSecurityCheck" type="msb:boolean" />
-                    <xs:attribute name="CallingConvention" />
-                    <xs:attribute name="CompileAs" />
-                    <xs:attribute name="CompileAsManaged" />
-                    <xs:attribute name="CreateHotpatchableImage" type="msb:boolean" />
-                    <xs:attribute name="DebugInformationFormat" />
-                    <xs:attribute name="DisableLanguageExtensions" type="msb:boolean" />
-                    <xs:attribute name="DisableSpecificWarnings" />
-                    <xs:attribute name="EnableEnhancedInstructionSet" />
-                    <xs:attribute name="EnableFiberSafeOptimizations" type="msb:boolean" />
-                    <xs:attribute name="EnablePREfast" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ErrorReporting" />
-                    <xs:attribute name="ExceptionHandling" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="ExpandAttributedSource" type="msb:boolean" />
-                    <xs:attribute name="FavorSizeOrSpeed" />
-                    <xs:attribute name="FloatingPointExceptions" type="msb:boolean" />
-                    <xs:attribute name="FloatingPointModel" />
-                    <xs:attribute name="ForceConformanceInForLoopScope" type="msb:boolean" />
-                    <xs:attribute name="ForcedIncludeFiles" />
-                    <xs:attribute name="ForcedUsingFiles" />
-                    <xs:attribute name="FunctionLevelLinking" type="msb:boolean" />
-                    <xs:attribute name="GenerateXMLDocumentationFiles" type="msb:boolean" />
-                    <xs:attribute name="IgnoreStandardIncludePath" type="msb:boolean" />
-                    <xs:attribute name="InlineFunctionExpansion" />
-                    <xs:attribute name="IntrinsicFunctions" type="msb:boolean" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuild" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="MultiProcessorCompilation" type="msb:boolean" />
-                    <xs:attribute name="ObjectFileName" />
-                    <xs:attribute name="ObjectFiles" />
-                    <xs:attribute name="OmitDefaultLibName" type="msb:boolean" />
-                    <xs:attribute name="OmitFramePointers" type="msb:boolean" />
-                    <xs:attribute name="OpenMPSupport" type="msb:boolean" />
-                    <xs:attribute name="Optimization" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="PrecompiledHeader" />
-                    <xs:attribute name="PrecompiledHeaderFile" />
-                    <xs:attribute name="PrecompiledHeaderOutputFile" />
-                    <xs:attribute name="PreprocessKeepComments" type="msb:boolean" />
-                    <xs:attribute name="PreprocessorDefinitions" />
-                    <xs:attribute name="PreprocessOutput" />
-                    <xs:attribute name="PreprocessSuppressLineNumbers" type="msb:boolean" />
-                    <xs:attribute name="PreprocessToFile" type="msb:boolean" />
-                    <xs:attribute name="ProcessorNumber" />
-                    <xs:attribute name="ProgramDataBaseFileName" />
-                    <xs:attribute name="RuntimeLibrary" />
-                    <xs:attribute name="RuntimeTypeInfo" type="msb:boolean" />
-                    <xs:attribute name="ShowIncludes" type="msb:boolean" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="SmallerTypeCheck" type="msb:boolean" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="StringPooling" type="msb:boolean" />
-                    <xs:attribute name="StructMemberAlignment" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="TreatSpecificWarningsAsErrors" />
-                    <xs:attribute name="TreatWarningAsError" type="msb:boolean" />
-                    <xs:attribute name="TreatWChar_tAsBuiltInType" type="msb:boolean" />
-                    <xs:attribute name="UndefineAllPreprocessorDefinitions" type="msb:boolean" />
-                    <xs:attribute name="UndefinePreprocessorDefinitions" />
-                    <xs:attribute name="UseFullPaths" type="msb:boolean" />
-                    <xs:attribute name="UseUnicodeForAssemblerListing" type="msb:boolean" />
-                    <xs:attribute name="WarningLevel" />
-                    <xs:attribute name="WholeProgramOptimization" type="msb:boolean" />
-                    <xs:attribute name="XMLDocumentationFileName" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Link" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalDependencies" />
-                    <xs:attribute name="AdditionalLibraryDirectories" />
-                    <xs:attribute name="AdditionalManifestDependencies" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="AddModuleNamesToAssembly" />
-                    <xs:attribute name="AllowIsolation" type="msb:boolean" />
-                    <xs:attribute name="AssemblyDebug" type="msb:boolean" />
-                    <xs:attribute name="AssemblyLinkResource" />
-                    <xs:attribute name="BaseAddress" />
-                    <xs:attribute name="CLRImageType" />
-                    <xs:attribute name="CLRSupportLastError" />
-                    <xs:attribute name="CLRThreadAttribute" />
-                    <xs:attribute name="CLRUnmanagedCodeCheck" type="msb:boolean" />
-                    <xs:attribute name="CreateHotPatchableImage" />
-                    <xs:attribute name="DataExecutionPrevention" type="msb:boolean" />
-                    <xs:attribute name="DelayLoadDLLs" />
-                    <xs:attribute name="DelaySign" type="msb:boolean" />
-                    <xs:attribute name="Driver" />
-                    <xs:attribute name="EmbedManagedResourceFile" />
-                    <xs:attribute name="EnableCOMDATFolding" type="msb:boolean" />
-                    <xs:attribute name="EnableUAC" type="msb:boolean" />
-                    <xs:attribute name="EntryPointSymbol" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="FixedBaseAddress" type="msb:boolean" />
-                    <xs:attribute name="ForceFileOutput" />
-                    <xs:attribute name="ForceSymbolReferences" />
-                    <xs:attribute name="FunctionOrder" />
-                    <xs:attribute name="GenerateDebugInformation" type="msb:boolean" />
-                    <xs:attribute name="GenerateManifest" type="msb:boolean" />
-                    <xs:attribute name="GenerateMapFile" type="msb:boolean" />
-                    <xs:attribute name="HeapCommitSize" />
-                    <xs:attribute name="HeapReserveSize" />
-                    <xs:attribute name="IgnoreAllDefaultLibraries" type="msb:boolean" />
-                    <xs:attribute name="IgnoreEmbeddedIDL" type="msb:boolean" />
-                    <xs:attribute name="IgnoreImportLibrary" type="msb:boolean" />
-                    <xs:attribute name="IgnoreSpecificDefaultLibraries" />
-                    <xs:attribute name="ImageHasSafeExceptionHandlers" type="msb:boolean" />
-                    <xs:attribute name="ImportLibrary" />
-                    <xs:attribute name="KeyContainer" />
-                    <xs:attribute name="KeyFile" />
-                    <xs:attribute name="LargeAddressAware" type="msb:boolean" />
-                    <xs:attribute name="LinkDLL" type="msb:boolean" />
-                    <xs:attribute name="LinkErrorReporting" />
-                    <xs:attribute name="LinkIncremental" type="msb:boolean" />
-                    <xs:attribute name="LinkLibraryDependencies" type="msb:boolean" />
-                    <xs:attribute name="LinkStatus" type="msb:boolean" />
-                    <xs:attribute name="LinkTimeCodeGeneration" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="ManifestFile" />
-                    <xs:attribute name="MapExports" type="msb:boolean" />
-                    <xs:attribute name="MapFileName" />
-                    <xs:attribute name="MergedIDLBaseFileName" />
-                    <xs:attribute name="MergeSections" />
-                    <xs:attribute name="MidlCommandFile" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="MinimumRequiredVersion" />
-                    <xs:attribute name="ModuleDefinitionFile" />
-                    <xs:attribute name="MSDOSStubFileName" />
-                    <xs:attribute name="NoEntryPoint" type="msb:boolean" />
-                    <xs:attribute name="ObjectFiles" />
-                    <xs:attribute name="OptimizeReferences" type="msb:boolean" />
-                    <xs:attribute name="OutputFile" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="PerUserRedirection" type="msb:boolean" />
-                    <xs:attribute name="PreprocessOutput" />
-                    <xs:attribute name="PreventDllBinding" type="msb:boolean" />
-                    <xs:attribute name="Profile" type="msb:boolean" />
-                    <xs:attribute name="ProfileGuidedDatabase" />
-                    <xs:attribute name="ProgramDatabaseFile" />
-                    <xs:attribute name="RandomizedBaseAddress" type="msb:boolean" />
-                    <xs:attribute name="RegisterOutput" type="msb:boolean" />
-                    <xs:attribute name="SectionAlignment" />
-                    <xs:attribute name="SetChecksum" type="msb:boolean" />
-                    <xs:attribute name="ShowProgress" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="SpecifySectionAttributes" />
-                    <xs:attribute name="StackCommitSize" />
-                    <xs:attribute name="StackReserveSize" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="StripPrivateSymbols" />
-                    <xs:attribute name="SubSystem" />
-                    <xs:attribute name="SupportNobindOfDelayLoadedDLL" type="msb:boolean" />
-                    <xs:attribute name="SupportUnloadOfDelayLoadedDLL" type="msb:boolean" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="SwapRunFromCD" type="msb:boolean" />
-                    <xs:attribute name="SwapRunFromNET" type="msb:boolean" />
-                    <xs:attribute name="TargetMachine" />
-                    <xs:attribute name="TerminalServerAware" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="TreatLinkerWarningAsErrors" type="msb:boolean" />
-                    <xs:attribute name="TurnOffAssemblyGeneration" type="msb:boolean" />
-                    <xs:attribute name="TypeLibraryFile" />
-                    <xs:attribute name="TypeLibraryResourceID" />
-                    <xs:attribute name="UACExecutionLevel" />
-                    <xs:attribute name="UACUIAccess" type="msb:boolean" />
-                    <xs:attribute name="UseLibraryDependencyInputs" type="msb:boolean" />
-                    <xs:attribute name="Version" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <!-- ======================== NATIVE TASKS ==============================-->
-    <xs:element name="BSCMake" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="OutputFile" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Sources" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="CPPClean" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DeletedFiles" />
-                    <xs:attribute name="DoDelete" type="msb:boolean" />
-                    <xs:attribute name="FilePatternsToDeleteOnClean" use="required" />
-                    <xs:attribute name="FilesExcludedFromClean" />
-                    <xs:attribute name="FoldersToClean" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="GetOutputFileName" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="OutputExtension" use="required" />
-                    <xs:attribute name="OutputFile" />
-                    <xs:attribute name="OutputPath" />
-                    <xs:attribute name="SourceFile" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="IsAssembly" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Assemblies" />
-                    <xs:attribute name="AssemblyFiles" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="LIB" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalDependencies" />
-                    <xs:attribute name="AdditionalLibraryDirectories" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="DisplayLibrary" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ErrorReporting" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="ExportNamedFunctions" />
-                    <xs:attribute name="ForceSymbolReferences" />
-                    <xs:attribute name="IgnoreAllDefaultLibraries" type="msb:boolean" />
-                    <xs:attribute name="IgnoreSpecificDefaultLibraries" />
-                    <xs:attribute name="LinkLibraryDependencies" type="msb:boolean" />
-                    <xs:attribute name="LinkTimeCodeGeneration" type="msb:boolean" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="MinimumRequiredVersion" />
-                    <xs:attribute name="ModuleDefinitionFile" />
-                    <xs:attribute name="OutputFile" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="RemoveObjects" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="SubSystem" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="TargetMachine" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="TreatLibWarningAsErrors" type="msb:boolean" />
-                    <xs:attribute name="UseUnicodeResponseFiles" type="msb:boolean" />
-                    <xs:attribute name="Verbose" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="MIDL" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalIncludeDirectories" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="ApplicationConfigurationMode" type="msb:boolean" />
-                    <xs:attribute name="ClientStubFile" />
-                    <xs:attribute name="CPreprocessOptions" />
-                    <xs:attribute name="DefaultCharType" />
-                    <xs:attribute name="DllDataFileName" />
-                    <xs:attribute name="EnableErrorChecks" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ErrorCheckAllocations" type="msb:boolean" />
-                    <xs:attribute name="ErrorCheckBounds" type="msb:boolean" />
-                    <xs:attribute name="ErrorCheckEnumRange" type="msb:boolean" />
-                    <xs:attribute name="ErrorCheckRefPointers" type="msb:boolean" />
-                    <xs:attribute name="ErrorCheckStubData" type="msb:boolean" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="GenerateClientFiles" />
-                    <xs:attribute name="GenerateServerFiles" />
-                    <xs:attribute name="GenerateStublessProxies" type="msb:boolean" />
-                    <xs:attribute name="GenerateTypeLibrary" type="msb:boolean" />
-                    <xs:attribute name="HeaderFileName" />
-                    <xs:attribute name="IgnoreStandardIncludePath" type="msb:boolean" />
-                    <xs:attribute name="InterfaceIdentifierFileName" />
-                    <xs:attribute name="LocaleID" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="MkTypLibCompatible" type="msb:boolean" />
-                    <xs:attribute name="OutputDirectory" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="PreprocessorDefinitions" />
-                    <xs:attribute name="ProxyFileName" />
-                    <xs:attribute name="RedirectOutputAndErrors" />
-                    <xs:attribute name="ServerStubFile" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Source" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="StructMemberAlignment" />
-                    <xs:attribute name="SuppressCompilerWarnings" type="msb:boolean" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="TargetEnvironment" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="TypeLibFormat" />
-                    <xs:attribute name="TypeLibraryName" />
-                    <xs:attribute name="UndefinePreprocessorDefinitions" />
-                    <xs:attribute name="ValidateAllParameters" type="msb:boolean" />
-                    <xs:attribute name="WarnAsError" type="msb:boolean" />
-                    <xs:attribute name="WarningLevel" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="Mt" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalManifestFiles" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="AssemblyIdentity" />
-                    <xs:attribute name="ComponentFileName" />
-                    <xs:attribute name="EmbedManifest" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="GenerateCatalogFiles" type="msb:boolean" />
-                    <xs:attribute name="GenerateCategoryTags" type="msb:boolean" />
-                    <xs:attribute name="InputResourceManifests" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="ManifestFromManagedAssembly" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="OutputManifestFile" />
-                    <xs:attribute name="OutputResourceManifests" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="RegistrarScriptFile" />
-                    <xs:attribute name="ReplacementsFile" />
-                    <xs:attribute name="ResourceOutputFileName" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Sources" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="SuppressDependencyElement" type="msb:boolean" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="TypeLibraryFile" />
-                    <xs:attribute name="UpdateFileHashes" type="msb:boolean" />
-                    <xs:attribute name="UpdateFileHashesSearchPath" />
-                    <xs:attribute name="VerboseOutput" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="RC" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalIncludeDirectories" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="Culture" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="IgnoreStandardIncludePath" type="msb:boolean" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="NullTerminateStrings" type="msb:boolean" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="PreprocessorDefinitions" />
-                    <xs:attribute name="ResourceOutputFileName" />
-                    <xs:attribute name="ShowProgress" type="msb:boolean" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Source" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                    <xs:attribute name="UndefinePreprocessorDefinitions" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="SetEnv" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Prefix" use="required" type="msb:boolean" />
-                    <xs:attribute name="Target" />
-                    <xs:attribute name="Value" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="XDCMake" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalDocumentFile" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="DocumentLibraryDependencies" type="msb:boolean" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="OutputFile" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="ProjectName" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="SlashOld" type="msb:boolean" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="XSD" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AcceptableNonZeroExitCodes" />
-                    <xs:attribute name="ActiveToolSwitchesValues" />
-                    <xs:attribute name="AdditionalOptions" />
-                    <xs:attribute name="EnvironmentVariables" />
-                    <xs:attribute name="ExcludedInputPaths" />
-                    <xs:attribute name="GenerateFromSchema" />
-                    <xs:attribute name="Language" />
-                    <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-                    <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
-                    <xs:attribute name="Namespace" />
-                    <xs:attribute name="PathOverride" />
-                    <xs:attribute name="SkippedExecution" type="msb:boolean" />
-                    <xs:attribute name="Sources" use="required" />
-                    <xs:attribute name="SourcesCompiled" />
-                    <xs:attribute name="StandardErrorImportance" />
-                    <xs:attribute name="StandardOutputImportance" />
-                    <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
-                    <xs:attribute name="Timeout" />
-                    <xs:attribute name="TLogReadFiles" />
-                    <xs:attribute name="TLogWriteFiles" />
-                    <xs:attribute name="ToolExe" />
-                    <xs:attribute name="ToolPath" />
-                    <xs:attribute name="TrackedInputFilesToIgnore" />
-                    <xs:attribute name="TrackedOutputFilesToIgnore" />
-                    <xs:attribute name="TrackerLogDirectory" />
-                    <xs:attribute name="TrackFileAccess" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="VCMessage" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Code" use="required" />
-                    <xs:attribute name="Type" />
-                    <xs:attribute name="Arguments" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <!-- ============================================================== -->
-    <!-- Elements used and/or defined in Microsoft.AppxPackage.targets. -->
-    <!-- ============================================================== -->
-
-    <!-- ===================== -->
-    <!-- Packaging properties. -->
-    <!-- ===================== -->
-
-    <xs:element name="DefaultLanguage" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="DefaultLanguage" _locComment="" -->Default resource language.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="PackageCertificateKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PackageCertificateKeyFile" _locComment="" -->App package certificate key file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxAutoIncrementPackageRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxAutoIncrementPackageRevision" _locComment="" -->Flag indicating whether to auto-increment package revision.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-        
-    <xs:element name="AppxMSBuildToolsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxMSBuildToolsPath" _locComment="" -->Full path to a folder containing packaging build targets and tasks assembly.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxMSBuildTaskAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxMSBuildTaskAssembly" _locComment="" -->Full path to packaging build tasks assembly.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackage" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackage" _locComment="" -->Flag marking current project as capable of being packaged as an app package.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxUseHardlinksIfPossible" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxUseHardlinksIfPossible" _locComment="" -->Flag indicating whether to use hard links if possible when copying files during creation of app packages.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxSkipUnchangedFiles" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxSkipUnchangedFiles" _locComment="" -->Flag indicating whether to skip unchanged files when copying files during creation of app packages.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxGeneratePriEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxGeneratePriEnabled" _locComment="" -->Flag indicating whether to generate resource index files (PRI files) during packaging.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackageSigningEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageSigningEnabled" _locComment="" -->Flag indicating whether to enable signing of app packages.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackageIncludePrivateSymbols" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageIncludePrivateSymbols" _locComment="" -->Flag indicating whether to include private symbols in symbol packages.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxSymbolPackageEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxSymbolPackageEnabled" _locComment="" -->Flag indicating whether to generate a symbol package when an app package is created.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxTestLayoutEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxTestLayoutEnabled" _locComment="" -->Flag indicating whether to create test layout when an app package is created.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackageValidationEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageValidationEnabled" _locComment="" -->Flag indicating whether to enable validation of app packages.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxHarvestWinmdRegistration" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxHarvestWinmdRegistration" _locComment="" -->Flag indicating whether to enable harvesting of WinMD registration information.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="EnableSigningChecks" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="EnableSigningChecks" _locComment="" -->Flag indicating whether to enable signing checks during app package generation.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxStrictManifestValidationEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxStrictManifestValidationEnabled" _locComment="" -->Flag indicating whether to enable strict manifest validation.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxFilterOutUnusedLanguagesResourceFileMaps" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxFilterOutUnusedLanguagesResourceFileMaps" _locComment="" -->Flag indicating whether to filter out unused language resource file maps.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxOSMinVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxOSMinVersion" _locComment="" -->Targeted minimum OS version.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxOSMaxVersionTested" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxOSMaxVersionTested" _locComment="" -->Targeted maximum OS version tested.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackageDirName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageDirName" _locComment="" -->Name of the folder where app packages are produced.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="PlatformSpecificBundleArtifactsListDirName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PlatformSpecificBundleArtifactsListDirName" _locComment="" -->Name of the folder where platform-specific bundle artifact lists are stored.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-        
-    <xs:element name="AppxPackageDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageDir" _locComment="" -->Full path to a folder where app packages will be saved.</xs:documentation>
-        </xs:annotation>
-    </xs:element>        
-
-    <xs:element name="AppxPackageArtifactsDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageArtifactsDir" _locComment="" -->Additional qualifier to append to AppxPackageDir.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="FinalAppxManifestName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="FinalAppxManifestName" _locComment="" -->Path to the final app manifest.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxValidateAppxManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxValidateAppxManifest" _locComment="" -->Flag indicating whether to validate app manifest.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-        
-    <xs:element name="MakePriExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="MakePriExeFullPath" _locComment="" -->Full path to makepri.exe utility.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-        
-    <xs:element name="MakeAppxExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="MakeAppxExeFullPath" _locComment="" -->Full path to makeappx.exe utility.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="SignAppxPackageExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="SignAppxPackageExeFullPath" _locComment="" -->Full path to signtool.exe utility.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="ResgenToolPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ResgenToolPath" _locComment="" -->Full path to a folder containing resgen tool.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="PdbCopyExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PdbCopyExeFullPath" _locComment="" -->Full path to pdbcopy.exe utility.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-            
-    <xs:element name="AppxSymbolStrippedDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxSymbolStrippedDir" _locComment="" -->Full path to a directory where stripped PDBs will be stored.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-            
-    <xs:element name="AppxPrependPriInitialPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPrependPriInitialPath" _locComment="" -->Flag indicating whether to enable prepending initial path when indexing RESW and RESJSON files in class libraries.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPriInitialPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPriInitialPath" _locComment="" -->Initial path when indexing RESW and RESJSON files in class libraries.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="ProjectPriFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ProjectPriFileName" _locComment="" -->File name to use for project-specific resource index file (PRI).</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="ProjectPriFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ProjectPriFullPath" _locComment="" -->Full path to project-specific resource index file (PRI).</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPackageRecipe" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageRecipe" _locComment="" -->Full path to the app package recipe.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="FinalAppxPackageRecipe" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="FinalAppxPackageRecipe" _locComment="" -->Full path to the final app package recipe.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AllowLocalNetworkLoopback" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AllowLocalNetworkLoopback" _locComment="" -->Flag indicating whether to allow local network loopback.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxDefaultHashAlgorithmId" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxDefaultHashAlgorithmId" _locComment="" -->Default hash algorithm ID, used for signing an app package.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPackageFileMap" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageFileMap" _locComment="" -->Full path to app package file map.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="LayoutDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="LayoutDir" _locComment="" -->Full path to a folder with package layout.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="ManagedWinmdInprocImplementation" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ManagedWinmdInprocImplementation" _locComment="" -->Name of the binary containing managed WinMD in-proc implementation.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="UseIncrementalAppxRegistration" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UseIncrementalAppxRegistration" _locComment="" -->Flag indicating whether to enable incremental registration of the app layout.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPackagingInfoFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackagingInfoFile" _locComment="" -->Full path to the packaging info file which will contain paths to produced packages.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxOSMinVersionReplaceManifestVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxOSMinVersionReplaceManifestVersion" _locComment="" -->Flag indicating whether minimum OS version in app manifest should be replaced.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxOSMaxVersionTestedReplaceManifestVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxOSMaxVersionTestedReplaceManifestVersion" _locComment="" -->Flag indicating whether maximum OS version tested in app manifest should be replaced.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="PackagingFileWritesLogPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PackagingFileWritesLogPath" _locComment="" -->Full path to a text file containing packaging file writes log.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="PackagingDirectoryWritesLogPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PackagingDirectoryWritesLogPath" _locComment="" -->Full path to a text file containing packaging directory writes log.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxCopyLocalFilesOutputGroupIncludeXmlFiles" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxCopyLocalFilesOutputGroupIncludeXmlFiles" _locComment="" -->Flag indicating whether CopyLocal files group should include XML files.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxDefaultResourceQualifiers" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxDefaultResourceQualifiers" _locComment="" -->'|'-delimited list of key=value pairs representing default resource qualifers.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPriConfigXmlPackagingSnippetPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPriConfigXmlPackagingSnippetPath" _locComment="" -->Path to an XML file containing packaging element for priconfi.xml file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPriConfigXmlDefaultSnippetPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPriConfigXmlDefaultSnippetPath" _locComment="" -->Path to an XML file containing default element for priconfi.xml file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="TargetPlatformSdkRootOverride" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="TargetPlatformSdkRootOverride" _locComment="" -->Full path to platform SDK root.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundle" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundle" _locComment="" -->Flag indicating whether packaging targets will produce an app bundle.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundlePlatforms" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundlePlatforms" _locComment="" -->'|'-delimited list of platforms which will be included in an app bundle.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleProducingPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleProducingPlatform" _locComment="" -->A platform which will be used to produce an app bundle.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleResourcePacksProducingPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleResourcePacksProducingPlatform" _locComment="" -->A platform which will be used to produce resource packs for an app bundle.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxLayoutFolderName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxLayoutFolderName" _locComment="" -->Name of the folder where package layout will be prepared when producing an app bundle.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxLayoutDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxLayoutDir" _locComment="" -->Full path to the folder where package layout will be prepared when producing an app bundle.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundlePriConfigXmlForSplittingFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundlePriConfigXmlForSplittingFileName" _locComment="" -->Full path to the priconfig.xml file used for splitting resource packs.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleAutoResourcePackageQualifiers" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleAutoResourcePackageQualifiers" _locComment="" -->'|'-delimited list of resource qualifers which will be used for automatic resource pack splitting.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleSplitResourcesPriPrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleSplitResourcesPriPrefix" _locComment="" -->Prefix used for split resources .pri and .map.txt files.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleSplitResourcesPriPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleSplitResourcesPriPath" _locComment="" -->Full path to split resources .pri file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleSplitResourcesGeneratedFilesListPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleSplitResourcesGeneratedFilesListPath" _locComment="" -->Full path to a log file containing a list of generated files during resource splitting.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleSplitResourcesQualifiersPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleSplitResourcesQualifiersPath" _locComment="" -->Full path to a log file containing a detected qualifiers during resource splitting.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundlePriConfigXmlForMainPackageFileMapFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundlePriConfigXmlForMainPackageFileMapFileName" _locComment="" -->Full path to the priconfig.xml file used for generating main package file map.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapIntermediatePrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapIntermediatePrefix" _locComment="" -->Prefix used for intermediate main package resources .pri and .map.txt files.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapSuffix" _locComment="" -->Suffix used before extension of resource map files.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapIntermediatePath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapIntermediatePath" _locComment="" -->Full path to an intermediate main package file map.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapIntermediatePriPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapIntermediatePriPath" _locComment="" -->Full path to an intermediate main package .pri file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapGeneratedFilesListPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapGeneratedFilesListPath" _locComment="" -->Full path to a log file containing a list of generated files during generation of main package file map.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapPrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapPrefix" _locComment="" -->Prefix used for main package resources .pri and .map.txt files.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleMainPackageFileMapPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleMainPackageFileMapPath" _locComment="" -->Full path to a main package file map.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleFolderSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxBundleFolderSuffix" _locComment="" -->Suffix to append to app bundle folder.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="PlatformSpecificBundleArtifactsListDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PlatformSpecificBundleArtifactsListDir" _locComment="" -->Full path to a folder where platform-specific bundle artifact list files are stored.</xs:documentation>
-        </xs:annotation>
-    </xs:element>    
-
-    <xs:element name="AppxPackageAllowDebugFrameworkReferencesInManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageAllowDebugFrameworkReferencesInManifest" _locComment="" -->Flag indicating whether to allow inclusion of debug framework references in an app manifest.</xs:documentation>
-        </xs:annotation>
-    </xs:element>    
-
-    <xs:element name="GenerateAppxPackageOnBuild" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="GenerateAppxPackageOnBuild" _locComment="" -->Flag indicating whether to generate app package during the build.</xs:documentation>
-        </xs:annotation>
-    </xs:element>    
-
-    <xs:element name="InsertReverseMap" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="InsertReverseMap" _locComment="" -->Flag indicating whether to insert reverse resource map during resource index generation.</xs:documentation>
-        </xs:annotation>
-    </xs:element>    
-
-    <xs:element name="IncludeBuiltProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Flag indicating whether to include primary build outputs into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeDebugSymbolsProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeDebugSymbolsProjectOutputGroup" _locComment="" -->Flag indicating whether to include debug symbols into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeDocumentationProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeDocumentationProjectOutputGroup" _locComment="" -->Flag indicating whether to include documentation into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeSatelliteDllsProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeSatelliteDllsProjectOutputGroup" _locComment="" -->Flag indicating whether to include satellite DLLs into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeSourceFilesProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeSourceFilesProjectOutputGroup" _locComment="" -->Flag indicating whether to include source files into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeContentFilesProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeContentFilesProjectOutputGroup" _locComment="" -->Flag indicating whether to include content files into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeSGenFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeSGenFilesOutputGroup" _locComment="" -->Flag indicating whether to include SGen files into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeCopyLocalFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeCopyLocalFilesOutputGroup" _locComment="" -->Flag indicating whether to include files marked as 'Copy local' into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeComFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeComFilesOutputGroup" _locComment="" -->Flag indicating whether to include COM files into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeCustomOutputGroupForPackaging" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeCustomOutputGroupForPackaging" _locComment="" -->Flag indicating whether to include custom output group into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeCopyWinmdArtifactsOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeCopyWinmdArtifactsOutputGroup" _locComment="" -->Flag indicating whether to include WinMD artifacts into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeSDKRedistOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Flag indicating whether to include SDK redist into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludePriFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludePriFilesOutputGroup" _locComment="" -->Flag indicating whether to include resource index (PRI) files into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="IncludeGetResolvedSDKReferences" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeGetResolvedSDKReferences" _locComment="" -->Flag indicating whether to include resolved SDK references into the app package payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="ProjectPriIndexName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ProjectPriIndexName" _locComment="" -->Name of the resource index used in the generated .pri file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AutoIncrementPackageRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AutoIncrementPackageRevision" _locComment="" -->Flag indicating whether to enable auto increment of an app package revision.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxBundleDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AutoIncrementPackageRevision" _locComment="" -->Full path to a folder where app bundle will be produced.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxPackageName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Name of the app package to generate.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxStoreContainer" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Name of the app store container to generate.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackageTestDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Name of the folder where test app packages will be copied</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxPackageOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxPackageOutput" _locComment="" -->Full path to the app package file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxSymbolPackageOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxSymbolPackageOutput" _locComment="" -->Full path to the app symbol package file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxGenerateProjectPriFileAdditionalMakepriExeParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxGenerateProjectPriFileAdditionalMakepriExeParameters" _locComment="" -->Additional parameters to pass to makepri.exe when generating project PRI file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxCreatePriFilesForPortableLibrariesAdditionalMakepriExeParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxCreatePriFilesForPortableLibrariesAdditionalMakepriExeParameters" _locComment="" -->Additional parameters to pass to makepri.exe when generating PRI file for a portable library.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxExpandPriContentAdditionalMakepriExeParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxExpandPriContentAdditionalMakepriExeParameters" _locComment="" -->Additional parameters to pass to makepri.exe when extracting payload file names.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="StoreManifestName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="StoreManifestName" _locComment="" -->Name of the store manifest file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxValidateStoreManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxValidateStoreManifest" _locComment="" -->Flag indicating whether to validate store manifest.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <!-- Following properties are declared here to get rid of schema validation warnings,    -->
-    <!-- but are not intended for overriding, so they do not have documentation annotations. --> 
-    
-    <xs:element name="_AdjustedPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_AppxBundlePlatformsForNamingIntermediate" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_AppxPackageConfiguration" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ContinueOnError" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_CreateAppxBundleFilesDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_CreateAppxBundlePlatformSpecificArtifactsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_CreateAppxPackageDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_CustomAppxManifestUsed" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_Extension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_FileNameToRemove" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_FileToBuild" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_GenerateAppxManifestDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_GenerateAppxPackageBaseDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_GenerateAppxPackageDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_GenerateAppxPackageRecipeDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_GenerateProjectPriFileDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_GetPackagePropertiesDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_LayoutResfilesPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_MultipleQualifiersPerDimensionFound" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_MultipleQualifiersPerDimensionFoundPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_PriConfigXmlPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_PriResfilesPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ProjectArchitectureOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ProjectArchitecturesFilePath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ProjectPriFullPathOriginal" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_QualifiersPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_Rebuilding" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ResourcesResfilesPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ReverseMapProjectPriDirectory" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ReverseMapProjectPriFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_ShouldUnsetParentConfigurationAndPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_SolutionConfigurationContentsToUse" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_TargetToBuild" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_WindowsPhoneSdkInstallPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_WindowsPhoneSdkInstallPath_RegistryKeyName" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_WindowsPhoneSdkInstallPath_RegistryValueName" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AllOutputGroupsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxBundleExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxBundleOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxBundlePlatformsForNaming" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxBundlePlatformSpecificArtifactsListPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxDefaultResourceQualifiers_Windows_80" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxDefaultResourceQualifiers_Windows_81" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxDefaultResourceQualifiers_Windows_Phone" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxHashAlgorithmId" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxIntermediateExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxMainPackageOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxManifestQueryNamespace81Prefix" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxManifestQueryNamespacePrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxPackageDirInProjectDir" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxPackageDirWasSpecified" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxPackageExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxPackageNameNeutral" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxResourcePackOutputBase" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxStoreContainerExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="AppxSymbolPackageExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="CleanPackageAction" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="ComFilesOutputGroupDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="CopyLocalFilesOutputGroupDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="CopyWinmdArtifactsOutputGroupDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="GetPackagingOutputsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="OsVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="PackageAction" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="PlatformSpecificBundleArtifactsListDirInProjectDir" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="PlatformSpecificBundleArtifactsListDirWasSpecified" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="PrepareForRunDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="PrepareLayoutDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="ProduceAppxBundle" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="RebuildPackageAction" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="ValidatePresenceOfAppxManifestItemsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-
-    <!-- TODO: Remove once Windows Phone SDK starts shipping StoreManifest.xsd -->
-    <xs:element name="VSINSTALLDIR" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-    <xs:element name="_StoreManifestSchemaDir" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
-
-    <!-- ================ -->
-    <!-- Packaging items. -->
-    <!-- ================ -->
-
-    <xs:complexType name="SchemaItemType">
-        <xs:complexContent>
-            <xs:extension base="msb:SimpleItemType">
-                <xs:all>
-                    <xs:element name="NamespaceAlias" minOccurs="1" maxOccurs="1">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="AppxManifestSchema_NamespaceAlias" _locComment="" -->Namespace alias used for this schema.</xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
-                    <xs:element name="NamespaceUri" minOccurs="1" maxOccurs="1">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="AppxManifestSchema_NamespaceUri" _locComment="" -->Namespace URI used for this schema.</xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
-                </xs:all>
-            </xs:extension>
-        </xs:complexContent>
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="NativeReference" _locComment="" -->Reference to a native manifest file, or to a file that contains a native manifest
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Name">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="NativeReference_Name" _locComment="" -->Base name of manifest file
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="HintPath">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="NativeReference_HintPath" _locComment="" -->Relative path to manifest file
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="NativeReference_Include" _locComment="" -->Reference full name
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
-
-    <xs:element name="AppxManifestSchema" type="msb:SchemaItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxManifestSchema" _locComment="" -->App manifest schema file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="StoreManifestSchema" type="msb:SchemaItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="StoreManifestSchema" _locComment="" -->Store manifest schema file.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-        
-    <xs:element name="AppxHashUri" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxHashUri" _locComment="" -->Hash algorithm URI.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="Id" minOccurs="1" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxHashUri_Id" _locComment="" -->Hash algorithm ID corresponding to given hash URI.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-        
-    <xs:element name="PRIResource" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PRIResource" _locComment="" -->String resources to be indexed in app package's resource index.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="DependentUpon" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="PRIResource_DependentUpon" _locComment="" -->Notional path within project to indicate parent item of the current item (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Link" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="PRIResource_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Visible" minOccurs="0" maxOccurs="1" type="msb:boolean">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="PRIResource_Visible" _locComment="" -->Display in user interface (optional, boolean).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="AppxSystemBinary" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxSystemBinary" _locComment="" -->Name of any file which is present on the machine and should not be part of the app payload.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxReservedFileName" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxReservedFileName" _locComment="" -->Reserved file name which cannot appear in the app package.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-    
-    <xs:element name="AppxManifestFileNameQuery" type="msb:SimpleItemType" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxManifestFileNameQuery" _locComment="" -->XPath queries used to extract file names from the app manifest.</xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="AppxManifestImageFileNameQuery" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxManifestImageFileNameQuery" _locComment="" -->XPath queries used to define image files in the app manifest and restrictions on them.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="DescriptionID" minOccurs="1" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestImageFileNameQuery_DescriptionID" _locComment="" -->ID of description string resource describing this type of the image.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="ExpectedScaleDimensions" minOccurs="1" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestImageFileNameQuery_ExpectedScaleDimensions" _locComment="" -->Semicolon-delimited list of expected scale dimensions in format '{scale}:{width}x{height}'.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="ExpectedTargetSizes" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestImageFileNameQuery_ExpectedScaleDimensions" _locComment="" -->Semicolon-delimited list of expected target sizes.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="MaximumFileSize" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestImageFileNameQuery_ExpectedScaleDimensions" _locComment="" -->Maximum file size in bytes.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="AppxManifest" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxManifest" _locComment="" -->app manifest template</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="DependentUpon" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifest_DependentUpon" _locComment="" -->Notional path within project to indicate parent item of the current item (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Link" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifest_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="SubType" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifest_SubType" _locComment="" -->Visual Studio sub-type for this item (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Visible" minOccurs="0" maxOccurs="1" type="msb:boolean">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifest_Visible" _locComment="" -->Display in user interface (optional, boolean).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="StoreAssociationFile" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="StoreAssociationFile" _locComment="" -->A file containing app store association data.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="DependentUpon" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="StoreAssociationFile_DependentUpon" _locComment="" -->Notional path within project to indicate parent item of the current item (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Link" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="StoreAssociationFile_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Visible" minOccurs="0" maxOccurs="1" type="msb:boolean">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="StoreAssociationFile_Visible" _locComment="" -->Display in user interface (optional, boolean).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="AppxManifestMetadata" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="AppxManifestMetadata" _locComment="" -->App manifest metadata item. Can be a literal, or it can be a path to a binary to extract version from.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="Value" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestMetadata_Value" _locComment="" -->Literal value of app manifest metadata to insert into manifest.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Version" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestMetadata_Version" _locComment="" -->Version to be inserted as a value of app manifest metadata to insert into manifest.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Name" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="AppxManifestMetadata_Name" _locComment="" -->Name of app manifest metadata to insert into manifest.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="PlatformVersionDescription" substitutionGroup="msb:Item">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PlatformVersionDescription" _locComment="" -->Platform version description. Used to map between internal OS version and marketing OS version.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPlatformIdentifier" minOccurs="1" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="PlatformVersionDescription_TargetPlatformIdentifier" _locComment="" -->Target platform identifier.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="TargetPlatformVersion" minOccurs="1" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="PlatformVersionDescription_TargetPlatformVersion" _locComment="" -->Target platform version.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="OSVersion" minOccurs="1" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation><!-- _locID_text="PlatformVersionDescription_OSVersion" _locComment="" -->Internal OS version.</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <!-- Following items are declared here to get rid of schema validation warnings,         -->
-    <!-- but are not intended for overriding, so they do not have documentation annotations. --> 
-
-    <xs:element name="_AppxBundleContent" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxBundleMainPackageMapGeneratedFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxBundleMainPackageMapInputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxBundleResourceFileMaps" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxBundleResourcePack" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxBundleSplitResourcesGeneratedFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxBundleSplitResourcesPriPathItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxPriConfigXmlDefaultSnippetItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxPriConfigXmlPackagingSnippetItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_AppxStoreContainer" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_CreateAppStoreBundleContainerInputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_CreateBundleInputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_GenerateAppxPackageRecipeInput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_GenerateCurrentProjectAppxManifestInput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_GenerateProjectPriFileCoreInput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_LayoutFile" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_LibrariesUnfiltered" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_MainPackageToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_OtherPlatformToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PackageLayoutFileSource" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PackageLayoutFileTarget" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PlatformSpecificBundleArtifact" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PowerShellScriptsDestination" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PowerShellScriptsSource" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PriFile" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PriFilesFromPayloadRaw" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_PriFilesToExpand" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_RecursiveProjectArchitecture" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_ResourcePackToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_SymbolPackageToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_TestLayoutSourceFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_TestLayoutTargetFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_UnfilteredAppxPackagePayload" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_UnfilteredRecursiveResolvedSDKReference" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_WinmdFilesFromOtherGroups" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_WinmdFilesFromReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_WinmdFilesFromSDKs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_WinmdFilesFromWinmdArtifacts" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="_WinmdWithImplementation" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="AppxBundlePlatformWithAnyCPU" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="AppxManifestForBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="CustomAppxManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="FileReads" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="FileWrites" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="FinalAppxManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="FinalAppxPackageItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="FinalAppxSymbolPackageItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="FrameworkSdkReference" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="NonFrameworkSdkReference" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="PackagingDirectoryWrites" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="PackagingFileWrites" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="PackagingOutputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="PDBPayload" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="ProjectArchitecture" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="SourceAppxManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-    <xs:element name="UpToDateCheckOutput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
-
-    <xs:element name="AppxPackagePayload" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="ComFilesOutputGroupOutputs" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="CopyWinmdArtifactsOutputGroupOutputs" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="CopyLocalFilesOutputGroupOutput" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="_PackagingOutputsUnexpanded" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" type="msb:StringPropertyType" />
-                        <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="_GetResolvedSDKReferencesOutput" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="_ProjectArchitectureItem" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="_AppxBundleResourceFileMapsIntermediate" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="ResourcePack" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="ProjectPriFile" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="_ProjectArchitectureFromPayload" substitutionGroup="msb:Item">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:all>
-                        <xs:element name="MSBuildSourceProjectFile" minOccurs="0" maxOccurs="1" />
-                    </xs:all>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <!-- ================ -->
-    <!-- Packaging tasks. -->
-    <!-- ================ -->
-    
-    <xs:complexType name="ToolTaskType">
-        <xs:complexContent>
-            <xs:extension base="msb:TaskType">
-                <xs:attribute name="ExitCode" />
-                <xs:attribute name="YieldDuringToolExecution" type="msb:boolean" />
-                <xs:attribute name="UseCommandProcessor" type="msb:boolean" />
-                <xs:attribute name="EchoOff" type="msb:boolean" />
-                <xs:attribute name="ToolExe" />
-                <xs:attribute name="ToolPath" />
-                <xs:attribute name="EnvironmentVariables" />
-                <xs:attribute name="Timeout" />
-                <xs:attribute name="StandardErrorImportance" />
-                <xs:attribute name="StandardOutputImportance" />
-                <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
-            </xs:extension>
-        </xs:complexContent>
+  </xs:element>
+  <xs:element name="ProjectReference" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ProjectReference" _locComment="" -->Reference to another project
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Name">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ProjectReference_Name" _locComment="" -->Friendly display name (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Project">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ProjectReference_Project" _locComment="" -->Project GUID, in the form {00000000-0000-0000-0000-000000000000}
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="ReferenceOutputAssembly" type="msb:boolean">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ProjectReference_Reference" _locComment="" -->Boolean specifying whether the outputs of the project referenced should be passed to the compiler. Default is true.
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="SpecificVersion">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Reference_SpecificVersion" _locComment="" -->Whether the exact version of the assembly should be used.
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Targets">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ProjectReference_Targets" _locComment="" -->Semicolon separated list of targets in the referenced projects that should be built. Default is the value of $(ProjectReferenceBuildTargets) whose default is blank, indicating the default targets.
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="OutputItemType">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ProjectReference_OutputItemType" _locComment="" -->Item type to emit target outputs into. Default is blank. If the Reference metadata is set to "true" (default) then target outputs will become references for the compiler.
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Package"/>
+              <xs:element name="EmbedInteropTypes" type="msb:boolean">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ProjectReference_EmbedInteropTypes" _locComment="" -->Whether the types in this reference need to embedded into the target assembly - interop asemblies only (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="ProjectReference_Package" _locComment="" -->Path to project file
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
-
-    <xs:element name="CreateAppStoreContainer" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Items" use="required" />
-                    <xs:attribute name="ProjectName" use="required" />
-                    <xs:attribute name="OutputPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="CreatePriConfigXmlTaskType">
-        <xs:complexContent>
-            <xs:extension base="msb:TaskType">
-                <xs:attribute name="PriConfigXmlPath" use="required" />
-                <xs:attribute name="PriInitialPath" />
-                <xs:attribute name="DefaultResourceLanguage" use="required" />
-                <xs:attribute name="DefaultResourceQualifiers" use="required" />
-                <xs:attribute name="ConvertDotsToSlashes" type="msb:boolean" />
-                <xs:attribute name="IntermediateExtension" use="required" />
-                <xs:attribute name="PriConfigXmlPackagingSnippetPath" />
-                <xs:attribute name="PriConfigXmlDefaultSnippetPath" />
-                <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                <xs:attribute name="TargetPlatformVersion" use="required" />
-            </xs:extension>
-        </xs:complexContent>
+  </xs:element>
+  <xs:element name="Compile" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Compile" _locComment="" -->Source files for compiler
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="SubType"/>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="AutoGen">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Compile_AutoGen" _locComment="" -->Whether file was generated from another file (boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="DesignTime"/>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Compile_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="DesignTimeSharedInput"/>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Compile_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="CopyToOutputDirectory"/>
+              <xs:element name="VBMyExtensionTemplateID"/>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Compile_Include" _locComment="" -->Semi-colon separated list of source files (wildcards are allowed)
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
-
-    <xs:element name="CreatePriConfigXmlTask" type="msb:CreatePriConfigXmlTaskType" substitutionGroup="msb:Task" />
-
-    <xs:element name="CreatePriConfigXmlForFullIndex" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:CreatePriConfigXmlTaskType">
-                    <xs:attribute name="LayoutResfilesPath" use="required" />
-                    <xs:attribute name="ResourcesResfilesPath" use="required" />
-                    <xs:attribute name="PriResfilesPath" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="CreatePriConfigXmlWithPackagingElementTaskType">
-        <xs:complexContent>
-            <xs:extension base="msb:CreatePriConfigXmlTaskType">
-                <xs:attribute name="AppxBundleAutoResourcePackageQualifiers" use="required" />
-            </xs:extension>
-        </xs:complexContent>
+  </xs:element>
+  <xs:element name="EmbeddedResource" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="EmbeddedResource" _locComment="" -->Resources to be embedded in the generated assembly
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="Generator">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="EmbeddedResource_Generator" _locComment="" -->Name of any file generator that is run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="LastGenOutput">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="EmbeddedResource_LastGenOutput" _locComment="" -->File that was created by any file generator that was run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="CustomToolNamespace">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="EmbeddedResource_CustomToolNamespace" _locComment="" -->Namespace into which any file generator that is run on this item should create code
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="EmbeddedResource_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="EmbeddedResource_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="SubType"/>
+              <xs:element name="CopyToOutputDirectory"/>
+              <xs:element name="LogicalName"/>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="EmbeddedResource_Include" _locComment="" -->Semi-colon separated list of resource files (wildcards are allowed)
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
-
-    <xs:element name="CreatePriConfigXmlForMainPackageFileMap" type="msb:CreatePriConfigXmlWithPackagingElementTaskType" substitutionGroup="msb:Task" />
-
-    <xs:element name="CreatePriConfigXmlForSplitting" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:CreatePriConfigXmlWithPackagingElementTaskType">
-                    <xs:attribute name="ResourcesPriFilePath" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="CreatePriFilesForPortableLibraries" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ContentToIndex" use="required" />
-                    <xs:attribute name="MakePriExeFullPath" use="required" />
-                    <xs:attribute name="MakePriExtensionPath" />
-                    <xs:attribute name="IntermediateDirectory" use="required" />
-                    <xs:attribute name="DefaultResourceLanguage" use="required" />
-                    <xs:attribute name="DefaultResourceQualifiers" use="required" />
-                    <xs:attribute name="IntermediateFileWrites" />
-                    <xs:attribute name="CreatedPriFiles" />
-                    <xs:attribute name="IntermediateExtension" use="required" />
-                    <xs:attribute name="AdditionalMakepriExeParameters" />
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="TargetPlatformVersion" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="ExpandPayloadDirectories" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Inputs" use="required" />
-                    <xs:attribute name="Expanded" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="ExpandPriContent" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:ToolTaskType">
-                    <xs:attribute name="Inputs" use="required" />
-                    <xs:attribute name="Expanded" />
-                    <xs:attribute name="IntermediateFileWrites" />
-                    <xs:attribute name="IntermediateDirectory" use="required" />
-                    <xs:attribute name="AdditionalMakepriExeParameters" />
-                    <xs:attribute name="MakePriExeFullPath" use="required" />
-                    <xs:attribute name="MakePriExtensionPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="ExtractHashAlgorithmId" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="StoreAssociationFile" />
-                    <xs:attribute name="HashUris" use="required" />
-                    <xs:attribute name="HashAlgorithmId" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="FilterOutUnusedLanguagesResourceFileMaps" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="FileMaps" use="required" />
-                    <xs:attribute name="FileNamePrefix" use="required" />
-                    <xs:attribute name="MapSuffix" use="required" />
-                    <xs:attribute name="Languages" use="required" />
-                    <xs:attribute name="FilteredFileMaps" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="GenerateAppxManifest" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ApplicationExecutableName" />
-                    <xs:attribute name="AppxManifestInput" use="required" />
-                    <xs:attribute name="CertificateThumbprint" />
-                    <xs:attribute name="CertificateFile" />
-                    <xs:attribute name="PackageArchitecture" use="required" />
-                    <xs:attribute name="FrameworkSdkReferences" use="required" />
-                    <xs:attribute name="NonFrameworkSdkReferences" use="required" />
-                    <xs:attribute name="AppxManifestOutput" use="required" />
-                    <xs:attribute name="DefaultResourceLanguage" use="required" />
-                    <xs:attribute name="QualifiersPath" use="required" />
-                    <xs:attribute name="ManagedWinmdInprocImplementation" use="required" />
-                    <xs:attribute name="WinmdFiles" use="required" />
-                    <xs:attribute name="SDKWinmdFiles" use="required" />
-                    <xs:attribute name="OSMinVersion" />
-                    <xs:attribute name="OSMaxVersionTested" />
-                    <xs:attribute name="OSMinVersionReplaceManifestVersion" type="msb:boolean" />
-                    <xs:attribute name="OSMaxVersionTestedReplaceManifestVersion" type="msb:boolean" />
-                    <xs:attribute name="EnableSigningChecks" type="msb:boolean" />
-                    <xs:attribute name="ManifestMetadata" />
-                    <xs:attribute name="TargetPlatformIdentifier" />
-                    <xs:attribute name="PackageSigningEnabled" type="msb:boolean" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="GenerateAppxPackageRecipe" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AppxManifestXml" use="required" />
-                    <xs:attribute name="SourceAppxManifest" use="required" />
-                    <xs:attribute name="SolutionConfiguration" use="required" />
-                    <xs:attribute name="PayloadFiles" use="required" />
-                    <xs:attribute name="FrameworkSdkPackages" use="required" />
-                    <xs:attribute name="RecipeFile" use="required" />
-                    <xs:attribute name="SystemBinaries" use="required" />
-                    <xs:attribute name="ReservedFileNames" use="required" />
-                    <xs:attribute name="QueryNamespacePrefix" use="required" />
-                    <xs:attribute name="QueryNamespace81Prefix" use="required" />
-                    <xs:attribute name="ManifestFileNameQueries" use="required" />
-                    <xs:attribute name="ManifestImageFileNameQueries" use="required" />
-                    <xs:attribute name="PackageArchitecture" use="required" />
-                    <xs:attribute name="ProjectDir" use="required" />
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="IndexedPayloadFiles" />
-                    <xs:attribute name="MakePriExtensionPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="GenerateAppxSymbolPackage" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="PdbCopyExeFullPath" use="required" />
-                    <xs:attribute name="PdbFiles" use="required" />
-                    <xs:attribute name="StrippedDirectory" use="required" />
-                    <xs:attribute name="AppxSymbolPackageOutput" use="required" />
-                    <xs:attribute name="ProjectName" use="required" />
-                    <xs:attribute name="StrippedPdbs" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="GeneratePriConfigurationFiles" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="LayoutResfilesPath" use="required" />
-                    <xs:attribute name="ResourcesResfilesPath" use="required" />
-                    <xs:attribute name="PriResfilesPath" use="required" />
-                    <xs:attribute name="LayoutFiles" use="required" />
-                    <xs:attribute name="PRIResourceFiles" use="required" />
-                    <xs:attribute name="PriFiles" use="required" />
-                    <xs:attribute name="IntermediateExtension" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GenerateProjectArchitecturesFile" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ProjectArchitectures" use="required" />
-                    <xs:attribute name="ProjectArchitecturesFilePath" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GenerateProjectPriFile" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:ToolTaskType">
-                    <xs:attribute name="MakePriExeFullPath" use="required" />
-                    <xs:attribute name="PriConfigXmlPath" use="required" />
-                    <xs:attribute name="IndexFilesForQualifiersCollection" />
-                    <xs:attribute name="ProjectPriIndexName" use="required" />
-                    <xs:attribute name="MappingFileFormat" />
-                    <xs:attribute name="InsertReverseMap" />
-                    <xs:attribute name="ProjectDirectory" use="required" />
-                    <xs:attribute name="OutputFileName" use="required" />
-                    <xs:attribute name="MakePriExtensionPath" />
-                    <xs:attribute name="QualifiersPath" />
-                    <xs:attribute name="GeneratedFilesListPath" />
-                    <xs:attribute name="AdditionalMakepriExeParameters" />
-                    <xs:attribute name="MultipleQualifiersPerDimensionFoundPath" />
-                    <xs:attribute name="IntermediateExtension" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GetAppxBundlePlatforms" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Input" use="required" />
-                    <xs:attribute name="PackageArchitecture" use="required" />
-                    <xs:attribute name="Platforms" />
-                    <xs:attribute name="Last" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GetDefaultResourceLanguage" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="DefaultLanguage" />
-                    <xs:attribute name="SourceAppxManifest" />
-                    <xs:attribute name="DefaultResourceLanguage" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GetFrameworkSdkPackages" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="FrameworkSdkReferences" use="required" />
-                    <xs:attribute name="FrameworkSdkPackages" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="GetPackageArchitecture" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Platform" use="required" />
-                    <xs:attribute name="ProjectArchitecture" use="required" />
-                    <xs:attribute name="RecursiveProjectArchitecture" use="required" />
-                    <xs:attribute name="PackageArchitecture" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GetSdkPropertyValue" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="TargetPlatformVersion" use="required" />
-                    <xs:attribute name="TargetPlatformSdkRootOverride" />
-                    <xs:attribute name="PropertyName" use="required" />
-                    <xs:attribute name="PropertyValue" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GetSdkToolFullPath" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="ToolName" use="required" />
-                    <xs:attribute name="ToolFullPath" />
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="TargetPlatformVersion" use="required" />
-                    <xs:attribute name="TargetPlatformSdkRootOverride" />
-                    <xs:attribute name="MSBuildArchitecture" />
-                    <xs:attribute name="ActualToolFullPath" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="GetWindowsDesktopSdkDir" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="TargetPlatformVersion" use="required" />
-                    <xs:attribute name="TargetPlatformSdkRootOverride" />
-                    <xs:attribute name="WindowsDesktopSdkDir" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="MakeAppxType">
-        <xs:complexContent>
-            <xs:extension base="msb:ToolTaskType">
-                <xs:attribute name="MakeAppxExeFullPath" use="required" />
-                <xs:attribute name="Parameters" />
-            </xs:extension>
-        </xs:complexContent>
+  </xs:element>
+  <xs:element name="Content" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Content" _locComment="" -->Files that are not compiled, but may be embedded or published
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="Generator">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Content_Generator" _locComment="" -->Name of any file generator that is run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="LastGenOutput"/>
+              <xs:element name="CustomToolNamespace"/>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Content_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Group"/>
+              <xs:element name="PublishState">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Content_PublishState" _locComment="" -->Default, Included, Excluded, DataFile, or Prerequisite
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="IsAssembly"/>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Content_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="SubType"/>
+              <xs:element name="CopyToOutputDirectory">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Content_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Content_Include" _locComment="" -->Semi-colon separated list of content files (wildcards are allowed)
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
-
-    <xs:complexType name="MakeAppxWithOutputType">
-        <xs:complexContent>
-            <xs:extension base="msb:MakeAppxType">
-                <xs:attribute name="Output" use="required" />
-            </xs:extension>
-        </xs:complexContent>
+  </xs:element>
+  <xs:element name="Page" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Page" _locComment="" -->XAML files that are converted to binary and compiled into the assembly
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="Generator">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Page_Generator" _locComment="" -->Name of any file generator that is run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="LastGenOutput"/>
+              <xs:element name="CustomToolNamespace"/>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Page_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Group"/>
+              <xs:element name="SubType"/>
+              <xs:element name="CopyToOutputDirectory">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Page_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Page_Include" _locComment="" -->Semi-colon separated list of XAML files (wildcards are allowed)
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
+  </xs:element>
+  <xs:element name="Resource" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Resource" _locComment="" -->File that is compiled into the assembly
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="Generator">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Resource_Generator" _locComment="" -->Name of any file generator that is run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="LastGenOutput"/>
+              <xs:element name="CustomToolNamespace"/>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Resource_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Group"/>
+              <xs:element name="SubType"/>
+              <xs:element name="CopyToOutputDirectory">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="Resource_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Resource_Include" _locComment="" -->Semi-colon separated list of files (wildcards are allowed)
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ApplicationDefinition" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ApplicationDefinition" _locComment="" -->XAML file that contains the application definition, only one can be defined
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="Generator">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ApplicationDefinition_Generator" _locComment="" -->Name of any file generator that is run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="LastGenOutput"/>
+              <xs:element name="CustomToolNamespace"/>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ApplicationDefinition_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Group"/>
+              <xs:element name="SubType"/>
+              <xs:element name="CopyToOutputDirectory">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="ApplicationDefinition_CopyToOutputDirectory" _locComment="" -->Copy file to output directory (optional, boolean, default false)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="None" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="None" _locComment="" -->Files that should have no role in the build process
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="DependentUpon"/>
+              <xs:element name="Generator">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="None_Generator" _locComment="" -->Name of any file generator that is run on this item
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="LastGenOutput"/>
+              <xs:element name="CustomToolNamespace"/>
+              <xs:element name="Link">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="None_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="None_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="CopyToOutputDirectory"/>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BaseApplicationManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="BaseApplicationManifest" _locComment="" -->The base application manifest for the build. Contains ClickOnce security information.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Folder" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Folder" _locComment="" -->Folder on disk
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Import" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Import" _locComment="" -->Assemblies whose namespaces should be imported by the Visual Basic compiler
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Service" type="msb:SimpleItemType" substitutionGroup="msb:Item"/>
+  <xs:element name="WebReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="WebReferences" _locComment="" -->Name of Web References folder to display in user interface
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="WebReferenceUrl" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="WebReferenceUrl" _locComment="" -->Represents a reference to a web service
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="UrlBehavior"/>
+              <xs:element name="RelPath"/>
+              <xs:element name="UpdateFromURL"/>
+              <xs:element name="ServiceLocationURL"/>
+              <xs:element name="CachedDynamicPropName"/>
+              <xs:element name="CachedAppSettingsObjectName"/>
+              <xs:element name="CachedSettingsPropName"/>
+            </xs:choice>
+          </xs:sequence>
+          <!-- redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="WebReferenceUrl_Include" _locComment="" -->URL to web service
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FileAssociation" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="FileAssociation_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="DefaultIcon"/>
+              <xs:element name="Description"/>
+              <xs:element name="Progid"/>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BootstrapperFile" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="BootstrapperFile_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="ProductName"/>
+              <xs:element name="Install"/>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PublishFile" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+              <xs:element name="Visible">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PublishFile_InProject" _locComment="" -->Display in user interface (optional, boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Group"/>
+              <xs:element name="IncludeHash">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PublishFile_IncludeHash" _locComment="" -->(boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="IsAssembly">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PublishFile_IsAssembly" _locComment="" -->(boolean)
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="PublishState">
+                <xs:annotation>
+                  <xs:documentation>
+                    <!-- _locID_text="PublishFile_PublishState" _locComment="" -->Default, Included, Excluded, DataFile, ManifestEntryPoint, or Prerequisite
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:choice>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TargetPlatform" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="TargetPlatform" _locComment="" -->Target platform in the form of "[Identifier], Version=[Version]", for example, "Windows, Version=8.0"
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Analyzer" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Analyzer" _locComment="" -->An assembly containing diagnostic analyzers
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <!-- redefine Include to make it required, and to give a specific description. -->
+          <xs:attribute name="Include" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="Analyzer_Include" _locComment="" -->Relative or absolute path to the assembly (required)
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ======================== PROPERTIES =====================================-->
+  <!-- Possible Types include StringPropertyType (text with no subelements), GenericPropertyType (any content), or something more specific.-->
 
-    <xs:element name="MakeAppxBundle" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:MakeAppxWithOutputType">
-                    <xs:attribute name="BundleDir" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+  <xs:element name="VisualStudioVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="MinimumVisualStudioVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AdditionalFileItemNames" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AllowUnsafeBlocks" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AppConfigForCompiler" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ApplicationIcon" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ApplicationRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ApplicationRevision" _locComment="" -->integer
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ApplicationVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ApplicationVersion" _locComment="" -->Matches the expression "\d\.\d\.\d\.(\d|\*)"
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AppDesignerFolder" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppDesignerFolder" _locComment="" -->Name of folder for Application Designer
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AspNetConfiguration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AssemblyKeyContainerName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AssemblyKeyProviderName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AssemblyName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AssemblyName" _locComment="" -->Name of output assembly
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AssemblyOriginatorKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AssemblyOriginatorKeyFileType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AssemblyOriginatorKeyMode" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AssemblyType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="AutoGenerateBindingRedirects" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AutorunEnabled" _locComment="" -->Indicates whether BindingRedirect elements should be automatically generated for referenced assemblies.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AutorunEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AutorunEnabled" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="BaseAddress" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="BootstrapperComponentsLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="BootstrapperComponentsLocation" _locComment="" -->HomeSite, Relative, or Absolute
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="BootstrapperComponentsUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="BootstrapperEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="BootstrapperEnabled" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CharacterSet" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="CheckForOverflowUnderflow" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="CLRSupport" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UseDebugLibraries" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="CodePage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="Configuration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ConfigurationName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ConfigurationOverrideFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="CreateDesktopShortcut" type="msb:boolean" substitutionGroup="msb:Property" />
+  <xs:element name="CreateWebPageOnPublish" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CreateWebPageOnPublish" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CurrentSolutionConfigurationContents" type="msb:GenericPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DebugSecurityZoneURL" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DebugSymbols" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DebugSymbols" _locComment="" -->Whether to emit symbols (boolean)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DebugType" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DebugType" _locComment="" -->none, pdbonly, or full
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DefaultClientScript" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DefaultHTMLPageLayout" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DefaultTargetSchema" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DefineConstants" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DefineDebug" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DefineDebug" _locComment="" -->Whether DEBUG is defined (boolean)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DefineTrace" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DefineTrace" _locComment="" -->Whether TRACE is defined (boolean)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DelaySign" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DisableLangXtns" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DisallowUrlActivation" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DisallowUrlActivation" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisAdditionalOptions" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisAdditionalOptions" _locComment="" -->Additional options to pass to the Code Analysis command line tool.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisApplyLogFileXsl" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisApplyLogFileXsl" _locComment="" -->Indicates whether to apply the XSL style sheet specified in $(CodeAnalysisLogFileXsl) to the Code Analysis report. This report is specified in $(CodeAnalysisLogFile). The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisConsoleXsl" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisConsoleXsl" _locComment="" -->Path to the XSL style sheet that will be applied to the Code Analysis console output. The default is an empty string (''), which causes Code Analysis to use its default console output.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisCulture" _locComment="" -->Culture to use for Code Analysis spelling rules, for example, 'en-US' or 'en-AU'. The default is the current user interface language for Windows.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisDependentAssemblyPaths" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisDependentAssemblyPaths" _locComment="" -->Additional reference assembly paths to pass to the Code Analysis command line tool.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <!-- Redefine Include to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="CodeAnalysisDependentAssemblyPaths_Include" _locComment="" -->A fully qualified path to a directory containing reference assemblies to be used by Code Analysis.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CodeAnalysisDictionary" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisDictionary" _locComment="" -->Code Analysis custom dictionaries.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <!-- Redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="CodeAnalysisDictionary_Include" _locComment="" -->Semicolon-separated list of Code Analysis custom dictionaries. Wildcards are allowed.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CodeAnalysisFailOnMissingRules" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisFailOnMissingRules" _locComment="" -->Indicates whether Code Analysis should fail if a rule or rule set is missing. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisForceOutput" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisForceOutput" _locComment="" -->Indicates whether Code Analysis generates a report file, even when there are no active warnings or errors. The default is true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisGenerateSuccessFile" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisGenerateSuccessFile" _locComment="" -->Indicates whether Code Analysis generates a '$(CodeAnalysisInputAssembly).lastcodeanalysissucceeded' file in the output folder when no build-breaking errors occur. The default is true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisIgnoreBuiltInRules" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisIgnoreBuiltInRules" _locComment="" -->Indicates whether Code Analysis will ignore the default rule directories when searching for rules. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisIgnoreBuiltInRuleSets" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisIgnoreBuiltInRuleSets" _locComment="" -->Indicates whether Code Analysis will ignore the default rule set directories when searching for rule sets. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisIgnoreInvalidTargets" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisIgnoreInvalidTargets" _locComment="" -->Indicates whether Code Analysis should silently fail when analyzing invalid assemblies, such as those without managed code. The default is true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisIgnoreGeneratedCode" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisIgnoreGeneratedCode" _locComment="" -->Indicates whether Code Analysis should fail silently when it analyzes invalid assemblies, such as those without managed code. The default is true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisImport" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisImport" _locComment="" -->Code Analysis projects (*.fxcop) or reports to import.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <!-- Redefine Include just to give a specific description -->
+          <xs:attribute name="Include" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="CodeAnalysisImport_Include" _locComment="" -->Semicolon-separated list of Code Analysis projects (*.fxcop) or reports to import. Wildcards are allowed.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CodeAnalysisInputAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisInputAssembly" _locComment="" -->Path to the assembly to be analyzed by Code Analysis. The default is '$(OutDir)$(TargetName)$(TargetExt)'.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisLogFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisLogFile" _locComment="" -->Path to the output file for the Code Analysis report. The default is '$(CodeAnalysisInputAssembly).CodeAnalysisLog.xml'.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisLogFileXsl" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisLogFileXsl" _locComment="" -->Path to the XSL style sheet to reference in the Code Analysis output report. This report is specified in $(CodeAnalysisLogFile). The default is an empty string ('').
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisModuleSuppressionsFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisModuleSuppressionsFile" _locComment="" -->Name of the file, without the path, where Code Analysis project-level suppressions are stored. The default is 'GlobalSuppressions$(DefaultLanguageSourceExtension)'.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisOverrideRuleVisibilities" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisOverrideRuleVisibilities" _locComment="" -->Indicates whether to run all overridable Code Analysis rules against all targets. This will cause specific rules, such as those within the Design and Naming categories, to run against both public and internal APIs, instead of only public APIs. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisOutputToConsole" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisOutputToConsole" _locComment="" -->Indicates whether to output Code Analysis warnings and errors to the console. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisVerbose" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisVerbose" _locComment="" -->Indicates whether to output verbose Code Analysis diagnostic info to the console. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisPath" _locComment="" -->Path to the Code Analysis installation folder. The default is '$(VSINSTALLDIR)\Team Tools\Static Analysis Tools\FxCop'.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisPlatformPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisPlatformPath" _locComment="" -->Path to the .NET Framework folder that contains platform assemblies, such as mscorlib.dll and System.dll. The default is an empty string ('').
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisProject" type="msb:StringPropertyType"  substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisProject" _locComment="" -->Path to the Code Analysis project (*.fxcop) to load. The default is an empty string ('').
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisQuiet" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisQuiet" _locComment="" -->Indicates whether to suppress all Code Analysis console output other than errors and warnings. This applies when $(CodeAnalysisOutputToConsole) is true. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisRuleAssemblies" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisRuleAssemblies" _locComment="" -->Semicolon-separated list of paths either to Code Analysis rule assemblies or to folders that contain Code Analysis rule assemblies. The paths are in the form '[+|-][!][file|folder]', where '+' enables all rules in rule assembly, '-' disables all rules in rule assembly, and '!' causes all rules in rule assembly to be treated as errors. For example '+D:\Projects\Rules\NamingRules.dll;+!D:\Projects\Rules\SecurityRules.dll'. The default is '$(CodeAnalysisPath)\Rules'.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisRuleDirectories" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisRuleDirectories" _locComment="" -->Semicolon-separated list of directories in which to search for rules when resolving a rule set. The default is '$(CodeAnalysisPath)\Rules' unless the CodeAnalysisIgnoreBuiltInRules property is set to true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisRules" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisRules" _locComment="" -->Semicolon-separated list of Code Analysis rules. The rules are in the form '[+|-][!]Category#CheckId', where '+' enables the rule, '-' disables the rule, and '!' causes the rule to be treated as an error. For example, '-Microsoft.Naming#CA1700;+!Microsoft.Naming#CA1701'. The default is an empty string ('') which enables all rules.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisRuleSet" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisRuleSet" _locComment="" -->A .ruleset file which contains a list of rules to run during analysis. The string can be a full path, a path relative to the project file, or a file name. If a file name is specified, the CodeAnalysisRuleSetDirectories property will be searched to find the file. The default is an empty string ('').
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisRuleSetDirectories" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisRuleSetDirectories" _locComment="" -->Semicolon-separated list of directories in which to search for rule sets. The default is '$(VSINSTALLDIR)\Team Tools\Static Analysis Tools\Rule Sets' unless the CodeAnalysisIgnoreBuiltInRuleSets property is set to true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisSaveMessagesToReport" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisSaveMessagesToReport" _locComment="" -->Comma-separated list of the type ('Active', 'Excluded', or 'Absent') of warnings and errors to save to the output report file. The default is 'Active'.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisSearchGlobalAssemblyCache" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisSearchGlobalAssemblyCache" _locComment="" -->Indicates whether Code Analysis should search the Global Assembly Cache (GAC) for missing references that are encountered during analysis. The default is true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisSummary" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisSummary" _locComment="" -->Indicates whether to output a Code Analysis summary to the console after analysis. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisTimeout" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisTimeout" _locComment="" -->The time, in seconds, that Code Analysis should wait for analysis of a single item to complete before it aborts analysis. Specify 0 to cause Code Analysis to wait indefinitely. The default is 120.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisTreatWarningsAsErrors" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisTreatWarningsAsErrors" _locComment="" -->Indicates whether to treat all Code Analysis warnings as errors. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisUpdateProject" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisUpdateProject" _locComment="" -->Indicates whether to update the Code Analysis project (*.fxcop) specified in $(CodeAnalysisProject). This applies when there are changes during analysis. The default is false.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CodeAnalysisUseTypeNameInSuppression" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="CodeAnalysisUseTypeNameInSuppression" _locComment="" -->Indicates whether to include the name of the rule when Code Analysis emits a suppression. The default is true.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ConfigurationType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DeployDirSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="DisableFastUpToDateCheck" type="msb:boolean" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DisableFastUpToDateCheck" _locComment="" -->Whether Visual Studio should do its own faster up-to-date check before Building, rather than invoke MSBuild to do a possibly more accurate one. You would set this to false if you have a heavily customized build process and builds in Visual Studio are not occurring when they should.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DocumentationFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="EnableASPDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="EnableASPXDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="EnableSQLServerDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="EnableSecurityDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="EnableUnmanagedDebugging" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ErrorLog" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ErrorReport" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="EmbedManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ErrorReportUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ExcludeDeploymentUrl" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="ExcludedPermissions" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="FallbackCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="FileAlignment" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="FileUpgradeFlags" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="FormFactorID" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="FrameworkPathOverride" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="FrameworkPathOverride" _locComment="" -->Sets the /sdkpath switch for a VB project to the specified value
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="GenerateManifests" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="GenerateLibraryLayout" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="DisableXbfGeneration" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="SuppressXamlWarnings" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="XamlRootsLog" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="XamlSavedStateFilePath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="GenerateSerializationAssemblies" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="HostInBrowser" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="IgnoreImportLibrary" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="Install" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="InstallFrom" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="InstallFrom" _locComment="" -->Web, Unc, or Disk
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="IsCodeSharingProject" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="IsWebBootstrapper" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="JCPA" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="Keyword" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="LangVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="VBRuntime" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="Prefer32Bit" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="HighEntropyVA" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="LinkIncremental" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ManifestCertificateThumbprint" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ManifestKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="MapFileExtensions" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="MapFileExtensions" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MinimumRequiredVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="MinimumRequiredVersion" _locComment="" -->Matches the expression "\d\.\d\.\d\.\d"
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MyType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="MSBuildAllProjects" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="NoConfig" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="NoStandardLibraries" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="NoStdLib" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="NoStdLib" _locComment="" -->Whether standard libraries (such as mscorlib) should be referenced automatically (boolean)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="NoWarn" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="NoWarn" _locComment="" -->Comma separated list of disabled warnings
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OldToolsVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="OutDir" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetExt" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="OpenBrowserOnPublish" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OpenBrowserOnPublish" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Optimize" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Optimize" _locComment="" -->Should compiler optimize output (boolean)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OptionCompare" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OptionCompare" _locComment="" -->Option Compare setting (Text or Binary)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OptionExplicit" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OptionExplicit" _locComment="" -->Should Option Explicit be set (On or Off)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OptionStrict" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OptionStrict" _locComment="" -->Should Option Strict be set (On or Off)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OptionInfer" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OptionInfer" _locComment="" -->Should Option Infer be set (On or Off)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OSVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="OutputPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OutputPath" _locComment="" -->Path to output folder, with trailing slash
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OutputType" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OutputType" _locComment="" -->Type of output to generate (WinExe, Exe, or Library)
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Platform" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PlatformName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PlatformFamilyName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PlatformID" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PlatformTarget" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PlatformToolset" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PostBuildEvent" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PostBuildEvent" _locComment="" -->Command line to be run at the end of build
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PreBuildEvent" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PreBuildEvent" _locComment="" -->Command line to be run at the start of build
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ProductName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ProductVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ProjectGuid" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ProjectType" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ProjectTypeGuids" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PublisherName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="PublishUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="RecursePath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ReferencePath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ReferencePath" _locComment="" -->Semi-colon separated list of folders to search during reference resolution
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterForComInterop" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="RemoteDebugEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="RemoteDebugMachine" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="RemoveIntegerChecks" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ReportAnalyzer" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="ResponseFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="RootNamespace" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SccProjectName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SccLocalPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SccProvider" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="RunCodeAnalysis" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="RunCodeAnalysis" _locComment="" -->Indicates whether to run Code Analysis during the build.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RunPostBuildEvent" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SchemaVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SecureScoping" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SignAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SignManifests" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SolutionDir" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SolutionExt" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SolutionFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SolutionName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SolutionPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartAction" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartArguments" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartPage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartProgram" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartURL" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartWithIE" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartWorkingDirectory" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="StartupObject" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="StartupObject" _locComment="" -->Type that contains the main entry point
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="SuiteName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="SupportUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetFrameworkProfile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetCulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetFrameworkVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetPlatformIdentifier" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetPlatformVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TargetZone" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TreatWarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="TrustUrlParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="TrustUrlParameters" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="TypeComplianceDiagnostics" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UICulture" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UpgradeBackupLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UpdateEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UpdateEnabled" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UpdateInterval" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UpdateIntervalUnits" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UpdateIntervalUnits" _locComment="" -->Hours, Days, or Weeks
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UpdateMode" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UpdateMode" _locComment="" -->Foreground or Background
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UpdatePeriodically" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UpdatePeriodically" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UpdateRequired" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UpdateRequired" _locComment="" -->boolean
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UpdateUrl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UseAppConfigForCompiler" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="UseApplicationTrust" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UseOfMfc" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UseOfAtl" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UseVSHostingProcess" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="UTF8OutPut" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="VCTargetsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="VSTO_TrustAssembliesLocation" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="WarningLevel" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="WarningLevel" _locComment="" -->integer between 0 and 4 inclusive
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="WarningsAsErrors" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="WarningsAsErrors" _locComment="" -->Comma separated list of warning numbers to treat as errors
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="WebPage" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="Win32ResourceFile" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="WholeProgramOptimization" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
 
-    <xs:element name="MakeAppxPack" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:MakeAppxWithOutputType">
-                    <xs:attribute name="ResourcePack" type="msb:boolean" />
-                    <xs:attribute name="ValidateResourcesReferencedByManifest" type="msb:boolean" />
-                    <xs:attribute name="HashAlgorithmId" use="required" />
-                    <xs:attribute name="AppxManifest" />
-                    <xs:attribute name="FileMap" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+  <!-- ======================== TASKS =====================================-->
+  <xs:element name="AL" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AlgorithmId" />
+          <xs:attribute name="BaseAddress" />
+          <xs:attribute name="CompanyName" />
+          <xs:attribute name="Configuration" />
+          <xs:attribute name="Copyright" />
+          <xs:attribute name="Culture" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="Description" />
+          <xs:attribute name="EmbedResources" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="EvidenceFile" />
+          <xs:attribute name="FileVersion" />
+          <xs:attribute name="Flags" />
+          <xs:attribute name="GenerateFullPaths" type="msb:boolean" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LinkResources" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MainEntryPoint" />
+          <xs:attribute name="OutputAssembly" use="required" />
+          <xs:attribute name="Platform" />
+          <xs:attribute name="ProductName" />
+          <xs:attribute name="ProductVersion" />
+          <xs:attribute name="ResponseFiles" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="SourceModules" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="TargetType" />
+          <xs:attribute name="TemplateFile" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="Title" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="Trademark" />
+          <xs:attribute name="Version" />
+          <xs:attribute name="Win32Icon" />
+          <xs:attribute name="Win32Resource" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AspNetCompiler" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AllowPartiallyTrustedCallers" type="msb:boolean" />
+          <xs:attribute name="Clean" type="msb:boolean" />
+          <xs:attribute name="Debug" type="msb:boolean" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="FixedNames" type="msb:boolean" />
+          <xs:attribute name="Force" type="msb:boolean" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MetabasePath" />
+          <xs:attribute name="PhysicalPath" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="TargetFrameworkMoniker" />
+          <xs:attribute name="TargetPath" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="Updateable" type="msb:boolean" />
+          <xs:attribute name="VirtualPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AssignCulture" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Files" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AssignProjectConfiguration" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AssignedProjects" />
+          <xs:attribute name="CurrentProjectConfiguration" />
+          <xs:attribute name="CurrentProjectPlatform" />
+          <xs:attribute name="DefaultToVcxPlatformMapping" />
+          <xs:attribute name="ProjectReferences" use="required" />
+          <xs:attribute name="ResolveConfigurationPlatformUsingMappings" type="msb:boolean" />
+          <xs:attribute name="SolutionConfigurationContents" />
+          <xs:attribute name="UnassignedProjects" />
+          <xs:attribute name="VcxToDefaultPlatformMapping" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AssignTargetPath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Files" />
+          <xs:attribute name="RootFolder" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AxImp" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ActiveXControlName" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="GenerateSource" type="msb:boolean" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="NoLogo" type="msb:boolean" />
+          <xs:attribute name="OutputAssembly" />
+          <xs:attribute name="RuntimeCallableWrapperAssembly" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="Silent" type="msb:boolean" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="Verbose" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CallTarget" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="RunEachTargetSeparately" type="msb:boolean" />
+          <xs:attribute name="Targets" />
+          <xs:attribute name="UseResultsCache" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CombinePath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="BasePath" />
+          <xs:attribute name="CombinedPaths" />
+          <xs:attribute name="Paths" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ConvertToAbsolutePath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AbsolutePaths" />
+          <xs:attribute name="Paths" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Copy" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DestinationFiles" />
+          <xs:attribute name="DestinationFolder" />
+          <xs:attribute name="OverwriteReadOnlyFiles" type="msb:boolean" />
+          <xs:attribute name="Retries" />
+          <xs:attribute name="RetryDelayMilliseconds" />
+          <xs:attribute name="SkipUnchangedFiles" type="msb:boolean" />
+          <xs:attribute name="UseHardlinksIfPossible" type="msb:boolean" />
+          <xs:attribute name="SourceFiles" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CreateCSharpManifestResourceName" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="PrependCultureAsDirectory" type="msb:boolean" />
+          <xs:attribute name="ResourceFiles" use="required" />
+          <xs:attribute name="ResourceFilesWithManifestResourceNames" />
+          <xs:attribute name="RootNamespace" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CreateItem" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AdditionalMetadata" />
+          <xs:attribute name="Exclude" />
+          <xs:attribute name="Include" />
+          <xs:attribute name="PreserveExistingMetadata" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CreateProperty" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Value" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CreateVisualBasicManifestResourceName" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="PrependCultureAsDirectory" type="msb:boolean" />
+          <xs:attribute name="ResourceFiles" use="required" />
+          <xs:attribute name="ResourceFilesWithManifestResourceNames" />
+          <xs:attribute name="RootNamespace" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Csc" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AdditionalLibPaths" />
+          <xs:attribute name="AddModules" />
+          <xs:attribute name="AllowUnsafeBlocks" type="msb:boolean" />
+          <xs:attribute name="BaseAddress" />
+          <xs:attribute name="CheckForOverflowUnderflow" type="msb:boolean" />
+          <xs:attribute name="CodePage" />
+          <xs:attribute name="DebugType" />
+          <xs:attribute name="DefineConstants" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="DisabledWarnings" />
+          <xs:attribute name="DocumentationFile" />
+          <xs:attribute name="EmitDebugInformation" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ErrorReport" />
+          <xs:attribute name="FileAlignment" />
+          <xs:attribute name="GenerateFullPaths" type="msb:boolean" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LangVersion" />
+          <xs:attribute name="LinkResources" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MainEntryPoint" />
+          <xs:attribute name="ModuleAssemblyName" />
+          <xs:attribute name="NoConfig" type="msb:boolean" />
+          <xs:attribute name="NoLogo" type="msb:boolean" />
+          <xs:attribute name="NoStandardLib" type="msb:boolean" />
+          <xs:attribute name="NoWin32Manifest" type="msb:boolean" />
+          <xs:attribute name="Optimize" type="msb:boolean" />
+          <xs:attribute name="OutputAssembly" />
+          <xs:attribute name="PdbFile" />
+          <xs:attribute name="Platform" />
+          <xs:attribute name="References" />
+          <xs:attribute name="Resources" />
+          <xs:attribute name="ResponseFiles" />
+          <xs:attribute name="Sources" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="TargetType" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TreatWarningsAsErrors" type="msb:boolean" />
+          <xs:attribute name="UseHostCompilerIfAvailable" type="msb:boolean" />
+          <xs:attribute name="Utf8Output" type="msb:boolean" />
+          <xs:attribute name="WarningLevel" />
+          <xs:attribute name="WarningsAsErrors" />
+          <xs:attribute name="WarningsNotAsErrors" />
+          <xs:attribute name="Win32Icon" />
+          <xs:attribute name="Win32Manifest" />
+          <xs:attribute name="Win32Resource" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Delete" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DeletedFiles" />
+          <xs:attribute name="Files" use="required" />
+          <xs:attribute name="TreatErrorsAsWarnings" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Error" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Code" />
+          <xs:attribute name="File" />
+          <xs:attribute name="HelpKeyword" />
+          <xs:attribute name="Text" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Exec" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Command" use="required" />
+          <xs:attribute name="CustomErrorRegularExpression" />
+          <xs:attribute name="CustomWarningRegularExpression" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="IgnoreExitCode" type="msb:boolean" />
+          <xs:attribute name="IgnoreStandardErrorWarningFormat" type="msb:boolean" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="Outputs" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="StdErrEncoding" />
+          <xs:attribute name="StdOutEncoding" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="WorkingDirectory" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FindAppConfigFile" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AppConfigFile" />
+          <xs:attribute name="PrimaryList" use="required" />
+          <xs:attribute name="SecondaryList" use="required" />
+          <xs:attribute name="TargetPath" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FindInList" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="CaseSensitive" type="msb:boolean" />
+          <xs:attribute name="FindLastMatch" type="msb:boolean" />
+          <xs:attribute name="ItemFound" />
+          <xs:attribute name="ItemSpecToFind" use="required" />
+          <xs:attribute name="List" use="required" />
+          <xs:attribute name="MatchFileNameOnly" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FindUnderPath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Files" />
+          <xs:attribute name="InPath" />
+          <xs:attribute name="OutOfPath" />
+          <xs:attribute name="Path" use="required" />
+          <xs:attribute name="UpdateToAbsolutePaths" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FormatUrl" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="InputUrl" />
+          <xs:attribute name="OutputUrl" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FormatVersion" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="FormatType" />
+          <xs:attribute name="OutputVersion" />
+          <xs:attribute name="Revision" />
+          <xs:attribute name="Version" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GenerateApplicationManifest" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AssemblyName" />
+          <xs:attribute name="AssemblyVersion" />
+          <xs:attribute name="ClrVersion" />
+          <xs:attribute name="ConfigFile" />
+          <xs:attribute name="Dependencies" />
+          <xs:attribute name="Description" />
+          <xs:attribute name="EntryPoint" />
+          <xs:attribute name="ErrorReportUrl" />
+          <xs:attribute name="FileAssociations" />
+          <xs:attribute name="Files" />
+          <xs:attribute name="HostInBrowser" type="msb:boolean" />
+          <xs:attribute name="IconFile" />
+          <xs:attribute name="InputManifest" />
+          <xs:attribute name="IsolatedComReferences" />
+          <xs:attribute name="ManifestType" />
+          <xs:attribute name="MaxTargetPath" />
+          <xs:attribute name="OSVersion" />
+          <xs:attribute name="OutputManifest" />
+          <xs:attribute name="Platform" />
+          <xs:attribute name="Product" />
+          <xs:attribute name="Publisher" />
+          <xs:attribute name="RequiresMinimumFramework35SP1" type="msb:boolean" />
+          <xs:attribute name="SuiteName" />
+          <xs:attribute name="SupportUrl" />
+          <xs:attribute name="TargetCulture" />
+          <xs:attribute name="TargetFrameworkMoniker" />
+          <xs:attribute name="TargetFrameworkProfile" />
+          <xs:attribute name="TargetFrameworkSubset" />
+          <xs:attribute name="TargetFrameworkVersion" />
+          <xs:attribute name="TrustInfoFile" />
+          <xs:attribute name="UseApplicationTrust" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GenerateBootstrapper" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ApplicationFile" />
+          <xs:attribute name="ApplicationName" />
+          <xs:attribute name="ApplicationRequiresElevation" type="msb:boolean" />
+          <xs:attribute name="ApplicationUrl" />
+          <xs:attribute name="BootstrapperComponentFiles" />
+          <xs:attribute name="BootstrapperItems" />
+          <xs:attribute name="BootstrapperKeyFile" />
+          <xs:attribute name="ComponentsLocation" />
+          <xs:attribute name="ComponentsUrl" />
+          <xs:attribute name="CopyComponents" type="msb:boolean" />
+          <xs:attribute name="Culture" />
+          <xs:attribute name="FallbackCulture" />
+          <xs:attribute name="OutputPath" />
+          <xs:attribute name="Path" />
+          <xs:attribute name="SupportUrl" />
+          <xs:attribute name="Validate" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GenerateDeploymentManifest" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AssemblyName" />
+          <xs:attribute name="AssemblyVersion" />
+          <xs:attribute name="CreateDesktopShortcut" type="msb:boolean" />
+          <xs:attribute name="DeploymentUrl" />
+          <xs:attribute name="Description" />
+          <xs:attribute name="DisallowUrlActivation" type="msb:boolean" />
+          <xs:attribute name="EntryPoint" />
+          <xs:attribute name="ErrorReportUrl" />
+          <xs:attribute name="InputManifest" />
+          <xs:attribute name="Install" type="msb:boolean" />
+          <xs:attribute name="MapFileExtensions" type="msb:boolean" />
+          <xs:attribute name="MaxTargetPath" />
+          <xs:attribute name="MinimumRequiredVersion" />
+          <xs:attribute name="OutputManifest" />
+          <xs:attribute name="Platform" />
+          <xs:attribute name="Product" />
+          <xs:attribute name="Publisher" />
+          <xs:attribute name="SuiteName" />
+          <xs:attribute name="SupportUrl" />
+          <xs:attribute name="TargetCulture" />
+          <xs:attribute name="TargetFrameworkMoniker" />
+          <xs:attribute name="TargetFrameworkVersion" />
+          <xs:attribute name="TrustUrlParameters" type="msb:boolean" />
+          <xs:attribute name="UpdateEnabled" type="msb:boolean" />
+          <xs:attribute name="UpdateInterval" />
+          <xs:attribute name="UpdateMode" />
+          <xs:attribute name="UpdateUnit" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GenerateResource" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AdditionalInputs" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="ExecuteAsTool" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="NeverLockTypeAssemblies" type="msb:boolean" />
+          <xs:attribute name="OutputResources" />
+          <xs:attribute name="PublicClass" type="msb:boolean" />
+          <xs:attribute name="References" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="StateFile" />
+          <xs:attribute name="StronglyTypedClassName" />
+          <xs:attribute name="StronglyTypedFileName" />
+          <xs:attribute name="StronglyTypedLanguage" />
+          <xs:attribute name="StronglyTypedManifestPrefix" />
+          <xs:attribute name="StronglyTypedNamespace" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="UseSourcePath" type="msb:boolean" />
+          <xs:attribute name="ExtractResWFiles" type="msb:boolean" />
+          <xs:attribute name="OutputDirectory" />
+          <xs:attribute name="MSBuildRuntime" />
+          <xs:attribute name="MSBuildArchitecture" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GenerateTrustInfo" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ApplicationDependencies" />
+          <xs:attribute name="BaseManifest" />
+          <xs:attribute name="ExcludedPermissions" />
+          <xs:attribute name="TargetFrameworkMoniker" />
+          <xs:attribute name="TargetZone" />
+          <xs:attribute name="TrustInfoFile" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GetAssemblyIdentity" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Assemblies" />
+          <xs:attribute name="AssemblyFiles" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GetFrameworkPath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Path" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GetFrameworkSdkPath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Path" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GetReferenceAssemblyPaths" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="RootPath" />
+          <xs:attribute name="TargetFrameworkMoniker" />
+          <xs:attribute name="TargetFrameworkMonikerDisplayName" />
+          <xs:attribute name="BypassFrameworkInstallChecks" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="LC" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="LicenseTarget" use="required" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="NoLogo" type="msb:boolean" />
+          <xs:attribute name="OutputDirectory" />
+          <xs:attribute name="OutputLicense" />
+          <xs:attribute name="ReferencedAssemblies" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MakeDir" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Directories" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Message" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Importance" type="msb:importance" />
+          <xs:attribute name="Text" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Move" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DestinationFiles" />
+          <xs:attribute name="DestinationFolder" />
+          <xs:attribute name="OverwriteReadOnlyFiles" type="msb:boolean" />
+          <xs:attribute name="SourceFiles" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MSBuild" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="BuildInParallel" type="msb:boolean" />
+          <xs:attribute name="Projects" use="required" />
+          <xs:attribute name="Properties" />
+          <xs:attribute name="RebaseOutputs" type="msb:boolean" />
+          <xs:attribute name="RunEachTargetSeparately" type="msb:boolean" />
+          <xs:attribute name="SkipNonexistentProjects" type="msb:boolean" />
+          <xs:attribute name="StopOnFirstFailure" type="msb:boolean" />
+          <xs:attribute name="TargetAndPropertyListSeparators" />
+          <xs:attribute name="Targets" />
+          <xs:attribute name="ToolsVersion" />
+          <xs:attribute name="UnloadProjectsOnCompletion" type="msb:boolean" />
+          <xs:attribute name="UseResultsCache" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ReadLinesFromFile" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="File" use="required" />
+          <xs:attribute name="Lines" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RegisterAssembly" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Assemblies" use="required" />
+          <xs:attribute name="AssemblyListFile" />
+          <xs:attribute name="CreateCodeBase" type="msb:boolean" />
+          <xs:attribute name="TypeLibFiles" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveDir" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Directories" use="required" />
+          <xs:attribute name="RemovedDirectories" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveDuplicates" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Filtered" />
+          <xs:attribute name="Inputs" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RequiresFramework35SP1Assembly" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Assemblies" />
+          <xs:attribute name="CreateDesktopShortcut" type="msb:boolean" />
+          <xs:attribute name="DeploymentManifestEntryPoint" />
+          <xs:attribute name="EntryPoint" />
+          <xs:attribute name="ErrorReportUrl" />
+          <xs:attribute name="Files" />
+          <xs:attribute name="ReferencedAssemblies" />
+          <xs:attribute name="RequiresMinimumFramework35SP1" type="msb:boolean" />
+          <xs:attribute name="SigningManifests" type="msb:boolean" />
+          <xs:attribute name="SuiteName" />
+          <xs:attribute name="TargetFrameworkVersion" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ResolveAssemblyReference" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AllowedAssemblyExtensions" />
+          <xs:attribute name="AllowedGlobalAssemblyNamePrefix" />
+          <xs:attribute name="AllowedRelatedFileExtensions" />
+          <xs:attribute name="AppConfigFile" />
+          <xs:attribute name="Assemblies" />
+          <xs:attribute name="AssemblyFiles" />
+          <xs:attribute name="AutoUnify" type="msb:boolean" />
+          <xs:attribute name="CandidateAssemblyFiles" />
+          <xs:attribute name="FilesWritten" />
+          <xs:attribute name="FindDependencies" type="msb:boolean" />
+          <xs:attribute name="FindRelatedFiles" type="msb:boolean" />
+          <xs:attribute name="FindSatellites" type="msb:boolean" />
+          <xs:attribute name="FindSerializationAssemblies" type="msb:boolean" />
+          <xs:attribute name="FullFrameworkAssemblyTables" />
+          <xs:attribute name="FullFrameworkFolders" />
+          <xs:attribute name="FullTargetFrameworkSubsetNames" />
+          <xs:attribute name="IgnoreDefaultInstalledAssemblySubsetTables" type="msb:boolean" />
+          <xs:attribute name="IgnoreDefaultInstalledAssemblyTables" type="msb:boolean" />
+          <xs:attribute name="InstalledAssemblySubsetTables" />
+          <xs:attribute name="InstalledAssemblyTables" />
+          <xs:attribute name="ProfileName" />
+          <xs:attribute name="PublicKeysRestrictedForGlobalLocation" />
+          <xs:attribute name="SearchPaths" use="required" />
+          <xs:attribute name="Silent" type="msb:boolean" />
+          <xs:attribute name="StateFile" />
+          <xs:attribute name="TargetedRuntimeVersion" />
+          <xs:attribute name="TargetFrameworkDirectories" />
+          <xs:attribute name="TargetFrameworkMoniker" />
+          <xs:attribute name="TargetFrameworkMonikerDisplayName" />
+          <xs:attribute name="TargetFrameworkSubsets" />
+          <xs:attribute name="TargetFrameworkVersion" />
+          <xs:attribute name="TargetProcessorArchitecture" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ResolveComReference" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="ExecuteAsTool" type="msb:boolean" />
+          <xs:attribute name="IncludeVersionInInteropName" type="msb:boolean" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="NoClassMembers" type="msb:boolean" />
+          <xs:attribute name="ResolvedAssemblyReferences" />
+          <xs:attribute name="ResolvedFiles" />
+          <xs:attribute name="ResolvedModules" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="StateFile" />
+          <xs:attribute name="TargetFrameworkVersion" />
+          <xs:attribute name="TargetProcessorArchitecture" />
+          <xs:attribute name="TypeLibFiles" />
+          <xs:attribute name="TypeLibNames" />
+          <xs:attribute name="WrapperOutputDirectory" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ResolveKeySource" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AutoClosePasswordPromptShow" />
+          <xs:attribute name="AutoClosePasswordPromptTimeout" />
+          <xs:attribute name="CertificateFile" />
+          <xs:attribute name="CertificateThumbprint" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="ResolvedKeyContainer" />
+          <xs:attribute name="ResolvedKeyFile" />
+          <xs:attribute name="ResolvedThumbprint" />
+          <xs:attribute name="ShowImportDialogDespitePreviousFailures" type="msb:boolean" />
+          <xs:attribute name="SuppressAutoClosePasswordPrompt" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ResolveManifestFiles" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DeploymentManifestEntryPoint" />
+          <xs:attribute name="EntryPoint" />
+          <xs:attribute name="ExtraFiles" />
+          <xs:attribute name="Files" />
+          <xs:attribute name="ManagedAssemblies" />
+          <xs:attribute name="NativeAssemblies" />
+          <xs:attribute name="OutputAssemblies" />
+          <xs:attribute name="OutputDeploymentManifestEntryPoint" />
+          <xs:attribute name="OutputEntryPoint" />
+          <xs:attribute name="OutputFiles" />
+          <xs:attribute name="PublishFiles" />
+          <xs:attribute name="SatelliteAssemblies" />
+          <xs:attribute name="SigningManifests" type="msb:boolean" />
+          <xs:attribute name="TargetCulture" />
+          <xs:attribute name="TargetFrameworkVersion" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ResolveNativeReference" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AdditionalSearchPaths" use="required" />
+          <xs:attribute name="ContainedComComponents" />
+          <xs:attribute name="ContainedLooseEtcFiles" />
+          <xs:attribute name="ContainedLooseTlbFiles" />
+          <xs:attribute name="ContainedPrerequisiteAssemblies" />
+          <xs:attribute name="ContainedTypeLibraries" />
+          <xs:attribute name="ContainingReferenceFiles" />
+          <xs:attribute name="NativeReferences" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ResolveNonMSBuildProjectOutput" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="PreresolvedProjectOutputs" />
+          <xs:attribute name="ProjectReferences" use="required" />
+          <xs:attribute name="ResolvedOutputPaths" />
+          <xs:attribute name="UnresolvedProjectReferences" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SGen" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="BuildAssemblyName" use="required" />
+          <xs:attribute name="BuildAssemblyPath" use="required" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="References" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="SerializationAssembly" />
+          <xs:attribute name="ShouldGenerateSerializer" use="required" type="msb:boolean" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="UseProxyTypes" use="required" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SignFile" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="CertificateThumbprint" use="required" />
+          <xs:attribute name="SigningTarget" use="required" />
+          <xs:attribute name="TimestampUrl" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TlbImp" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AssemblyNamespace" />
+          <xs:attribute name="AssemblyVersion" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="NoLogo" type="msb:boolean" />
+          <xs:attribute name="OutputAssembly" />
+          <xs:attribute name="PreventClassMembers" type="msb:boolean" />
+          <xs:attribute name="SafeArrayAsSystemArray" type="msb:boolean" />
+          <xs:attribute name="SdkToolsPath" />
+          <xs:attribute name="Silent" type="msb:boolean" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="Transform" />
+          <xs:attribute name="TypeLibName" />
+          <xs:attribute name="Verbose" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Touch" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AlwaysCreate" type="msb:boolean" />
+          <xs:attribute name="Files" use="required" />
+          <xs:attribute name="ForceTouch" type="msb:boolean" />
+          <xs:attribute name="Time" />
+          <xs:attribute name="TouchedFiles" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UnregisterAssembly" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Assemblies" />
+          <xs:attribute name="AssemblyListFile" />
+          <xs:attribute name="TypeLibFiles" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UpdateManifest" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ApplicationManifest" use="required" />
+          <xs:attribute name="TargetFrameworkVersion" />
+          <xs:attribute name="ApplicationPath" use="required" />
+          <xs:attribute name="InputManifest" use="required" />
+          <xs:attribute name="OutputManifest" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Vbc" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AdditionalLibPaths" />
+          <xs:attribute name="AddModules" />
+          <xs:attribute name="BaseAddress" />
+          <xs:attribute name="CodePage" />
+          <xs:attribute name="DebugType" />
+          <xs:attribute name="DefineConstants" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="DisabledWarnings" />
+          <xs:attribute name="DocumentationFile" />
+          <xs:attribute name="EmitDebugInformation" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ErrorReport" />
+          <xs:attribute name="FileAlignment" />
+          <xs:attribute name="GenerateDocumentation" type="msb:boolean" />
+          <xs:attribute name="Imports" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LangVersion" />
+          <xs:attribute name="VBRuntime" />
+          <xs:attribute name="LinkResources" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MainEntryPoint" />
+          <xs:attribute name="ModuleAssemblyName" />
+          <xs:attribute name="NoConfig" type="msb:boolean" />
+          <xs:attribute name="NoLogo" type="msb:boolean" />
+          <xs:attribute name="NoStandardLib" type="msb:boolean" />
+          <xs:attribute name="NoVBRuntimeReference" type="msb:boolean" />
+          <xs:attribute name="NoWarnings" type="msb:boolean" />
+          <xs:attribute name="NoWin32Manifest" type="msb:boolean" />
+          <xs:attribute name="Optimize" type="msb:boolean" />
+          <xs:attribute name="OptionCompare" />
+          <xs:attribute name="OptionExplicit" type="msb:boolean" />
+          <xs:attribute name="OptionInfer" type="msb:boolean" />
+          <xs:attribute name="OptionStrict" type="msb:boolean" />
+          <xs:attribute name="OptionStrictType" />
+          <xs:attribute name="OutputAssembly" />
+          <xs:attribute name="Platform" />
+          <xs:attribute name="References" />
+          <xs:attribute name="RemoveIntegerChecks" type="msb:boolean" />
+          <xs:attribute name="Resources" />
+          <xs:attribute name="ResponseFiles" />
+          <xs:attribute name="RootNamespace" />
+          <xs:attribute name="SdkPath" />
+          <xs:attribute name="Sources" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="TargetCompactFramework" type="msb:boolean" />
+          <xs:attribute name="TargetType" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TreatWarningsAsErrors" type="msb:boolean" />
+          <xs:attribute name="UseHostCompilerIfAvailable" type="msb:boolean" />
+          <xs:attribute name="Utf8Output" type="msb:boolean" />
+          <xs:attribute name="Verbosity" />
+          <xs:attribute name="WarningsAsErrors" />
+          <xs:attribute name="WarningsNotAsErrors" />
+          <xs:attribute name="Win32Icon" />
+          <xs:attribute name="Win32Manifest" />
+          <xs:attribute name="Win32Resource" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="VCBuild" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AdditionalLibPaths" />
+          <xs:attribute name="AdditionalLinkLibraryPaths" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="Clean" type="msb:boolean" />
+          <xs:attribute name="Configuration" />
+          <xs:attribute name="Override" />
+          <xs:attribute name="Platform" />
+          <xs:attribute name="Projects" use="required" />
+          <xs:attribute name="Rebuild" type="msb:boolean" />
+          <xs:attribute name="SolutionFile" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="UseEnvironment" type="msb:boolean" />
+          <!-- OBSOLETE: Will be removed in a future version. Use UseEnvironment instead -->
+          <xs:attribute name="UserEnvironment" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Warning" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Code" />
+          <xs:attribute name="File" />
+          <xs:attribute name="HelpKeyword" />
+          <xs:attribute name="Text" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="WcfConfigValidationEnabled" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenCollectionTypes" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenEnabled" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenEnableDataBinding" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenGenerateAsynchronousOperations" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenGenerateDataTypesOnly" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenGenerateInternalTypes" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenGenerateMessageContract" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenGenerateSerializableTypes" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenNamespaceMappings" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenImportXmlTypes" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenReuseTypesFlag" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenReuseTypesMode" substitutionGroup="msb:Property">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="All" />
+        <xs:enumeration value="Partial" />
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="WsdlXsdCodeGenSerializerMode" substitutionGroup="msb:Property">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="XmlSerializer" />
+        <xs:enumeration value="DataContractSerializer" />
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="WsdlXsdCodeGenUseSerializerForFaults" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WsdlXsdCodeGenWrapped" type="msb:boolean" substitutionGroup="msb:Property"/>
+  <xs:element name="WriteCodeFragment" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AssemblyAttributes" />
+          <xs:attribute name="Language" use="required" />
+          <xs:attribute name="OutputDirectory" />
+          <xs:attribute name="OutputFile" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="WriteLinesToFile" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Encoding" />
+          <xs:attribute name="File" use="required" />
+          <xs:attribute name="Lines" />
+          <xs:attribute name="Overwrite" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="XslTransformation" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="OutputPaths" use="required" />
+          <xs:attribute name="Parameters" />
+          <xs:attribute name="XmlContent" />
+          <xs:attribute name="XmlInputPaths" />
+          <xs:attribute name="XslCompiledDllPath" />
+          <xs:attribute name="XslContent" />
+          <xs:attribute name="XslInputPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CodeAnalysis" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AlternativeToolName" />
+          <xs:attribute name="AnalysisTimeout" />
+          <xs:attribute name="ApplyLogFileXsl" type="msb:boolean" />
+          <xs:attribute name="Assemblies" />
+          <xs:attribute name="ConsoleXsl" />
+          <xs:attribute name="Culture" />
+          <xs:attribute name="DependentAssemblyPaths" />
+          <xs:attribute name="Dictionaries" />
+          <xs:attribute name="FilesWritten" />
+          <xs:attribute name="ForceOutput" type="msb:boolean"/>
+          <xs:attribute name="GenerateSuccessFile" type="msb:boolean" />
+          <xs:attribute name="IgnoreInvalidTargets" type="msb:boolean" />
+          <xs:attribute name="IgnoreGeneratedCode" type="msb:boolean" />
+          <xs:attribute name="Imports" />
+          <xs:attribute name="LogFile" />
+          <xs:attribute name="LogFileXsl" />
+          <xs:attribute name="OutputToConsole" type="msb:boolean" />
+          <xs:attribute name="OverrideRuleVisibilities" type="msb:boolean" />
+          <xs:attribute name="PlatformPath" />
+          <xs:attribute name="Project" />
+          <xs:attribute name="Quiet" type="msb:boolean" />
+          <xs:attribute name="References" />
+          <xs:attribute name="RuleAssemblies" />
+          <xs:attribute name="Rules" />
+          <xs:attribute name="SaveMessagesToReport" />
+          <xs:attribute name="SearchGlobalAssemblyCache" type="msb:boolean" />
+          <xs:attribute name="Summary" type="msb:boolean" />
+          <xs:attribute name="SuccessFile" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TreatWarningsAsErrors" type="msb:boolean" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="UpdateProject" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ==================== NATIVE CL/LINK TASKS ==========================-->
+  <xs:element name="CL" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalIncludeDirectories" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="AdditionalUsingDirectories" />
+          <xs:attribute name="AssemblerListingLocation" />
+          <xs:attribute name="AssemblerOutput" />
+          <xs:attribute name="BasicRuntimeChecks" />
+          <xs:attribute name="BrowseInformation" type="msb:boolean" />
+          <xs:attribute name="BrowseInformationFile" />
+          <xs:attribute name="BufferSecurityCheck" type="msb:boolean" />
+          <xs:attribute name="CallingConvention" />
+          <xs:attribute name="CompileAs" />
+          <xs:attribute name="CompileAsManaged" />
+          <xs:attribute name="CreateHotpatchableImage" type="msb:boolean" />
+          <xs:attribute name="DebugInformationFormat" />
+          <xs:attribute name="DisableLanguageExtensions" type="msb:boolean" />
+          <xs:attribute name="DisableSpecificWarnings" />
+          <xs:attribute name="EnableEnhancedInstructionSet" />
+          <xs:attribute name="EnableFiberSafeOptimizations" type="msb:boolean" />
+          <xs:attribute name="EnablePREfast" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ErrorReporting" />
+          <xs:attribute name="ExceptionHandling" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="ExpandAttributedSource" type="msb:boolean" />
+          <xs:attribute name="FavorSizeOrSpeed" />
+          <xs:attribute name="FloatingPointExceptions" type="msb:boolean" />
+          <xs:attribute name="FloatingPointModel" />
+          <xs:attribute name="ForceConformanceInForLoopScope" type="msb:boolean" />
+          <xs:attribute name="ForcedIncludeFiles" />
+          <xs:attribute name="ForcedUsingFiles" />
+          <xs:attribute name="FunctionLevelLinking" type="msb:boolean" />
+          <xs:attribute name="GenerateXMLDocumentationFiles" type="msb:boolean" />
+          <xs:attribute name="IgnoreStandardIncludePath" type="msb:boolean" />
+          <xs:attribute name="InlineFunctionExpansion" />
+          <xs:attribute name="IntrinsicFunctions" type="msb:boolean" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuild" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="MultiProcessorCompilation" type="msb:boolean" />
+          <xs:attribute name="ObjectFileName" />
+          <xs:attribute name="ObjectFiles" />
+          <xs:attribute name="OmitDefaultLibName" type="msb:boolean" />
+          <xs:attribute name="OmitFramePointers" type="msb:boolean" />
+          <xs:attribute name="OpenMPSupport" type="msb:boolean" />
+          <xs:attribute name="Optimization" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="PrecompiledHeader" />
+          <xs:attribute name="PrecompiledHeaderFile" />
+          <xs:attribute name="PrecompiledHeaderOutputFile" />
+          <xs:attribute name="PreprocessKeepComments" type="msb:boolean" />
+          <xs:attribute name="PreprocessorDefinitions" />
+          <xs:attribute name="PreprocessOutput" />
+          <xs:attribute name="PreprocessSuppressLineNumbers" type="msb:boolean" />
+          <xs:attribute name="PreprocessToFile" type="msb:boolean" />
+          <xs:attribute name="ProcessorNumber" />
+          <xs:attribute name="ProgramDataBaseFileName" />
+          <xs:attribute name="RuntimeLibrary" />
+          <xs:attribute name="RuntimeTypeInfo" type="msb:boolean" />
+          <xs:attribute name="ShowIncludes" type="msb:boolean" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="SmallerTypeCheck" type="msb:boolean" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="StringPooling" type="msb:boolean" />
+          <xs:attribute name="StructMemberAlignment" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="TreatSpecificWarningsAsErrors" />
+          <xs:attribute name="TreatWarningAsError" type="msb:boolean" />
+          <xs:attribute name="TreatWChar_tAsBuiltInType" type="msb:boolean" />
+          <xs:attribute name="UndefineAllPreprocessorDefinitions" type="msb:boolean" />
+          <xs:attribute name="UndefinePreprocessorDefinitions" />
+          <xs:attribute name="UseFullPaths" type="msb:boolean" />
+          <xs:attribute name="UseUnicodeForAssemblerListing" type="msb:boolean" />
+          <xs:attribute name="WarningLevel" />
+          <xs:attribute name="WholeProgramOptimization" type="msb:boolean" />
+          <xs:attribute name="XMLDocumentationFileName" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Link" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalDependencies" />
+          <xs:attribute name="AdditionalLibraryDirectories" />
+          <xs:attribute name="AdditionalManifestDependencies" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="AddModuleNamesToAssembly" />
+          <xs:attribute name="AllowIsolation" type="msb:boolean" />
+          <xs:attribute name="AssemblyDebug" type="msb:boolean" />
+          <xs:attribute name="AssemblyLinkResource" />
+          <xs:attribute name="BaseAddress" />
+          <xs:attribute name="CLRImageType" />
+          <xs:attribute name="CLRSupportLastError" />
+          <xs:attribute name="CLRThreadAttribute" />
+          <xs:attribute name="CLRUnmanagedCodeCheck" type="msb:boolean" />
+          <xs:attribute name="CreateHotPatchableImage" />
+          <xs:attribute name="DataExecutionPrevention" type="msb:boolean" />
+          <xs:attribute name="DelayLoadDLLs" />
+          <xs:attribute name="DelaySign" type="msb:boolean" />
+          <xs:attribute name="Driver" />
+          <xs:attribute name="EmbedManagedResourceFile" />
+          <xs:attribute name="EnableCOMDATFolding" type="msb:boolean" />
+          <xs:attribute name="EnableUAC" type="msb:boolean" />
+          <xs:attribute name="EntryPointSymbol" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="FixedBaseAddress" type="msb:boolean" />
+          <xs:attribute name="ForceFileOutput" />
+          <xs:attribute name="ForceSymbolReferences" />
+          <xs:attribute name="FunctionOrder" />
+          <xs:attribute name="GenerateDebugInformation" type="msb:boolean" />
+          <xs:attribute name="GenerateManifest" type="msb:boolean" />
+          <xs:attribute name="GenerateMapFile" type="msb:boolean" />
+          <xs:attribute name="HeapCommitSize" />
+          <xs:attribute name="HeapReserveSize" />
+          <xs:attribute name="IgnoreAllDefaultLibraries" type="msb:boolean" />
+          <xs:attribute name="IgnoreEmbeddedIDL" type="msb:boolean" />
+          <xs:attribute name="IgnoreImportLibrary" type="msb:boolean" />
+          <xs:attribute name="IgnoreSpecificDefaultLibraries" />
+          <xs:attribute name="ImageHasSafeExceptionHandlers" type="msb:boolean" />
+          <xs:attribute name="ImportLibrary" />
+          <xs:attribute name="KeyContainer" />
+          <xs:attribute name="KeyFile" />
+          <xs:attribute name="LargeAddressAware" type="msb:boolean" />
+          <xs:attribute name="LinkDLL" type="msb:boolean" />
+          <xs:attribute name="LinkErrorReporting" />
+          <xs:attribute name="LinkIncremental" type="msb:boolean" />
+          <xs:attribute name="LinkLibraryDependencies" type="msb:boolean" />
+          <xs:attribute name="LinkStatus" type="msb:boolean" />
+          <xs:attribute name="LinkTimeCodeGeneration" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="ManifestFile" />
+          <xs:attribute name="MapExports" type="msb:boolean" />
+          <xs:attribute name="MapFileName" />
+          <xs:attribute name="MergedIDLBaseFileName" />
+          <xs:attribute name="MergeSections" />
+          <xs:attribute name="MidlCommandFile" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="MinimumRequiredVersion" />
+          <xs:attribute name="ModuleDefinitionFile" />
+          <xs:attribute name="MSDOSStubFileName" />
+          <xs:attribute name="NoEntryPoint" type="msb:boolean" />
+          <xs:attribute name="ObjectFiles" />
+          <xs:attribute name="OptimizeReferences" type="msb:boolean" />
+          <xs:attribute name="OutputFile" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="PerUserRedirection" type="msb:boolean" />
+          <xs:attribute name="PreprocessOutput" />
+          <xs:attribute name="PreventDllBinding" type="msb:boolean" />
+          <xs:attribute name="Profile" type="msb:boolean" />
+          <xs:attribute name="ProfileGuidedDatabase" />
+          <xs:attribute name="ProgramDatabaseFile" />
+          <xs:attribute name="RandomizedBaseAddress" type="msb:boolean" />
+          <xs:attribute name="RegisterOutput" type="msb:boolean" />
+          <xs:attribute name="SectionAlignment" />
+          <xs:attribute name="SetChecksum" type="msb:boolean" />
+          <xs:attribute name="ShowProgress" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="SpecifySectionAttributes" />
+          <xs:attribute name="StackCommitSize" />
+          <xs:attribute name="StackReserveSize" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="StripPrivateSymbols" />
+          <xs:attribute name="SubSystem" />
+          <xs:attribute name="SupportNobindOfDelayLoadedDLL" type="msb:boolean" />
+          <xs:attribute name="SupportUnloadOfDelayLoadedDLL" type="msb:boolean" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="SwapRunFromCD" type="msb:boolean" />
+          <xs:attribute name="SwapRunFromNET" type="msb:boolean" />
+          <xs:attribute name="TargetMachine" />
+          <xs:attribute name="TerminalServerAware" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="TreatLinkerWarningAsErrors" type="msb:boolean" />
+          <xs:attribute name="TurnOffAssemblyGeneration" type="msb:boolean" />
+          <xs:attribute name="TypeLibraryFile" />
+          <xs:attribute name="TypeLibraryResourceID" />
+          <xs:attribute name="UACExecutionLevel" />
+          <xs:attribute name="UACUIAccess" type="msb:boolean" />
+          <xs:attribute name="UseLibraryDependencyInputs" type="msb:boolean" />
+          <xs:attribute name="Version" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ======================== NATIVE TASKS ==============================-->
+  <xs:element name="BSCMake" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="OutputFile" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Sources" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CPPClean" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DeletedFiles" />
+          <xs:attribute name="DoDelete" type="msb:boolean" />
+          <xs:attribute name="FilePatternsToDeleteOnClean" use="required" />
+          <xs:attribute name="FilesExcludedFromClean" />
+          <xs:attribute name="FoldersToClean" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="GetOutputFileName" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="OutputExtension" use="required" />
+          <xs:attribute name="OutputFile" />
+          <xs:attribute name="OutputPath" />
+          <xs:attribute name="SourceFile" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IsAssembly" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Assemblies" />
+          <xs:attribute name="AssemblyFiles" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="LIB" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalDependencies" />
+          <xs:attribute name="AdditionalLibraryDirectories" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="DisplayLibrary" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ErrorReporting" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="ExportNamedFunctions" />
+          <xs:attribute name="ForceSymbolReferences" />
+          <xs:attribute name="IgnoreAllDefaultLibraries" type="msb:boolean" />
+          <xs:attribute name="IgnoreSpecificDefaultLibraries" />
+          <xs:attribute name="LinkLibraryDependencies" type="msb:boolean" />
+          <xs:attribute name="LinkTimeCodeGeneration" type="msb:boolean" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="MinimumRequiredVersion" />
+          <xs:attribute name="ModuleDefinitionFile" />
+          <xs:attribute name="OutputFile" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="RemoveObjects" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="SubSystem" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="TargetMachine" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="TreatLibWarningAsErrors" type="msb:boolean" />
+          <xs:attribute name="UseUnicodeResponseFiles" type="msb:boolean" />
+          <xs:attribute name="Verbose" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MIDL" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalIncludeDirectories" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="ApplicationConfigurationMode" type="msb:boolean" />
+          <xs:attribute name="ClientStubFile" />
+          <xs:attribute name="CPreprocessOptions" />
+          <xs:attribute name="DefaultCharType" />
+          <xs:attribute name="DllDataFileName" />
+          <xs:attribute name="EnableErrorChecks" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ErrorCheckAllocations" type="msb:boolean" />
+          <xs:attribute name="ErrorCheckBounds" type="msb:boolean" />
+          <xs:attribute name="ErrorCheckEnumRange" type="msb:boolean" />
+          <xs:attribute name="ErrorCheckRefPointers" type="msb:boolean" />
+          <xs:attribute name="ErrorCheckStubData" type="msb:boolean" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="GenerateClientFiles" />
+          <xs:attribute name="GenerateServerFiles" />
+          <xs:attribute name="GenerateStublessProxies" type="msb:boolean" />
+          <xs:attribute name="GenerateTypeLibrary" type="msb:boolean" />
+          <xs:attribute name="HeaderFileName" />
+          <xs:attribute name="IgnoreStandardIncludePath" type="msb:boolean" />
+          <xs:attribute name="InterfaceIdentifierFileName" />
+          <xs:attribute name="LocaleID" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="MkTypLibCompatible" type="msb:boolean" />
+          <xs:attribute name="OutputDirectory" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="PreprocessorDefinitions" />
+          <xs:attribute name="ProxyFileName" />
+          <xs:attribute name="RedirectOutputAndErrors" />
+          <xs:attribute name="ServerStubFile" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Source" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="StructMemberAlignment" />
+          <xs:attribute name="SuppressCompilerWarnings" type="msb:boolean" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="TargetEnvironment" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="TypeLibFormat" />
+          <xs:attribute name="TypeLibraryName" />
+          <xs:attribute name="UndefinePreprocessorDefinitions" />
+          <xs:attribute name="ValidateAllParameters" type="msb:boolean" />
+          <xs:attribute name="WarnAsError" type="msb:boolean" />
+          <xs:attribute name="WarningLevel" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Mt" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalManifestFiles" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="AssemblyIdentity" />
+          <xs:attribute name="ComponentFileName" />
+          <xs:attribute name="EmbedManifest" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="GenerateCatalogFiles" type="msb:boolean" />
+          <xs:attribute name="GenerateCategoryTags" type="msb:boolean" />
+          <xs:attribute name="InputResourceManifests" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="ManifestFromManagedAssembly" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="OutputManifestFile" />
+          <xs:attribute name="OutputResourceManifests" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="RegistrarScriptFile" />
+          <xs:attribute name="ReplacementsFile" />
+          <xs:attribute name="ResourceOutputFileName" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Sources" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="SuppressDependencyElement" type="msb:boolean" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="TypeLibraryFile" />
+          <xs:attribute name="UpdateFileHashes" type="msb:boolean" />
+          <xs:attribute name="UpdateFileHashesSearchPath" />
+          <xs:attribute name="VerboseOutput" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RC" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalIncludeDirectories" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="Culture" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="IgnoreStandardIncludePath" type="msb:boolean" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="NullTerminateStrings" type="msb:boolean" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="PreprocessorDefinitions" />
+          <xs:attribute name="ResourceOutputFileName" />
+          <xs:attribute name="ShowProgress" type="msb:boolean" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Source" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+          <xs:attribute name="UndefinePreprocessorDefinitions" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SetEnv" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Prefix" use="required" type="msb:boolean" />
+          <xs:attribute name="Target" />
+          <xs:attribute name="Value" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="XDCMake" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalDocumentFile" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="DocumentLibraryDependencies" type="msb:boolean" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="OutputFile" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="ProjectName" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="SlashOld" type="msb:boolean" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="XSD" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AcceptableNonZeroExitCodes" />
+          <xs:attribute name="ActiveToolSwitchesValues" />
+          <xs:attribute name="AdditionalOptions" />
+          <xs:attribute name="EnvironmentVariables" />
+          <xs:attribute name="ExcludedInputPaths" />
+          <xs:attribute name="GenerateFromSchema" />
+          <xs:attribute name="Language" />
+          <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+          <xs:attribute name="MinimalRebuildFromTracking" type="msb:boolean" />
+          <xs:attribute name="Namespace" />
+          <xs:attribute name="PathOverride" />
+          <xs:attribute name="SkippedExecution" type="msb:boolean" />
+          <xs:attribute name="Sources" use="required" />
+          <xs:attribute name="SourcesCompiled" />
+          <xs:attribute name="StandardErrorImportance" />
+          <xs:attribute name="StandardOutputImportance" />
+          <xs:attribute name="SuppressStartupBanner" type="msb:boolean" />
+          <xs:attribute name="Timeout" />
+          <xs:attribute name="TLogReadFiles" />
+          <xs:attribute name="TLogWriteFiles" />
+          <xs:attribute name="ToolExe" />
+          <xs:attribute name="ToolPath" />
+          <xs:attribute name="TrackedInputFilesToIgnore" />
+          <xs:attribute name="TrackedOutputFilesToIgnore" />
+          <xs:attribute name="TrackerLogDirectory" />
+          <xs:attribute name="TrackFileAccess" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="VCMessage" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Code" use="required" />
+          <xs:attribute name="Type" />
+          <xs:attribute name="Arguments" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
 
-    <xs:element name="ParsePlatformSpecificBundleArtifactsLists" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Files" use="required" />
-                    <xs:attribute name="Artifacts" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>    
+  <!-- ============================================================== -->
+  <!-- Elements used and/or defined in Microsoft.AppxPackage.targets. -->
+  <!-- ============================================================== -->
 
-    <xs:element name="RemoveDuplicatePayload" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Inputs" use="required" />
-                    <xs:attribute name="Platform" use="required" />
-                    <xs:attribute name="Filtered" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="RemoveDuplicatePriFiles" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Inputs" use="required" />
-                    <xs:attribute name="Platform" use="required" />
-                    <xs:attribute name="Filtered" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="RemoveDuplicateSDKReferences" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Inputs" use="required" />
-                    <xs:attribute name="Filtered" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="SignAppxPackage" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AppxPackageToSign" use="required" />
-                    <xs:attribute name="CertificateThumbprint" />
-                    <xs:attribute name="CertificateFile" />
-                    <xs:attribute name="HashAlgorithmId" use="required" />
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="TargetPlatformVersion" use="required" />
-                    <xs:attribute name="TargetPlatformSdkRootOverride" />
-                    <xs:attribute name="SignAppxPackageExeFullPath" />
-                    <xs:attribute name="MSBuildArchitecture" />
-                    <xs:attribute name="EnableSigningChecks" type="msb:boolean" />
-                    <xs:attribute name="ExportCertificate" type="msb:boolean" />
-                    <xs:attribute name="ResolvedThumbprint" />
-                    <xs:attribute name="AppxPackagePublicKeyFile" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+  <!-- ===================== -->
+  <!-- Packaging properties. -->
+  <!-- ===================== -->
 
-    <xs:element name="StripPrivateSymbols" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:ToolTaskType">
-                    <xs:attribute name="PdbCopyToolPath" use="required" />
-                    <xs:attribute name="InputPdb" use="required" />
-                    <xs:attribute name="StrippedPdb" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="UpdateAppxManifestForBundle" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="FinalAppxManifest" use="required" />
-                    <xs:attribute name="AppxManifestForBundle" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+  <xs:element name="DefaultLanguage" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="DefaultLanguage" _locComment="" -->Default resource language.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
 
-    <xs:element name="UpdateMainPackageFileMap" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Input" use="required" />
-                    <xs:attribute name="Output" use="required" />
-                    <xs:attribute name="SplitResourcesPriPath" use="required" />
-                    <xs:attribute name="DefaultResourceLanguage" use="required" />
-                    <xs:attribute name="DefaultResourceQualifiers" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="ValidateAppxManifest" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Input" use="required" />
-                    <xs:attribute name="SourceAppxManifest" use="required" />
-                    <xs:attribute name="AppxManifestSchema" use="required" />
-                    <xs:attribute name="StoreAssociationFile" />
-                    <xs:attribute name="TargetPlatformIdentifier" use="required" />
-                    <xs:attribute name="TargetPlatformVersion" use="required" />
-                    <xs:attribute name="OSMinVersion" use="required" />
-                    <xs:attribute name="OSMaxVersionTested" use="required" />
-                    <xs:attribute name="PlatformVersionDescriptions" use="required" />
-                    <xs:attribute name="ResolvedSDKReferences" use="required" />
-                    <xs:attribute name="StrictManifestValidationEnabled" type="msb:boolean" />
-                    <xs:attribute name="ValidateWinmds" type="msb:boolean" />
-                    <xs:attribute name="NonFrameworkSdkReferences" />
-                    <xs:attribute name="WinmdFiles" />
-                    <xs:attribute name="SDKWinmdFiles" />
-                    <xs:attribute name="ManagedWinmdInprocImplementation" />
-                    <xs:attribute name="ValidateManifest" type="msb:boolean" />
-                    <xs:attribute name="Resources" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+  <xs:element name="PackageCertificateKeyFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PackageCertificateKeyFile" _locComment="" -->App package certificate key file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
 
-    <xs:element name="ValidateAppxManifestItems" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="AppxManifestItems" />
-                    <xs:attribute name="CustomAppxManifestItems" />
-                    <xs:attribute name="AppxPackageProject" type="msb:boolean" />
-                    <xs:attribute name="IdentityName" />
-                    <xs:attribute name="IdentityVersion" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="ValidateAppxPackage" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="SourceAppxManifest" use="required" />
-                    <xs:attribute name="AppxManifest" use="required" />
-                    <xs:attribute name="StoreAssociationFile" />
-                    <xs:attribute name="PackageArchitecture" use="required" />
-                    <xs:attribute name="AppxPackagePayload" use="required" />
-                    <xs:attribute name="QueryNamespacePrefix" use="required" />
-                    <xs:attribute name="QueryNamespace81Prefix" use="required" />
-                    <xs:attribute name="ManifestImageFileNameQueries" use="required" />
-                    <xs:attribute name="ResolvedSDKReferences" use="required" />
-                    <xs:attribute name="AllowDebugFrameworkReferencesInManifest" type="msb:boolean" />
-                    <xs:attribute name="ProjectDir" use="required" />
-                    <xs:attribute name="IndexedPayloadFiles" />
-                    <xs:attribute name="MakePriExtensionPath" />
-                    <xs:attribute name="OSMinVersion" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+  <xs:element name="AppxAutoIncrementPackageRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxAutoIncrementPackageRevision" _locComment="" -->Flag indicating whether to auto-increment package revision.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
 
-    <xs:element name="ValidateStoreManifest" substitutionGroup="msb:Task">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="Input" use="required" />
-                    <xs:attribute name="StoreManifestSchema" use="required" />
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-    
+  <xs:element name="AppxMSBuildToolsPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxMSBuildToolsPath" _locComment="" -->Full path to a folder containing packaging build targets and tasks assembly.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxMSBuildTaskAssembly" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxMSBuildTaskAssembly" _locComment="" -->Full path to packaging build tasks assembly.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackage" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackage" _locComment="" -->Flag marking current project as capable of being packaged as an app package.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxUseHardlinksIfPossible" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxUseHardlinksIfPossible" _locComment="" -->Flag indicating whether to use hard links if possible when copying files during creation of app packages.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxSkipUnchangedFiles" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxSkipUnchangedFiles" _locComment="" -->Flag indicating whether to skip unchanged files when copying files during creation of app packages.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxGeneratePriEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxGeneratePriEnabled" _locComment="" -->Flag indicating whether to generate resource index files (PRI files) during packaging.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageSigningEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageSigningEnabled" _locComment="" -->Flag indicating whether to enable signing of app packages.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageIncludePrivateSymbols" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageIncludePrivateSymbols" _locComment="" -->Flag indicating whether to include private symbols in symbol packages.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxSymbolPackageEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxSymbolPackageEnabled" _locComment="" -->Flag indicating whether to generate a symbol package when an app package is created.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxTestLayoutEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxTestLayoutEnabled" _locComment="" -->Flag indicating whether to create test layout when an app package is created.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageValidationEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageValidationEnabled" _locComment="" -->Flag indicating whether to enable validation of app packages.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxHarvestWinmdRegistration" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxHarvestWinmdRegistration" _locComment="" -->Flag indicating whether to enable harvesting of WinMD registration information.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="EnableSigningChecks" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="EnableSigningChecks" _locComment="" -->Flag indicating whether to enable signing checks during app package generation.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxStrictManifestValidationEnabled" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxStrictManifestValidationEnabled" _locComment="" -->Flag indicating whether to enable strict manifest validation.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxFilterOutUnusedLanguagesResourceFileMaps" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxFilterOutUnusedLanguagesResourceFileMaps" _locComment="" -->Flag indicating whether to filter out unused language resource file maps.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxOSMinVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxOSMinVersion" _locComment="" -->Targeted minimum OS version.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxOSMaxVersionTested" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxOSMaxVersionTested" _locComment="" -->Targeted maximum OS version tested.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageDirName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageDirName" _locComment="" -->Name of the folder where app packages are produced.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="PlatformSpecificBundleArtifactsListDirName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PlatformSpecificBundleArtifactsListDirName" _locComment="" -->Name of the folder where platform-specific bundle artifact lists are stored.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageDir" _locComment="" -->Full path to a folder where app packages will be saved.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageArtifactsDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageArtifactsDir" _locComment="" -->Additional qualifier to append to AppxPackageDir.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="FinalAppxManifestName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="FinalAppxManifestName" _locComment="" -->Path to the final app manifest.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxValidateAppxManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxValidateAppxManifest" _locComment="" -->Flag indicating whether to validate app manifest.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="MakePriExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="MakePriExeFullPath" _locComment="" -->Full path to makepri.exe utility.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="MakeAppxExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="MakeAppxExeFullPath" _locComment="" -->Full path to makeappx.exe utility.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="SignAppxPackageExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="SignAppxPackageExeFullPath" _locComment="" -->Full path to signtool.exe utility.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="ResgenToolPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ResgenToolPath" _locComment="" -->Full path to a folder containing resgen tool.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="PdbCopyExeFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PdbCopyExeFullPath" _locComment="" -->Full path to pdbcopy.exe utility.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxSymbolStrippedDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxSymbolStrippedDir" _locComment="" -->Full path to a directory where stripped PDBs will be stored.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPrependPriInitialPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPrependPriInitialPath" _locComment="" -->Flag indicating whether to enable prepending initial path when indexing RESW and RESJSON files in class libraries.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPriInitialPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPriInitialPath" _locComment="" -->Initial path when indexing RESW and RESJSON files in class libraries.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="ProjectPriFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ProjectPriFileName" _locComment="" -->File name to use for project-specific resource index file (PRI).
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="ProjectPriFullPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ProjectPriFullPath" _locComment="" -->Full path to project-specific resource index file (PRI).
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageRecipe" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageRecipe" _locComment="" -->Full path to the app package recipe.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="FinalAppxPackageRecipe" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="FinalAppxPackageRecipe" _locComment="" -->Full path to the final app package recipe.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AllowLocalNetworkLoopback" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AllowLocalNetworkLoopback" _locComment="" -->Flag indicating whether to allow local network loopback.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxDefaultHashAlgorithmId" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxDefaultHashAlgorithmId" _locComment="" -->Default hash algorithm ID, used for signing an app package.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageFileMap" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageFileMap" _locComment="" -->Full path to app package file map.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="LayoutDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="LayoutDir" _locComment="" -->Full path to a folder with package layout.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="ManagedWinmdInprocImplementation" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ManagedWinmdInprocImplementation" _locComment="" -->Name of the binary containing managed WinMD in-proc implementation.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="UseIncrementalAppxRegistration" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UseIncrementalAppxRegistration" _locComment="" -->Flag indicating whether to enable incremental registration of the app layout.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackagingInfoFile" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackagingInfoFile" _locComment="" -->Full path to the packaging info file which will contain paths to produced packages.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxOSMinVersionReplaceManifestVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxOSMinVersionReplaceManifestVersion" _locComment="" -->Flag indicating whether minimum OS version in app manifest should be replaced.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxOSMaxVersionTestedReplaceManifestVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxOSMaxVersionTestedReplaceManifestVersion" _locComment="" -->Flag indicating whether maximum OS version tested in app manifest should be replaced.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="PackagingFileWritesLogPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PackagingFileWritesLogPath" _locComment="" -->Full path to a text file containing packaging file writes log.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="PackagingDirectoryWritesLogPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PackagingDirectoryWritesLogPath" _locComment="" -->Full path to a text file containing packaging directory writes log.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxCopyLocalFilesOutputGroupIncludeXmlFiles" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxCopyLocalFilesOutputGroupIncludeXmlFiles" _locComment="" -->Flag indicating whether CopyLocal files group should include XML files.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxDefaultResourceQualifiers" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxDefaultResourceQualifiers" _locComment="" -->'|'-delimited list of key=value pairs representing default resource qualifers.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPriConfigXmlPackagingSnippetPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPriConfigXmlPackagingSnippetPath" _locComment="" -->Path to an XML file containing packaging element for priconfi.xml file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPriConfigXmlDefaultSnippetPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPriConfigXmlDefaultSnippetPath" _locComment="" -->Path to an XML file containing default element for priconfi.xml file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="TargetPlatformSdkRootOverride" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="TargetPlatformSdkRootOverride" _locComment="" -->Full path to platform SDK root.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundle" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundle" _locComment="" -->Flag indicating whether packaging targets will produce an app bundle.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundlePlatforms" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundlePlatforms" _locComment="" -->'|'-delimited list of platforms which will be included in an app bundle.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleProducingPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleProducingPlatform" _locComment="" -->A platform which will be used to produce an app bundle.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleResourcePacksProducingPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleResourcePacksProducingPlatform" _locComment="" -->A platform which will be used to produce resource packs for an app bundle.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxLayoutFolderName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxLayoutFolderName" _locComment="" -->Name of the folder where package layout will be prepared when producing an app bundle.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxLayoutDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxLayoutDir" _locComment="" -->Full path to the folder where package layout will be prepared when producing an app bundle.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundlePriConfigXmlForSplittingFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundlePriConfigXmlForSplittingFileName" _locComment="" -->Full path to the priconfig.xml file used for splitting resource packs.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleAutoResourcePackageQualifiers" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleAutoResourcePackageQualifiers" _locComment="" -->'|'-delimited list of resource qualifers which will be used for automatic resource pack splitting.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleSplitResourcesPriPrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleSplitResourcesPriPrefix" _locComment="" -->Prefix used for split resources .pri and .map.txt files.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleSplitResourcesPriPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleSplitResourcesPriPath" _locComment="" -->Full path to split resources .pri file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleSplitResourcesGeneratedFilesListPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleSplitResourcesGeneratedFilesListPath" _locComment="" -->Full path to a log file containing a list of generated files during resource splitting.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleSplitResourcesQualifiersPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleSplitResourcesQualifiersPath" _locComment="" -->Full path to a log file containing a detected qualifiers during resource splitting.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundlePriConfigXmlForMainPackageFileMapFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundlePriConfigXmlForMainPackageFileMapFileName" _locComment="" -->Full path to the priconfig.xml file used for generating main package file map.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapIntermediatePrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapIntermediatePrefix" _locComment="" -->Prefix used for intermediate main package resources .pri and .map.txt files.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapSuffix" _locComment="" -->Suffix used before extension of resource map files.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapIntermediatePath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapIntermediatePath" _locComment="" -->Full path to an intermediate main package file map.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapIntermediatePriPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapIntermediatePriPath" _locComment="" -->Full path to an intermediate main package .pri file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapGeneratedFilesListPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapGeneratedFilesListPath" _locComment="" -->Full path to a log file containing a list of generated files during generation of main package file map.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapPrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapPrefix" _locComment="" -->Prefix used for main package resources .pri and .map.txt files.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleMainPackageFileMapPath" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleMainPackageFileMapPath" _locComment="" -->Full path to a main package file map.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleFolderSuffix" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxBundleFolderSuffix" _locComment="" -->Suffix to append to app bundle folder.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="PlatformSpecificBundleArtifactsListDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PlatformSpecificBundleArtifactsListDir" _locComment="" -->Full path to a folder where platform-specific bundle artifact list files are stored.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageAllowDebugFrameworkReferencesInManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageAllowDebugFrameworkReferencesInManifest" _locComment="" -->Flag indicating whether to allow inclusion of debug framework references in an app manifest.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="GenerateAppxPackageOnBuild" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="GenerateAppxPackageOnBuild" _locComment="" -->Flag indicating whether to generate app package during the build.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="InsertReverseMap" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="InsertReverseMap" _locComment="" -->Flag indicating whether to insert reverse resource map during resource index generation.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeBuiltProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Flag indicating whether to include primary build outputs into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeDebugSymbolsProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeDebugSymbolsProjectOutputGroup" _locComment="" -->Flag indicating whether to include debug symbols into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeDocumentationProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeDocumentationProjectOutputGroup" _locComment="" -->Flag indicating whether to include documentation into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeSatelliteDllsProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeSatelliteDllsProjectOutputGroup" _locComment="" -->Flag indicating whether to include satellite DLLs into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeSourceFilesProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeSourceFilesProjectOutputGroup" _locComment="" -->Flag indicating whether to include source files into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeContentFilesProjectOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeContentFilesProjectOutputGroup" _locComment="" -->Flag indicating whether to include content files into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeSGenFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeSGenFilesOutputGroup" _locComment="" -->Flag indicating whether to include SGen files into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeCopyLocalFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeCopyLocalFilesOutputGroup" _locComment="" -->Flag indicating whether to include files marked as 'Copy local' into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeComFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeComFilesOutputGroup" _locComment="" -->Flag indicating whether to include COM files into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeCustomOutputGroupForPackaging" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeCustomOutputGroupForPackaging" _locComment="" -->Flag indicating whether to include custom output group into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeCopyWinmdArtifactsOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeCopyWinmdArtifactsOutputGroup" _locComment="" -->Flag indicating whether to include WinMD artifacts into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeSDKRedistOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Flag indicating whether to include SDK redist into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludePriFilesOutputGroup" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludePriFilesOutputGroup" _locComment="" -->Flag indicating whether to include resource index (PRI) files into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="IncludeGetResolvedSDKReferences" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeGetResolvedSDKReferences" _locComment="" -->Flag indicating whether to include resolved SDK references into the app package payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="ProjectPriIndexName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ProjectPriIndexName" _locComment="" -->Name of the resource index used in the generated .pri file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AutoIncrementPackageRevision" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AutoIncrementPackageRevision" _locComment="" -->Flag indicating whether to enable auto increment of an app package revision.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxBundleDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AutoIncrementPackageRevision" _locComment="" -->Full path to a folder where app bundle will be produced.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Name of the app package to generate.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxStoreContainer" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Name of the app store container to generate.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageTestDir" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="IncludeBuiltProjectOutputGroup" _locComment="" -->Name of the folder where test app packages will be copied
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxPackageOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxPackageOutput" _locComment="" -->Full path to the app package file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxSymbolPackageOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxSymbolPackageOutput" _locComment="" -->Full path to the app symbol package file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxGenerateProjectPriFileAdditionalMakepriExeParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxGenerateProjectPriFileAdditionalMakepriExeParameters" _locComment="" -->Additional parameters to pass to makepri.exe when generating project PRI file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxCreatePriFilesForPortableLibrariesAdditionalMakepriExeParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxCreatePriFilesForPortableLibrariesAdditionalMakepriExeParameters" _locComment="" -->Additional parameters to pass to makepri.exe when generating PRI file for a portable library.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxExpandPriContentAdditionalMakepriExeParameters" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxExpandPriContentAdditionalMakepriExeParameters" _locComment="" -->Additional parameters to pass to makepri.exe when extracting payload file names.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="StoreManifestName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="StoreManifestName" _locComment="" -->Name of the store manifest file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxValidateStoreManifest" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxValidateStoreManifest" _locComment="" -->Flag indicating whether to validate store manifest.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <!-- Following properties are declared here to get rid of schema validation warnings,    -->
+  <!-- but are not intended for overriding, so they do not have documentation annotations. -->
+
+  <xs:element name="_AdjustedPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_AppxBundlePlatformsForNamingIntermediate" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_AppxPackageConfiguration" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ContinueOnError" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_CreateAppxBundleFilesDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_CreateAppxBundlePlatformSpecificArtifactsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_CreateAppxPackageDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_CustomAppxManifestUsed" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_Extension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_FileNameToRemove" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_FileToBuild" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_GenerateAppxManifestDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_GenerateAppxPackageBaseDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_GenerateAppxPackageDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_GenerateAppxPackageRecipeDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_GenerateProjectPriFileDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_GetPackagePropertiesDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_LayoutResfilesPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_MultipleQualifiersPerDimensionFound" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_MultipleQualifiersPerDimensionFoundPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_PriConfigXmlPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_PriResfilesPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ProjectArchitectureOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ProjectArchitecturesFilePath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ProjectPriFullPathOriginal" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_QualifiersPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_Rebuilding" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ResourcesResfilesPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ReverseMapProjectPriDirectory" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ReverseMapProjectPriFileName" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_ShouldUnsetParentConfigurationAndPlatform" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_SolutionConfigurationContentsToUse" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_TargetToBuild" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_WindowsPhoneSdkInstallPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_WindowsPhoneSdkInstallPath_RegistryKeyName" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_WindowsPhoneSdkInstallPath_RegistryValueName" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AllOutputGroupsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxBundleExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxBundleOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxBundlePlatformsForNaming" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxBundlePlatformSpecificArtifactsListPath" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxDefaultResourceQualifiers_Windows_80" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxDefaultResourceQualifiers_Windows_81" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxDefaultResourceQualifiers_Windows_Phone" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxHashAlgorithmId" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxIntermediateExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxMainPackageOutput" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxManifestQueryNamespace81Prefix" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxManifestQueryNamespacePrefix" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxPackageDirInProjectDir" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxPackageDirWasSpecified" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxPackageExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxPackageNameNeutral" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxResourcePackOutputBase" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxStoreContainerExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="AppxSymbolPackageExtension" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="CleanPackageAction" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="ComFilesOutputGroupDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="CopyLocalFilesOutputGroupDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="CopyWinmdArtifactsOutputGroupDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="GetPackagingOutputsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="OsVersion" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="PackageAction" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="PlatformSpecificBundleArtifactsListDirInProjectDir" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="PlatformSpecificBundleArtifactsListDirWasSpecified" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="PrepareForRunDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="PrepareLayoutDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="ProduceAppxBundle" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="RebuildPackageAction" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="ValidatePresenceOfAppxManifestItemsDependsOn" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+
+  <!-- TODO: Remove once Windows Phone SDK starts shipping StoreManifest.xsd -->
+  <xs:element name="VSINSTALLDIR" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+  <xs:element name="_StoreManifestSchemaDir" type="msb:StringPropertyType" substitutionGroup="msb:Property" />
+
+  <!-- ================ -->
+  <!-- Packaging items. -->
+  <!-- ================ -->
+
+  <xs:complexType name="SchemaItemType">
+    <xs:complexContent>
+      <xs:extension base="msb:SimpleItemType">
+        <xs:all>
+          <xs:element name="NamespaceAlias" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="AppxManifestSchema_NamespaceAlias" _locComment="" -->Namespace alias used for this schema.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="NamespaceUri" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="AppxManifestSchema_NamespaceUri" _locComment="" -->Namespace URI used for this schema.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:all>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="AppxManifestSchema" type="msb:SchemaItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxManifestSchema" _locComment="" -->App manifest schema file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="StoreManifestSchema" type="msb:SchemaItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="StoreManifestSchema" _locComment="" -->Store manifest schema file.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxHashUri" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxHashUri" _locComment="" -->Hash algorithm URI.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="Id" minOccurs="1" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxHashUri_Id" _locComment="" -->Hash algorithm ID corresponding to given hash URI.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="PRIResource" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PRIResource" _locComment="" -->String resources to be indexed in app package's resource index.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="DependentUpon" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="PRIResource_DependentUpon" _locComment="" -->Notional path within project to indicate parent item of the current item (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Link" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="PRIResource_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Visible" minOccurs="0" maxOccurs="1" type="msb:boolean">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="PRIResource_Visible" _locComment="" -->Display in user interface (optional, boolean).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="AppxSystemBinary" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxSystemBinary" _locComment="" -->Name of any file which is present on the machine and should not be part of the app payload.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxReservedFileName" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxReservedFileName" _locComment="" -->Reserved file name which cannot appear in the app package.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxManifestFileNameQuery" type="msb:SimpleItemType" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxManifestFileNameQuery" _locComment="" -->XPath queries used to extract file names from the app manifest.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="AppxManifestImageFileNameQuery" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxManifestImageFileNameQuery" _locComment="" -->XPath queries used to define image files in the app manifest and restrictions on them.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="DescriptionID" minOccurs="1" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestImageFileNameQuery_DescriptionID" _locComment="" -->ID of description string resource describing this type of the image.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="ExpectedScaleDimensions" minOccurs="1" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestImageFileNameQuery_ExpectedScaleDimensions" _locComment="" -->Semicolon-delimited list of expected scale dimensions in format '{scale}:{width}x{height}'.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="ExpectedTargetSizes" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestImageFileNameQuery_ExpectedScaleDimensions" _locComment="" -->Semicolon-delimited list of expected target sizes.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="MaximumFileSize" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestImageFileNameQuery_ExpectedScaleDimensions" _locComment="" -->Maximum file size in bytes.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="AppxManifest" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxManifest" _locComment="" -->app manifest template
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="DependentUpon" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifest_DependentUpon" _locComment="" -->Notional path within project to indicate parent item of the current item (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Link" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifest_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="SubType" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifest_SubType" _locComment="" -->Visual Studio sub-type for this item (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Visible" minOccurs="0" maxOccurs="1" type="msb:boolean">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifest_Visible" _locComment="" -->Display in user interface (optional, boolean).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="StoreAssociationFile" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="StoreAssociationFile" _locComment="" -->A file containing app store association data.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="DependentUpon" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="StoreAssociationFile_DependentUpon" _locComment="" -->Notional path within project to indicate parent item of the current item (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Link" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="StoreAssociationFile_Link" _locComment="" -->Notional path within project to display if the file is physically located outside of the project file's cone (optional).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Visible" minOccurs="0" maxOccurs="1" type="msb:boolean">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="StoreAssociationFile_Visible" _locComment="" -->Display in user interface (optional, boolean).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="AppxManifestMetadata" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="AppxManifestMetadata" _locComment="" -->App manifest metadata item. Can be a literal, or it can be a path to a binary to extract version from.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="Value" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestMetadata_Value" _locComment="" -->Literal value of app manifest metadata to insert into manifest.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Version" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestMetadata_Version" _locComment="" -->Version to be inserted as a value of app manifest metadata to insert into manifest.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Name" minOccurs="0" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="AppxManifestMetadata_Name" _locComment="" -->Name of app manifest metadata to insert into manifest.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="PlatformVersionDescription" substitutionGroup="msb:Item">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PlatformVersionDescription" _locComment="" -->Platform version description. Used to map between internal OS version and marketing OS version.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPlatformIdentifier" minOccurs="1" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="PlatformVersionDescription_TargetPlatformIdentifier" _locComment="" -->Target platform identifier.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="TargetPlatformVersion" minOccurs="1" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="PlatformVersionDescription_TargetPlatformVersion" _locComment="" -->Target platform version.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OSVersion" minOccurs="1" maxOccurs="1">
+              <xs:annotation>
+                <xs:documentation>
+                  <!-- _locID_text="PlatformVersionDescription_OSVersion" _locComment="" -->Internal OS version.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Following items are declared here to get rid of schema validation warnings,         -->
+  <!-- but are not intended for overriding, so they do not have documentation annotations. -->
+
+  <xs:element name="_AppxBundleContent" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxBundleMainPackageMapGeneratedFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxBundleMainPackageMapInputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxBundleResourceFileMaps" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxBundleResourcePack" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxBundleSplitResourcesGeneratedFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxBundleSplitResourcesPriPathItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxPriConfigXmlDefaultSnippetItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxPriConfigXmlPackagingSnippetItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_AppxStoreContainer" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_CreateAppStoreBundleContainerInputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_CreateBundleInputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_GenerateAppxPackageRecipeInput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_GenerateCurrentProjectAppxManifestInput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_GenerateProjectPriFileCoreInput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_LayoutFile" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_LibrariesUnfiltered" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_MainPackageToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_OtherPlatformToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PackageLayoutFileSource" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PackageLayoutFileTarget" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PlatformSpecificBundleArtifact" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PowerShellScriptsDestination" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PowerShellScriptsSource" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PriFile" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PriFilesFromPayloadRaw" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_PriFilesToExpand" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_RecursiveProjectArchitecture" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_ResourcePackToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_SymbolPackageToBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_TestLayoutSourceFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_TestLayoutTargetFiles" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_UnfilteredAppxPackagePayload" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_UnfilteredRecursiveResolvedSDKReference" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_WinmdFilesFromOtherGroups" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_WinmdFilesFromReferences" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_WinmdFilesFromSDKs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_WinmdFilesFromWinmdArtifacts" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="_WinmdWithImplementation" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="AppxBundlePlatformWithAnyCPU" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="AppxManifestForBundle" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="CustomAppxManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="FileReads" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="FileWrites" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="FinalAppxManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="FinalAppxPackageItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="FinalAppxSymbolPackageItem" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="FrameworkSdkReference" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="NonFrameworkSdkReference" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="PackagingDirectoryWrites" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="PackagingFileWrites" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="PackagingOutputs" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="PDBPayload" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="ProjectArchitecture" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="SourceAppxManifest" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+  <xs:element name="UpToDateCheckOutput" type="msb:SimpleItemType" substitutionGroup="msb:Item" />
+
+  <xs:element name="AppxPackagePayload" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
+            <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ComFilesOutputGroupOutputs" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="CopyWinmdArtifactsOutputGroupOutputs" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="CopyLocalFilesOutputGroupOutput" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="_PackagingOutputsUnexpanded" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" type="msb:StringPropertyType" />
+            <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="_GetResolvedSDKReferencesOutput" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="_ProjectArchitectureItem" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="_AppxBundleResourceFileMapsIntermediate" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="ResourcePack" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ProjectPriFile" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="TargetPath" minOccurs="0" maxOccurs="1" />
+            <xs:element name="OutputGroup" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ProjectName" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="_ProjectArchitectureFromPayload" substitutionGroup="msb:Item">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:SimpleItemType">
+          <xs:all>
+            <xs:element name="MSBuildSourceProjectFile" minOccurs="0" maxOccurs="1" />
+          </xs:all>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ================ -->
+  <!-- Packaging tasks. -->
+  <!-- ================ -->
+
+  <xs:complexType name="ToolTaskType">
+    <xs:complexContent>
+      <xs:extension base="msb:TaskType">
+        <xs:attribute name="ExitCode" />
+        <xs:attribute name="YieldDuringToolExecution" type="msb:boolean" />
+        <xs:attribute name="UseCommandProcessor" type="msb:boolean" />
+        <xs:attribute name="EchoOff" type="msb:boolean" />
+        <xs:attribute name="ToolExe" />
+        <xs:attribute name="ToolPath" />
+        <xs:attribute name="EnvironmentVariables" />
+        <xs:attribute name="Timeout" />
+        <xs:attribute name="StandardErrorImportance" />
+        <xs:attribute name="StandardOutputImportance" />
+        <xs:attribute name="LogStandardErrorAsError" type="msb:boolean" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="CreateAppStoreContainer" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Items" use="required" />
+          <xs:attribute name="ProjectName" use="required" />
+          <xs:attribute name="OutputPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="CreatePriConfigXmlTaskType">
+    <xs:complexContent>
+      <xs:extension base="msb:TaskType">
+        <xs:attribute name="PriConfigXmlPath" use="required" />
+        <xs:attribute name="PriInitialPath" />
+        <xs:attribute name="DefaultResourceLanguage" use="required" />
+        <xs:attribute name="DefaultResourceQualifiers" use="required" />
+        <xs:attribute name="ConvertDotsToSlashes" type="msb:boolean" />
+        <xs:attribute name="IntermediateExtension" use="required" />
+        <xs:attribute name="PriConfigXmlPackagingSnippetPath" />
+        <xs:attribute name="PriConfigXmlDefaultSnippetPath" />
+        <xs:attribute name="TargetPlatformIdentifier" use="required" />
+        <xs:attribute name="TargetPlatformVersion" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="CreatePriConfigXmlTask" type="msb:CreatePriConfigXmlTaskType" substitutionGroup="msb:Task" />
+
+  <xs:element name="CreatePriConfigXmlForFullIndex" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:CreatePriConfigXmlTaskType">
+          <xs:attribute name="LayoutResfilesPath" use="required" />
+          <xs:attribute name="ResourcesResfilesPath" use="required" />
+          <xs:attribute name="PriResfilesPath" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="CreatePriConfigXmlWithPackagingElementTaskType">
+    <xs:complexContent>
+      <xs:extension base="msb:CreatePriConfigXmlTaskType">
+        <xs:attribute name="AppxBundleAutoResourcePackageQualifiers" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="CreatePriConfigXmlForMainPackageFileMap" type="msb:CreatePriConfigXmlWithPackagingElementTaskType" substitutionGroup="msb:Task" />
+
+  <xs:element name="CreatePriConfigXmlForSplitting" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:CreatePriConfigXmlWithPackagingElementTaskType">
+          <xs:attribute name="ResourcesPriFilePath" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="CreatePriFilesForPortableLibraries" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ContentToIndex" use="required" />
+          <xs:attribute name="MakePriExeFullPath" use="required" />
+          <xs:attribute name="MakePriExtensionPath" />
+          <xs:attribute name="IntermediateDirectory" use="required" />
+          <xs:attribute name="DefaultResourceLanguage" use="required" />
+          <xs:attribute name="DefaultResourceQualifiers" use="required" />
+          <xs:attribute name="IntermediateFileWrites" />
+          <xs:attribute name="CreatedPriFiles" />
+          <xs:attribute name="IntermediateExtension" use="required" />
+          <xs:attribute name="AdditionalMakepriExeParameters" />
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="TargetPlatformVersion" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ExpandPayloadDirectories" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Inputs" use="required" />
+          <xs:attribute name="Expanded" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ExpandPriContent" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:ToolTaskType">
+          <xs:attribute name="Inputs" use="required" />
+          <xs:attribute name="Expanded" />
+          <xs:attribute name="IntermediateFileWrites" />
+          <xs:attribute name="IntermediateDirectory" use="required" />
+          <xs:attribute name="AdditionalMakepriExeParameters" />
+          <xs:attribute name="MakePriExeFullPath" use="required" />
+          <xs:attribute name="MakePriExtensionPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ExtractHashAlgorithmId" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="StoreAssociationFile" />
+          <xs:attribute name="HashUris" use="required" />
+          <xs:attribute name="HashAlgorithmId" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="FilterOutUnusedLanguagesResourceFileMaps" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="FileMaps" use="required" />
+          <xs:attribute name="FileNamePrefix" use="required" />
+          <xs:attribute name="MapSuffix" use="required" />
+          <xs:attribute name="Languages" use="required" />
+          <xs:attribute name="FilteredFileMaps" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GenerateAppxManifest" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ApplicationExecutableName" />
+          <xs:attribute name="AppxManifestInput" use="required" />
+          <xs:attribute name="CertificateThumbprint" />
+          <xs:attribute name="CertificateFile" />
+          <xs:attribute name="PackageArchitecture" use="required" />
+          <xs:attribute name="FrameworkSdkReferences" use="required" />
+          <xs:attribute name="NonFrameworkSdkReferences" use="required" />
+          <xs:attribute name="AppxManifestOutput" use="required" />
+          <xs:attribute name="DefaultResourceLanguage" use="required" />
+          <xs:attribute name="QualifiersPath" use="required" />
+          <xs:attribute name="ManagedWinmdInprocImplementation" use="required" />
+          <xs:attribute name="WinmdFiles" use="required" />
+          <xs:attribute name="SDKWinmdFiles" use="required" />
+          <xs:attribute name="OSMinVersion" />
+          <xs:attribute name="OSMaxVersionTested" />
+          <xs:attribute name="OSMinVersionReplaceManifestVersion" type="msb:boolean" />
+          <xs:attribute name="OSMaxVersionTestedReplaceManifestVersion" type="msb:boolean" />
+          <xs:attribute name="EnableSigningChecks" type="msb:boolean" />
+          <xs:attribute name="ManifestMetadata" />
+          <xs:attribute name="TargetPlatformIdentifier" />
+          <xs:attribute name="PackageSigningEnabled" type="msb:boolean" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GenerateAppxPackageRecipe" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AppxManifestXml" use="required" />
+          <xs:attribute name="SourceAppxManifest" use="required" />
+          <xs:attribute name="SolutionConfiguration" use="required" />
+          <xs:attribute name="PayloadFiles" use="required" />
+          <xs:attribute name="FrameworkSdkPackages" use="required" />
+          <xs:attribute name="RecipeFile" use="required" />
+          <xs:attribute name="SystemBinaries" use="required" />
+          <xs:attribute name="ReservedFileNames" use="required" />
+          <xs:attribute name="QueryNamespacePrefix" use="required" />
+          <xs:attribute name="QueryNamespace81Prefix" use="required" />
+          <xs:attribute name="ManifestFileNameQueries" use="required" />
+          <xs:attribute name="ManifestImageFileNameQueries" use="required" />
+          <xs:attribute name="PackageArchitecture" use="required" />
+          <xs:attribute name="ProjectDir" use="required" />
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="IndexedPayloadFiles" />
+          <xs:attribute name="MakePriExtensionPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GenerateAppxSymbolPackage" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="PdbCopyExeFullPath" use="required" />
+          <xs:attribute name="PdbFiles" use="required" />
+          <xs:attribute name="StrippedDirectory" use="required" />
+          <xs:attribute name="AppxSymbolPackageOutput" use="required" />
+          <xs:attribute name="ProjectName" use="required" />
+          <xs:attribute name="StrippedPdbs" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GeneratePriConfigurationFiles" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="LayoutResfilesPath" use="required" />
+          <xs:attribute name="ResourcesResfilesPath" use="required" />
+          <xs:attribute name="PriResfilesPath" use="required" />
+          <xs:attribute name="LayoutFiles" use="required" />
+          <xs:attribute name="PRIResourceFiles" use="required" />
+          <xs:attribute name="PriFiles" use="required" />
+          <xs:attribute name="IntermediateExtension" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GenerateProjectArchitecturesFile" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ProjectArchitectures" use="required" />
+          <xs:attribute name="ProjectArchitecturesFilePath" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GenerateProjectPriFile" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:ToolTaskType">
+          <xs:attribute name="MakePriExeFullPath" use="required" />
+          <xs:attribute name="PriConfigXmlPath" use="required" />
+          <xs:attribute name="IndexFilesForQualifiersCollection" />
+          <xs:attribute name="ProjectPriIndexName" use="required" />
+          <xs:attribute name="MappingFileFormat" />
+          <xs:attribute name="InsertReverseMap" />
+          <xs:attribute name="ProjectDirectory" use="required" />
+          <xs:attribute name="OutputFileName" use="required" />
+          <xs:attribute name="MakePriExtensionPath" />
+          <xs:attribute name="QualifiersPath" />
+          <xs:attribute name="GeneratedFilesListPath" />
+          <xs:attribute name="AdditionalMakepriExeParameters" />
+          <xs:attribute name="MultipleQualifiersPerDimensionFoundPath" />
+          <xs:attribute name="IntermediateExtension" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetAppxBundlePlatforms" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Input" use="required" />
+          <xs:attribute name="PackageArchitecture" use="required" />
+          <xs:attribute name="Platforms" />
+          <xs:attribute name="Last" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetDefaultResourceLanguage" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="DefaultLanguage" />
+          <xs:attribute name="SourceAppxManifest" />
+          <xs:attribute name="DefaultResourceLanguage" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetFrameworkSdkPackages" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="FrameworkSdkReferences" use="required" />
+          <xs:attribute name="FrameworkSdkPackages" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetPackageArchitecture" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Platform" use="required" />
+          <xs:attribute name="ProjectArchitecture" use="required" />
+          <xs:attribute name="RecursiveProjectArchitecture" use="required" />
+          <xs:attribute name="PackageArchitecture" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetSdkPropertyValue" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="TargetPlatformVersion" use="required" />
+          <xs:attribute name="TargetPlatformSdkRootOverride" />
+          <xs:attribute name="PropertyName" use="required" />
+          <xs:attribute name="PropertyValue" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetSdkToolFullPath" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="ToolName" use="required" />
+          <xs:attribute name="ToolFullPath" />
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="TargetPlatformVersion" use="required" />
+          <xs:attribute name="TargetPlatformSdkRootOverride" />
+          <xs:attribute name="MSBuildArchitecture" />
+          <xs:attribute name="ActualToolFullPath" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="GetWindowsDesktopSdkDir" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="TargetPlatformVersion" use="required" />
+          <xs:attribute name="TargetPlatformSdkRootOverride" />
+          <xs:attribute name="WindowsDesktopSdkDir" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="MakeAppxType">
+    <xs:complexContent>
+      <xs:extension base="msb:ToolTaskType">
+        <xs:attribute name="MakeAppxExeFullPath" use="required" />
+        <xs:attribute name="Parameters" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="MakeAppxWithOutputType">
+    <xs:complexContent>
+      <xs:extension base="msb:MakeAppxType">
+        <xs:attribute name="Output" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="MakeAppxBundle" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:MakeAppxWithOutputType">
+          <xs:attribute name="BundleDir" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="MakeAppxPack" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:MakeAppxWithOutputType">
+          <xs:attribute name="ResourcePack" type="msb:boolean" />
+          <xs:attribute name="ValidateResourcesReferencedByManifest" type="msb:boolean" />
+          <xs:attribute name="HashAlgorithmId" use="required" />
+          <xs:attribute name="AppxManifest" />
+          <xs:attribute name="FileMap" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ParsePlatformSpecificBundleArtifactsLists" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Files" use="required" />
+          <xs:attribute name="Artifacts" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="RemoveDuplicatePayload" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Inputs" use="required" />
+          <xs:attribute name="Platform" use="required" />
+          <xs:attribute name="Filtered" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="RemoveDuplicatePriFiles" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Inputs" use="required" />
+          <xs:attribute name="Platform" use="required" />
+          <xs:attribute name="Filtered" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="RemoveDuplicateSDKReferences" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Inputs" use="required" />
+          <xs:attribute name="Filtered" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="SignAppxPackage" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AppxPackageToSign" use="required" />
+          <xs:attribute name="CertificateThumbprint" />
+          <xs:attribute name="CertificateFile" />
+          <xs:attribute name="HashAlgorithmId" use="required" />
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="TargetPlatformVersion" use="required" />
+          <xs:attribute name="TargetPlatformSdkRootOverride" />
+          <xs:attribute name="SignAppxPackageExeFullPath" />
+          <xs:attribute name="MSBuildArchitecture" />
+          <xs:attribute name="EnableSigningChecks" type="msb:boolean" />
+          <xs:attribute name="ExportCertificate" type="msb:boolean" />
+          <xs:attribute name="ResolvedThumbprint" />
+          <xs:attribute name="AppxPackagePublicKeyFile" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="StripPrivateSymbols" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:ToolTaskType">
+          <xs:attribute name="PdbCopyToolPath" use="required" />
+          <xs:attribute name="InputPdb" use="required" />
+          <xs:attribute name="StrippedPdb" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="UpdateAppxManifestForBundle" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="FinalAppxManifest" use="required" />
+          <xs:attribute name="AppxManifestForBundle" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="UpdateMainPackageFileMap" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Input" use="required" />
+          <xs:attribute name="Output" use="required" />
+          <xs:attribute name="SplitResourcesPriPath" use="required" />
+          <xs:attribute name="DefaultResourceLanguage" use="required" />
+          <xs:attribute name="DefaultResourceQualifiers" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ValidateAppxManifest" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Input" use="required" />
+          <xs:attribute name="SourceAppxManifest" use="required" />
+          <xs:attribute name="AppxManifestSchema" use="required" />
+          <xs:attribute name="StoreAssociationFile" />
+          <xs:attribute name="TargetPlatformIdentifier" use="required" />
+          <xs:attribute name="TargetPlatformVersion" use="required" />
+          <xs:attribute name="OSMinVersion" use="required" />
+          <xs:attribute name="OSMaxVersionTested" use="required" />
+          <xs:attribute name="PlatformVersionDescriptions" use="required" />
+          <xs:attribute name="ResolvedSDKReferences" use="required" />
+          <xs:attribute name="StrictManifestValidationEnabled" type="msb:boolean" />
+          <xs:attribute name="ValidateWinmds" type="msb:boolean" />
+          <xs:attribute name="NonFrameworkSdkReferences" />
+          <xs:attribute name="WinmdFiles" />
+          <xs:attribute name="SDKWinmdFiles" />
+          <xs:attribute name="ManagedWinmdInprocImplementation" />
+          <xs:attribute name="ValidateManifest" type="msb:boolean" />
+          <xs:attribute name="Resources" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ValidateAppxManifestItems" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="AppxManifestItems" />
+          <xs:attribute name="CustomAppxManifestItems" />
+          <xs:attribute name="AppxPackageProject" type="msb:boolean" />
+          <xs:attribute name="IdentityName" />
+          <xs:attribute name="IdentityVersion" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ValidateAppxPackage" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="SourceAppxManifest" use="required" />
+          <xs:attribute name="AppxManifest" use="required" />
+          <xs:attribute name="StoreAssociationFile" />
+          <xs:attribute name="PackageArchitecture" use="required" />
+          <xs:attribute name="AppxPackagePayload" use="required" />
+          <xs:attribute name="QueryNamespacePrefix" use="required" />
+          <xs:attribute name="QueryNamespace81Prefix" use="required" />
+          <xs:attribute name="ManifestImageFileNameQueries" use="required" />
+          <xs:attribute name="ResolvedSDKReferences" use="required" />
+          <xs:attribute name="AllowDebugFrameworkReferencesInManifest" type="msb:boolean" />
+          <xs:attribute name="ProjectDir" use="required" />
+          <xs:attribute name="IndexedPayloadFiles" />
+          <xs:attribute name="MakePriExtensionPath" />
+          <xs:attribute name="OSMinVersion" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ValidateStoreManifest" substitutionGroup="msb:Task">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="msb:TaskType">
+          <xs:attribute name="Input" use="required" />
+          <xs:attribute name="StoreManifestSchema" use="required" />
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/src/XMakeCommandLine/Microsoft.Build.Core.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.Core.xsd
@@ -1,722 +1,848 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xs:schema targetNamespace="http://schemas.microsoft.com/developer/msbuild/2003" xmlns:msb="http://schemas.microsoft.com/developer/msbuild/2003" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <!-- ======================================================================================= -->
-    <xs:element name="Project">
-         <xs:annotation>
-            <xs:documentation><!-- _locID_text="Project" _locComment="" -->An MSBuild Project</xs:documentation>
+  <!-- ======================================================================================= -->
+  <xs:element name="Project">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="Project" _locComment="" -->An MSBuild Project
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="msb:ProjectLevelTagExceptTargetOrImportType" minOccurs="0" maxOccurs="unbounded"/>
+        <!-- must be at least one Target or Import tag-->
+        <xs:group ref="msb:TargetOrImportType"/>
+        <xs:group ref="msb:ProjectLevelTagType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="DefaultTargets" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            <!-- _locID_text="Project_DefaultTargets" _locComment="" -->Optional semi-colon separated list of one or more targets that will be built if no targets are otherwise specified
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InitialTargets" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            <!-- _locID_text="Project_InitialTargets" _locComment="" -->Optional semi-colon separated list of targets that should always be built before any other targets
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ToolsVersion" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            <!-- _locID_text="Project_ToolsVersion" _locComment="" -->Optional string describing the toolset version this project should normally be built with
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- ======================================================================================= -->
+  <xs:group name="ProjectLevelTagExceptTargetOrImportType">
+    <xs:choice>
+      <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
+      <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
+      <xs:element name="ItemDefinitionGroup" type="msb:ItemDefinitionGroupType"/>
+      <xs:element name="Choose" type="msb:ChooseType"/>
+      <xs:element name="UsingTask" type="msb:UsingTaskType"/>
+      <xs:element name="ProjectExtensions" type="msb:ProjectExtensionsType"/>
+    </xs:choice>
+  </xs:group>
+  <!-- ======================================================================================= -->
+  <xs:group name="ProjectLevelTagType">
+    <xs:choice>
+      <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
+      <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
+      <xs:element name="ItemDefinitionGroup" type="msb:ItemDefinitionGroupType"/>
+      <xs:element name="Choose" type="msb:ChooseType"/>
+      <xs:element name="UsingTask" type="msb:UsingTaskType"/>
+      <xs:element name="Target" type="msb:TargetType"/>
+      <xs:element name="Import" type="msb:ImportType"/>
+      <xs:element name="ImportGroup" type="msb:ImportGroupType"/>
+      <xs:element name="ProjectExtensions" type="msb:ProjectExtensionsType"/>
+    </xs:choice>
+  </xs:group>
+  <!-- ======================================================================================= -->
+  <xs:group name="TargetOrImportType">
+    <xs:choice>
+      <xs:element name="Target" type="msb:TargetType"/>
+      <xs:element name="Import" type="msb:ImportType"/>
+      <xs:element name="ImportGroup" type="msb:ImportGroupType"/>
+    </xs:choice>
+  </xs:group>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="TargetType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="TargetType" _locComment="" -->Groups tasks into a section of the build process
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="msb:Task"/>
+          <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
+          <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:element name="OnError" type="msb:OnErrorType" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- no elements are allowed under Target after an OnError element-->
+    </xs:sequence>
+    <xs:attribute name="Name" type="msb:non_empty_string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_Name" _locComment="" -->Name of the target
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DependsOnTargets" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_DependsOnTargets" _locComment="" -->Optional semi-colon separated list of targets that should be run before this target
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Inputs" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_Inputs" _locComment="" -->Optional semi-colon separated list of files that form inputs into this target. Their timestamps will be compared with the timestamps of files in Outputs to determine whether the Target is up to date
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Outputs" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_Outputs" _locComment="" -->Optional semi-colon separated list of files that form outputs into this target. Their timestamps will be compared with the timestamps of files in Inputs to determine whether the Target is up to date
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_Condition" _locComment="" -->Optional expression evaluated to determine whether the Target and the targets it depends on should be run
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="KeepDuplicateOutputs" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_KeepDuplicateOutputs" _locComment="" -->Optional expression evaluated to determine whether duplicate items in the Target's Returns should be removed before returning them. The default is not to eliminate duplicates.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Returns" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_Returns" _locComment="" -->Optional expression evaluated to determine which items generated by the target should be returned by the target. If there are no Returns attributes on Targets in the file, the Outputs attributes are used instead for this purpose.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="BeforeTargets" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_BeforeTargets" _locComment="" -->Optional semi-colon separated list of targets that this target should run before.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="AfterTargets" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TargetType_AfterTargets" _locComment="" -->Optional semi-colon separated list of targets that this target should run after.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="PropertyGroupType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="PropertyGroupType" _locComment="" -->Groups property definitions
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="msb:Property"/>
+    </xs:sequence>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="PropertyGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the PropertyGroup should be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="PropertyGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ImportGroupType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ImportGroupType" _locComment="" -->Groups import definitions
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="Import" type="msb:ImportType"/>
+    </xs:sequence>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the ImportGroup should be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ItemGroupType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ItemGroupType" _locComment="" -->Groups item list definitions
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="msb:Item"/>
+      <xs:element name="Link" type="msb:LinkItem" />
+      <xs:element name="ResourceCompile" type="msb:ResourceCompile" />
+      <xs:element name="PreBuildEvent" type="msb:PreBuildEventItem" />
+      <xs:element name="PostBuildEvent" type="msb:PostBuildEventItem" />
+    </xs:choice>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ItemGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the ItemGroup should be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ItemGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ItemDefinitionGroupType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ItemDefinitionGroupType" _locComment="" -->Groups item metadata definitions
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="msb:Item"/>
+      <xs:element name="Link" type="msb:LinkItem" />
+      <xs:element name="ResourceCompile" type="msb:ResourceCompile" />
+      <xs:element name="PreBuildEvent" type="msb:PreBuildEventItem" />
+      <xs:element name="PostBuildEvent" type="msb:PostBuildEventItem" />
+    </xs:choice>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ItemDefinitionGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the ItemDefinitionGroup should be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ItemDefinitionGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ChooseType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ChooseType" _locComment="" -->Groups When and Otherwise elements
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="When" type="msb:WhenType" maxOccurs="unbounded"/>
+      <xs:element name="Otherwise" type="msb:OtherwiseType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ChooseType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="WhenType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="WhenType" _locComment="" -->Groups PropertyGroup and/or ItemGroup elements
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:choice>
+        <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
+        <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
+        <xs:element name="Choose" type="msb:ChooseType"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="Condition" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="WhenType_Condition" _locComment="" -->Optional expression evaluated to determine whether the child PropertyGroups and/or ItemGroups should be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="OtherwiseType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OtherwiseType" _locComment="" -->Groups PropertyGroup and/or ItemGroup elements that are used if no Conditions on sibling When elements evaluate to true
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:choice>
+        <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
+        <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
+        <xs:element name="Choose" type="msb:ChooseType"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="OnErrorType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="OnErrorType" _locComment="" -->Specifies targets to execute in the event of a recoverable error
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="OnErrorType_Condition" _locComment="" -->Optional expression evaluated to determine whether the targets should be executed
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ExecuteTargets" type="msb:non_empty_string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="OnErrorType_ExecuteTargets" _locComment="" -->Semi-colon separated list of targets to execute
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="UsingTaskType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UsingTaskType" _locComment="" -->Defines the assembly containing a task's implementation, or contains the implementation itself.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ParameterGroup" type="msb:ParameterGroupType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Task" type="msb:UsingTaskBodyType" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_Condition" _locComment="" -->Optional expression evaluated to determine whether the declaration should be evaluated
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="AssemblyName" type="msb:non_empty_string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_AssemblyName" _locComment="" -->Optional name of assembly containing the task. Either AssemblyName or AssemblyFile must be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="AssemblyFile" type="msb:non_empty_string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_AssemblyFile" _locComment="" -->Optional path to assembly containing the task. Either AssemblyName or AssemblyFile must be used
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="TaskName" type="msb:non_empty_string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_TaskName" _locComment="" -->Name of task class in the assembly
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="TaskFactory" type="msb:non_empty_string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_TaskFactory" _locComment="" -->Name of the task factory class in the assembly
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Architecture" type="msb:architecture" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_Architecture" _locComment="" -->Defines the architecture of the task host that this task should be run in.  Currently supported values:  x86, x64, CurrentArchitecture, and * (any).  If Architecture is not specified, either the task will be run within the MSBuild process, or the task host will be launched using the architecture of the parent MSBuild process
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Runtime" type="msb:runtime" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskType_Runtime" _locComment="" -->Defines the .NET runtime version of the task host that this task should be run in.  Currently supported values:  CLR2, CLR4, CurrentRuntime, and * (any).  If Runtime is not specified, either the task will be run within the MSBuild process, or the task host will be launched using the runtime of the parent MSBuild process
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ParameterGroupType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ParameterGroupType" _locComment="" -->Groups parameters that are part of an inline task definition.
+      </xs:documentation>
+    </xs:annotation>
+    <!-- ParameterGroup contains parameter elements whose element names are the parameter names.
+         Attributes are:
+              * ParameterType. Optional string. Type of the task parameter. Defaults to string type.
+              * Output. Optional bool. Whether this task parameter can be retrieved as an output. Defaults to false.
+              * Required. Optional bool. Whether this task parameter is required to be passed a value. Defaults to false.
+         It is not possible to validate attributes on elements with undefined names using XSD.
+      -->
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:any processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="UsingTaskBodyType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="UsingTaskBodyType" _locComment="" -->Contains the inline task implementation. Content is opaque to MSBuild.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:any namespace="##any" processContents="skip"/>
+    </xs:sequence>
+    <xs:attribute name="Evaluate" type="msb:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="UsingTaskBodyType_Evaluate" _locComment="" -->Whether the body should have properties expanded before use. Defaults to false.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ImportType">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ImportType" _locComment="" -->Declares that the contents of another project file should be inserted at this location
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportType_Condition" _locComment="" -->Optional expression evaluated to determine whether the import should occur
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Project" type="msb:non_empty_string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportType_Project" _locComment="" -->Project file to import
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="ProjectExtensionsType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <!-- _locID_text="ProjectExtensionsType" _locComment="" -->Optional section used by MSBuild hosts, that may contain arbitrary XML content that is ignored by MSBuild itself
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:any processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:element name="Item" type="msb:SimpleItemType" abstract="true"/>
+  <!-- ======================================================================================= -->
+  <!-- convenience type for items that have no meta-data-->
+  <!-- note this allows Remove or no attribute instead of Include, which is too lax outside of Targets at present, but
+       it's the best we can reasonably do with an XSD -->
+  <xs:complexType name="SimpleItemType">
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="SimpleItemType_Condition" _locComment="" -->Optional expression evaluated to determine whether the items should be evaluated
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Include" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="SimpleItemType_Include" _locComment="" -->Semi-colon separated list of files (wildcards are allowed) or other item names to include in this item list
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Exclude" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="SimpleItemType_Exclude" _locComment="" -->Semi-colon separated list of files (wildcards are allowed) or other item names to exclude from the Include list
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Remove" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="SimpleItemType_Remove" _locComment="" -->Semi-colon separated list of files (wildcards are allowed) or other item names to remove from the existing list contents
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <!-- general utility type allowing an item type to be defined but not its child meta-data-->
+  <xs:complexType name="GenericItemType">
+    <xs:complexContent>
+      <xs:extension base="msb:SimpleItemType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:any namespace="##any" processContents="skip"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <!-- no type declared on this abstract element, so either a simple or complex type can be substituted for it.-->
+  <xs:element name="Property" abstract="true"/>
+  <!-- ======================================================================================= -->
+  <!-- convenience type for properties that just want to allow text and no elements in them-->
+  <xs:complexType name="StringPropertyType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="Condition" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              <!-- _locID_text="StringPropertyType_Condition" _locComment="" -->Optional expression evaluated to determine whether the property should be evaluated
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="Label" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <!-- general utility type allowing text and/or elements inside-->
+  <xs:complexType name="GenericPropertyType" mixed="true">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:any namespace="##any" processContents="skip"/>
+    </xs:sequence>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="GenericPropertyType_Condition" _locComment="" -->Optional expression evaluated to determine whether the property should be evaluated
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Label" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <xs:element name="Task" type="msb:TaskType" abstract="true"/>
+  <!-- ======================================================================================= -->
+  <xs:complexType name="TaskType">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="Output">
+        <xs:annotation>
+          <xs:documentation>
+            <!-- _locID_text="TaskType_Output" _locComment="" -->Optional element specifying a specific task output to be gathered
+          </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:group ref="msb:ProjectLevelTagExceptTargetOrImportType" minOccurs="0" maxOccurs="unbounded"/>
-                <!-- must be at least one Target or Import tag-->
-                <xs:group ref="msb:TargetOrImportType"/>
-                <xs:group ref="msb:ProjectLevelTagType" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-            <xs:attribute name="DefaultTargets" type="xs:string" use="optional">
-                <xs:annotation>
-                    <xs:documentation><!-- _locID_text="Project_DefaultTargets" _locComment="" -->Optional semi-colon separated list of one or more targets that will be built if no targets are otherwise specified</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="InitialTargets" type="xs:string" use="optional">
-                <xs:annotation>
-                    <xs:documentation><!-- _locID_text="Project_InitialTargets" _locComment="" -->Optional semi-colon separated list of targets that should always be built before any other targets</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="ToolsVersion" type="xs:string" use="optional">
-                <xs:annotation>
-                    <xs:documentation><!-- _locID_text="Project_ToolsVersion" _locComment="" -->Optional string describing the toolset version this project should normally be built with</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
+          <xs:attribute name="TaskParameter" type="msb:non_empty_string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="TaskType_Output_TaskParameter" _locComment="" -->Task parameter to gather. Matches the name of a .NET Property on the task class that has an [Output] attribute
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="ItemName" type="msb:non_empty_string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="TaskType_Output_ItemName" _locComment="" -->Optional name of an item list to put the gathered outputs into. Either ItemName or PropertyName must be specified
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="PropertyName" type="msb:non_empty_string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="TaskType_Output_PropertyName" _locComment="" -->Optional name of a property to put the gathered output into. Either PropertyName or ItemName must be specified
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="Condition" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                <!-- _locID_text="TaskType_Output_Condition" _locComment="" -->Optional expression evaluated to determine whether the output should be gathered
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         </xs:complexType>
-    </xs:element>
-    <!-- ======================================================================================= -->
-    <xs:group name="ProjectLevelTagExceptTargetOrImportType">
-        <xs:choice>
-            <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
-            <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
-            <xs:element name="ItemDefinitionGroup" type="msb:ItemDefinitionGroupType"/>
-            <xs:element name="Choose" type="msb:ChooseType"/>
-            <xs:element name="UsingTask" type="msb:UsingTaskType"/>
-            <xs:element name="ProjectExtensions" type="msb:ProjectExtensionsType"/>
-        </xs:choice>
-    </xs:group>
-    <!-- ======================================================================================= -->    
-    <xs:group name="ProjectLevelTagType">
-        <xs:choice>
-            <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
-            <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
-            <xs:element name="ItemDefinitionGroup" type="msb:ItemDefinitionGroupType"/>
-            <xs:element name="Choose" type="msb:ChooseType"/>
-            <xs:element name="UsingTask" type="msb:UsingTaskType"/>
-            <xs:element name="Target" type="msb:TargetType"/>
-            <xs:element name="Import" type="msb:ImportType"/>
-            <xs:element name="ImportGroup" type="msb:ImportGroupType"/>
-            <xs:element name="ProjectExtensions" type="msb:ProjectExtensionsType"/>
-        </xs:choice>
-    </xs:group>
-    <!-- ======================================================================================= -->
-    <xs:group name="TargetOrImportType">
-        <xs:choice>
-            <xs:element name="Target" type="msb:TargetType"/>
-            <xs:element name="Import" type="msb:ImportType"/>
-            <xs:element name="ImportGroup" type="msb:ImportGroupType"/>
-        </xs:choice>
-    </xs:group>    
-    <!-- ======================================================================================= -->        
-    <xs:complexType name="TargetType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="TargetType" _locComment="" -->Groups tasks into a section of the build process</xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="msb:Task"/>
-                    <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
-                    <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
-                </xs:choice>
-            </xs:sequence>
-            <xs:element name="OnError" type="msb:OnErrorType" minOccurs="0" maxOccurs="unbounded"/>
-            <!-- no elements are allowed under Target after an OnError element-->
-        </xs:sequence>
-        <xs:attribute name="Name" type="msb:non_empty_string" use="required">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_Name" _locComment="" -->Name of the target</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="DependsOnTargets" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_DependsOnTargets" _locComment="" -->Optional semi-colon separated list of targets that should be run before this target</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>            
-        <xs:attribute name="Inputs" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_Inputs" _locComment="" -->Optional semi-colon separated list of files that form inputs into this target. Their timestamps will be compared with the timestamps of files in Outputs to determine whether the Target is up to date</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>                
-        <xs:attribute name="Outputs" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_Outputs" _locComment="" -->Optional semi-colon separated list of files that form outputs into this target. Their timestamps will be compared with the timestamps of files in Inputs to determine whether the Target is up to date</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_Condition" _locComment="" -->Optional expression evaluated to determine whether the Target and the targets it depends on should be run</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>            
-        <xs:attribute name="KeepDuplicateOutputs" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_KeepDuplicateOutputs" _locComment="" -->Optional expression evaluated to determine whether duplicate items in the Target's Returns should be removed before returning them. The default is not to eliminate duplicates.</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Returns" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_Returns" _locComment="" -->Optional expression evaluated to determine which items generated by the target should be returned by the target. If there are no Returns attributes on Targets in the file, the Outputs attributes are used instead for this purpose.</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="BeforeTargets" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_BeforeTargets" _locComment="" -->Optional semi-colon separated list of targets that this target should run before.</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>   
-        <xs:attribute name="AfterTargets" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TargetType_AfterTargets" _locComment="" -->Optional semi-colon separated list of targets that this target should run after.</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>     
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->        
-    <xs:complexType name="PropertyGroupType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="PropertyGroupType" _locComment="" -->Groups property definitions</xs:documentation>
-        </xs:annotation>
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="msb:Property"/>
-        </xs:sequence>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="PropertyGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the PropertyGroup should be used</xs:documentation>
-            </xs:annotation> 
-        </xs:attribute>     
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="PropertyGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->        
-    <xs:complexType name="ImportGroupType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ImportGroupType" _locComment="" -->Groups import definitions</xs:documentation>
-        </xs:annotation>
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="Import" type="msb:ImportType"/>
-        </xs:sequence>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the ImportGroup should be used</xs:documentation>
-            </xs:annotation> 
-        </xs:attribute>     
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->        
-    <xs:complexType name="ItemGroupType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ItemGroupType" _locComment="" -->Groups item list definitions</xs:documentation>
-        </xs:annotation>        
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="msb:Item"/>
-            <xs:element name="Link" type="msb:LinkItem" />
-            <xs:element name="ResourceCompile" type="msb:ResourceCompile" />
-            <xs:element name="PreBuildEvent" type="msb:PreBuildEventItem" />
-            <xs:element name="PostBuildEvent" type="msb:PostBuildEventItem" />
-        </xs:choice>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ItemGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the ItemGroup should be used</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>     
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ItemGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->        
-    <xs:complexType name="ItemDefinitionGroupType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ItemDefinitionGroupType" _locComment="" -->Groups item metadata definitions</xs:documentation>
-        </xs:annotation>
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element ref="msb:Item"/>
-            <xs:element name="Link" type="msb:LinkItem" />
-            <xs:element name="ResourceCompile" type="msb:ResourceCompile" />
-            <xs:element name="PreBuildEvent" type="msb:PreBuildEventItem" />
-            <xs:element name="PostBuildEvent" type="msb:PostBuildEventItem" />
-        </xs:choice>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-          <xs:annotation>
-             <xs:documentation><!-- _locID_text="ItemDefinitionGroupType_Condition" _locComment="" -->Optional expression evaluated to determine whether the ItemDefinitionGroup should be used</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ItemDefinitionGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->
-    <xs:complexType name="ChooseType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ChooseType" _locComment="" -->Groups When and Otherwise elements</xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="When" type="msb:WhenType" maxOccurs="unbounded"/>
-            <xs:element name="Otherwise" type="msb:OtherwiseType" minOccurs="0"/>
-        </xs:sequence>
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ChooseType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->
-    <xs:complexType name="WhenType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="WhenType" _locComment="" -->Groups PropertyGroup and/or ItemGroup elements</xs:documentation>
-        </xs:annotation>
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:choice>
-                <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
-                <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
-                <xs:element name="Choose" type="msb:ChooseType"/>
-            </xs:choice>
-        </xs:sequence>
-        <xs:attribute name="Condition" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="WhenType_Condition" _locComment="" -->Optional expression evaluated to determine whether the child PropertyGroups and/or ItemGroups should be used</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->
-    <xs:complexType name="OtherwiseType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OtherwiseType" _locComment="" -->Groups PropertyGroup and/or ItemGroup elements that are used if no Conditions on sibling When elements evaluate to true</xs:documentation>
-        </xs:annotation>        
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:choice>
-                <xs:element name="PropertyGroup" type="msb:PropertyGroupType"/>
-                <xs:element name="ItemGroup" type="msb:ItemGroupType"/>
-                <xs:element name="Choose" type="msb:ChooseType"/>
-            </xs:choice>
-        </xs:sequence>
-    </xs:complexType>
-    <!-- ======================================================================================= -->        
-    <xs:complexType name="OnErrorType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="OnErrorType" _locComment="" -->Specifies targets to execute in the event of a recoverable error</xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="OnErrorType_Condition" _locComment="" -->Optional expression evaluated to determine whether the targets should be executed</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="ExecuteTargets" type="msb:non_empty_string" use="required">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="OnErrorType_ExecuteTargets" _locComment="" -->Semi-colon separated list of targets to execute</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>    
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>        
-    </xs:complexType>
-    <!-- ======================================================================================= -->    
-    <xs:complexType name="UsingTaskType">
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="Condition" type="xs:string" use="optional">
       <xs:annotation>
-        <xs:documentation><!-- _locID_text="UsingTaskType" _locComment="" -->Defines the assembly containing a task's implementation, or contains the implementation itself.</xs:documentation>
+        <xs:documentation>
+          <!-- _locID_text="TaskType_Condition" _locComment="" -->Optional expression evaluated to determine whether the task should be executed
+        </xs:documentation>
       </xs:annotation>
-      <xs:sequence>
-        <xs:element name="ParameterGroup" type="msb:ParameterGroupType" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="Task" type="msb:UsingTaskBodyType" minOccurs="0" maxOccurs="1"/>    
-      </xs:sequence> 
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="UsingTaskType_Condition" _locComment="" -->Optional expression evaluated to determine whether the declaration should be evaluated</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>          
-        <xs:attribute name="AssemblyName" type="msb:non_empty_string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="UsingTaskType_AssemblyName" _locComment="" -->Optional name of assembly containing the task. Either AssemblyName or AssemblyFile must be used</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="AssemblyFile" type="msb:non_empty_string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="UsingTaskType_AssemblyFile" _locComment="" -->Optional path to assembly containing the task. Either AssemblyName or AssemblyFile must be used</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>            
-        <xs:attribute name="TaskName" type="msb:non_empty_string" use="required">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="UsingTaskType_TaskName" _locComment="" -->Name of task class in the assembly</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="TaskFactory" type="msb:non_empty_string" use="optional">
-          <xs:annotation>
-            <xs:documentation><!-- _locID_text="UsingTaskType_TaskFactory" _locComment="" -->Name of the task factory class in the assembly</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Architecture" type="msb:architecture" use="optional">
-          <xs:annotation>
-            <xs:documentation>
-              <!-- _locID_text="UsingTaskType_Architecture" _locComment="" -->Defines the architecture of the task host that this task should be run in.  Currently supported values:  x86, x64, CurrentArchitecture, and * (any).  If Architecture is not specified, either the task will be run within the MSBuild process, or the task host will be launched using the architecture of the parent MSBuild process
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Runtime" type="msb:runtime" use="optional">
-          <xs:annotation>
-            <xs:documentation>
-              <!-- _locID_text="UsingTaskType_Runtime" _locComment="" -->Defines the .NET runtime version of the task host that this task should be run in.  Currently supported values:  CLR2, CLR4, CurrentRuntime, and * (any).  If Runtime is not specified, either the task will be run within the MSBuild process, or the task host will be launched using the runtime of the parent MSBuild process
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-    </xs:complexType> 
-    <!-- ======================================================================================= -->
-    <xs:complexType name="ParameterGroupType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ParameterGroupType" _locComment="" -->Groups parameters that are part of an inline task definition.</xs:documentation>
-        </xs:annotation> 
-        <!-- ParameterGroup contains parameter elements whose element names are the parameter names.
-             Attributes are:
-                  * ParameterType. Optional string. Type of the task parameter. Defaults to string type.
-                  * Output. Optional bool. Whether this task parameter can be retrieved as an output. Defaults to false.
-                  * Required. Optional bool. Whether this task parameter is required to be passed a value. Defaults to false.
-             It is not possible to validate attributes on elements with undefined names using XSD.
-          -->
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-           <xs:any processContents="skip"/>
-        </xs:sequence>
-    </xs:complexType>     
-    <!-- ======================================================================================= -->
-    <xs:complexType name="UsingTaskBodyType" mixed="true">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="UsingTaskBodyType" _locComment="" -->Contains the inline task implementation. Content is opaque to MSBuild.</xs:documentation>
-        </xs:annotation>
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:any namespace="##any" processContents="skip"/>
-        </xs:sequence>        
-        <xs:attribute name="Evaluate" type="msb:boolean" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="UsingTaskBodyType_Evaluate" _locComment="" -->Whether the body should have properties expanded before use. Defaults to false.</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>        
-    </xs:complexType>     
-    <!-- ======================================================================================= -->  
-    <xs:complexType name="ImportType">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ImportType" _locComment="" -->Declares that the contents of another project file should be inserted at this location</xs:documentation>
-        </xs:annotation>        
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportType_Condition" _locComment="" -->Optional expression evaluated to determine whether the import should occur</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>              
-        <xs:attribute name="Project" type="msb:non_empty_string" use="required">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportType_Project" _locComment="" -->Project file to import</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>     
-        <xs:attribute name="Label" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="ImportType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->  
-    <xs:complexType name="ProjectExtensionsType" mixed="true">
-        <xs:annotation>
-            <xs:documentation><!-- _locID_text="ProjectExtensionsType" _locComment="" -->Optional section used by MSBuild hosts, that may contain arbitrary XML content that is ignored by MSBuild itself</xs:documentation>
-        </xs:annotation>
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:any processContents="skip"/>
-        </xs:sequence>
-    </xs:complexType>    
-    <!-- ======================================================================================= -->
-    <xs:element name="Item" type="msb:SimpleItemType" abstract="true"/>
-    <!-- ======================================================================================= -->   
-    <!-- convenience type for items that have no meta-data-->
-    <!-- note this allows Remove or no attribute instead of Include, which is too lax outside of Targets at present, but 
-         it's the best we can reasonably do with an XSD -->
-    <xs:complexType name="SimpleItemType">
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="SimpleItemType_Condition" _locComment="" -->Optional expression evaluated to determine whether the items should be evaluated</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Include" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="SimpleItemType_Include" _locComment="" -->Semi-colon separated list of files (wildcards are allowed) or other item names to include in this item list</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>             
-        <xs:attribute name="Exclude" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="SimpleItemType_Exclude" _locComment="" -->Semi-colon separated list of files (wildcards are allowed) or other item names to exclude from the Include list</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Remove" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="SimpleItemType_Remove" _locComment="" -->Semi-colon separated list of files (wildcards are allowed) or other item names to remove from the existing list contents</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Label" type="xs:string" use="optional">
-          <xs:annotation>
-            <xs:documentation>
-              <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->      
-    <!-- general utility type allowing an item type to be defined but not its child meta-data-->
-    <xs:complexType name="GenericItemType">
-        <xs:complexContent>
-            <xs:extension base="msb:SimpleItemType">
-                <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                    <xs:any namespace="##any" processContents="skip"/>  
-                </xs:sequence>      
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-    <!-- ======================================================================================= -->  
-    <!-- no type declared on this abstract element, so either a simple or complex type can be substituted for it.-->
-    <xs:element name="Property" abstract="true"/>
-    <!-- ======================================================================================= -->      
-    <!-- convenience type for properties that just want to allow text and no elements in them-->
-    <xs:complexType name="StringPropertyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="Condition" type="xs:string" use="optional">
-                    <xs:annotation>
-                        <xs:documentation><!-- _locID_text="StringPropertyType_Condition" _locComment="" -->Optional expression evaluated to determine whether the property should be evaluated</xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="Label" type="xs:string" use="optional">
-                  <xs:annotation>
-                    <xs:documentation>
-                      <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
-                    </xs:documentation>
-                  </xs:annotation>
-                </xs:attribute>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-    <!-- ======================================================================================= -->      
-    <!-- general utility type allowing text and/or elements inside-->
-    <xs:complexType name="GenericPropertyType" mixed="true">
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:any namespace="##any" processContents="skip"/>
-        </xs:sequence>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="GenericPropertyType_Condition" _locComment="" -->Optional expression evaluated to determine whether the property should be evaluated</xs:documentation>
-            </xs:annotation>         
-        </xs:attribute>
-        <xs:attribute name="Label" type="xs:string" use="optional">
-          <xs:annotation>
-            <xs:documentation>
-              <!-- _locID_text="ImportGroupType_Label" _locComment="" -->Optional expression. Used to identify or order system and user elements
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    <!-- ======================================================================================= -->
-    <xs:element name="Task" type="msb:TaskType" abstract="true"/>
-    <!-- ======================================================================================= -->
-    <xs:complexType name="TaskType">
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="Output">
-                <xs:annotation>
-                    <xs:documentation><!-- _locID_text="TaskType_Output" _locComment="" -->Optional element specifying a specific task output to be gathered</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="TaskParameter" type="msb:non_empty_string" use="required">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="TaskType_Output_TaskParameter" _locComment="" -->Task parameter to gather. Matches the name of a .NET Property on the task class that has an [Output] attribute</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="ItemName" type="msb:non_empty_string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="TaskType_Output_ItemName" _locComment="" -->Optional name of an item list to put the gathered outputs into. Either ItemName or PropertyName must be specified</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="PropertyName" type="msb:non_empty_string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="TaskType_Output_PropertyName" _locComment="" -->Optional name of a property to put the gathered output into. Either PropertyName or ItemName must be specified</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="Condition" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation><!-- _locID_text="TaskType_Output_Condition" _locComment="" -->Optional expression evaluated to determine whether the output should be gathered</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-        <xs:attribute name="Condition" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TaskType_Condition" _locComment="" -->Optional expression evaluated to determine whether the task should be executed</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="ContinueOnError" type="msb:boolean" use="optional">
-            <xs:annotation>
-                <xs:documentation><!-- _locID_text="TaskType_ContinueOnError" _locComment="" -->Optional boolean indicating whether a recoverable task error should be ignored. Default false</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Architecture" type="msb:architecture" use="optional">
-          <xs:annotation>
-            <xs:documentation>
-              <!-- _locID_text="TaskType_Architecture" _locComment="" -->Defines the bitness of the task if it must be run specifically in a 32bit or 64bit process. If not specified, it will run with the bitness of the build process.  If there are multiple tasks defined in UsingTask with the same name but with different Architecture attribute values, the value of the Architecture attribute specified here will be used to match and select the correct task
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="Runtime" type="msb:runtime" use="optional">
-          <xs:annotation>
-            <xs:documentation>
-              <!-- _locID_text="TaskType_Runtime" _locComment="" -->Defines the .NET runtime of the task. This must be specified if the task must run on a specific version of the .NET runtime. If not specified, the task will run on the runtime being used by the build process. If there are multiple tasks defined in UsingTask with the same name but with different Runtime attribute values, the value of the Runtime attribute specified here will be used to match and select the correct task
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <!-- We don't need the anyAttribute here because other types deriving from this type will add the right attributes.-->
-    </xs:complexType>
-    <!-- ======================================================================================= -->  
-    <!-- XSD considers an empty-valued attribute to satisfy use="required", but we want it to have a non-empty value in most cases, hence this utility type. -->
-    <xs:simpleType name="non_empty_string">
+    </xs:attribute>
+    <xs:attribute name="ContinueOnError" type="msb:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TaskType_ContinueOnError" _locComment="" -->Optional boolean indicating whether a recoverable task error should be ignored. Default false
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Architecture" type="msb:architecture" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TaskType_Architecture" _locComment="" -->Defines the bitness of the task if it must be run specifically in a 32bit or 64bit process. If not specified, it will run with the bitness of the build process.  If there are multiple tasks defined in UsingTask with the same name but with different Architecture attribute values, the value of the Architecture attribute specified here will be used to match and select the correct task
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Runtime" type="msb:runtime" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <!-- _locID_text="TaskType_Runtime" _locComment="" -->Defines the .NET runtime of the task. This must be specified if the task must run on a specific version of the .NET runtime. If not specified, the task will run on the runtime being used by the build process. If there are multiple tasks defined in UsingTask with the same name but with different Runtime attribute values, the value of the Runtime attribute specified here will be used to match and select the correct task
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <!-- We don't need the anyAttribute here because other types deriving from this type will add the right attributes.-->
+  </xs:complexType>
+  <!-- ======================================================================================= -->
+  <!-- XSD considers an empty-valued attribute to satisfy use="required", but we want it to have a non-empty value in most cases, hence this utility type. -->
+  <xs:simpleType name="non_empty_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <!-- This type causes intellisense to suggest "true" or "false", but doesn't actually constrain the value beyond msb:non_empty_string.
+  We can't constrain the value, because the project author might want to pass a property or item instead of a literal value.
+  Besides, MSBuild will accept other literal values, like "on" and "off", just as well. -->
+  <xs:simpleType name="boolean">
+    <xs:union memberTypes="msb:non_empty_string">
+      <xs:simpleType>
         <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
+          <xs:enumeration value="true" />
+          <xs:enumeration value="false" />
         </xs:restriction>
-    </xs:simpleType>
-    <!-- This type causes intellisense to suggest "true" or "false", but doesn't actually constrain the value beyond msb:non_empty_string.
-    We can't constrain the value, because the project author might want to pass a property or item instead of a literal value.
-    Besides, MSBuild will accept other literal values, like "on" and "off", just as well. -->
-    <xs:simpleType name="boolean">
-        <xs:union memberTypes="msb:non_empty_string">
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="true" />
-                    <xs:enumeration value="false" />
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <!-- Similar trick for Importance -->
-    <xs:simpleType name="importance">
-        <xs:union memberTypes="msb:non_empty_string">
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="high" />
-                    <xs:enumeration value="normal" />
-                    <xs:enumeration value="low" />
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
-    </xs:simpleType>
-    <!-- Similar trick for Architecture -->
-    <xs:simpleType name="architecture">
-      <xs:union memberTypes="msb:non_empty_string">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="*" />
-            <xs:enumeration value="CurrentArchitecture" />
-            <xs:enumeration value="x86" />
-            <xs:enumeration value="x64" />
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:union>
-    </xs:simpleType>
-    <!-- Similar trick for Runtime -->
-    <xs:simpleType name="runtime">
-      <xs:union memberTypes="msb:non_empty_string">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="*" />
-            <xs:enumeration value="CurrentRuntime" />
-            <xs:enumeration value="CLR2" />
-            <xs:enumeration value="CLR4" />
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:union>
-    </xs:simpleType>
-    <!-- ======================================================================================= -->  
-    <!-- These types are used to enable Tasks and TaskItems global elements to exist in the schema. 
-         They cannot both be declared as "Link" Elements of differing types in global scope. -->
-    <xs:complexType name="LinkItem">
-      <xs:complexContent>
-        <xs:extension base="msb:SimpleItemType">
-          <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="AdditionalDependencies" />
-            <xs:element name="OutputFile" />
-            <xs:element name="AssemblyDebug" />
-            <xs:element name="SubSystem" />
-            <xs:element name="ShowProgress" />
-            <xs:element name="GenerateDebugInformation" />
-            <xs:element name="EnableCOMDATFolding" />
-            <xs:element name="OptimizeReferences" />
-            <xs:element name="Version" />
-            <xs:element name="Driver"/>
-            <xs:element name="RandomizedBaseAddress" />
-            <xs:element name="SuppressStartupBanner" />
-            <xs:element name="AdditionalLibraryDirectories" />
-            <xs:element name="Profile" />
-            <xs:element name="LinkStatus" />
-            <xs:element name="FixedBaseAddress"/>
-            <xs:element name="DataExecutionPrevention" />
-            <xs:element name="SwapRunFromCD"/>
-            <xs:element name="SwapRunFromNET" />
-            <xs:element name="RegisterOutput" />
-            <xs:element name="AllowIsolation" />
-            <xs:element name="EnableUAC" />
-            <xs:element name="UACExecutionLevel" />
-            <xs:element name="UACUIAccess" />
-            <xs:element name="PreventDllBinding" />
-            <xs:element name="IgnoreStandardIncludePath"/>
-            <xs:element name="GenerateMapFile" />
-            <xs:element name="IgnoreEmbeddedIDL" />
-            <xs:element name="TypeLibraryResourceID" />
-            <xs:element name="LinkErrorReporting" />
-            <xs:element name="MapExports"/>
-            <xs:element name="TargetMachine" />
-            <xs:element name="TreatLinkerWarningAsErrors" />
-            <xs:element name="ForceFileOutput" />
-            <xs:element name="CreateHotPatchableImage" />
-            <xs:element name="SpecifySectionAttributes" />
-            <xs:element name="MSDOSStubFileName" />
-            <xs:element name="IgnoreAllDefaultLibraries" />
-            <xs:element name="IgnoreSpecificDefaultLibraries" />
-            <xs:element name="ModuleDefinitionFile" />
-            <xs:element name="AddModuleNamesToAssembly" />
-            <xs:element name="EmbedManagedResourceFile" />
-            <xs:element name="ForceSymbolReferences" />
-            <xs:element name="DelayLoadDLLs" />
-            <xs:element name="AssemblyLinkResource" />
-            <xs:element name="AdditionalManifestDependencies" />
-            <xs:element name="StripPrivateSymbols" />
-            <xs:element name="MapFileName" />
-            <xs:element name="MinimumRequiredVersion" />
-            <xs:element name="HeapReserveSize" />
-            <xs:element name="HeapCommitSize" />
-            <xs:element name="StackReserveSize" />
-            <xs:element name="StackCommitSize" />
-            <xs:element name="LargeAddressAware" />
-            <xs:element name="TerminalServerAware" />
-            <xs:element name="FunctionOrder" />
-            <xs:element name="ProfileGuidedDatabase" />
-            <xs:element name="LinkTimeCodeGeneration" />
-            <xs:element name="MidlCommandFile" />
-            <xs:element name="MergedIDLBaseFileName" />
-            <xs:element name="TypeLibraryFile" />
-            <xs:element name="EntryPointSymbol" />
-            <xs:element name="BaseAddress" />
-            <xs:element name="ProgramDatabaseFile"/>
-            <xs:element name="SupportUnloadOfDelayLoadedDLL" />
-            <xs:element name="SupportNobindOfDelayLoadedDLL" />
-            <xs:element name="ImportLibrary" />
-            <xs:element name="MergeSections" />
-            <xs:element name="CLRThreadAttribute" />
-            <xs:element name="CLRImageType" />
-            <xs:element name="KeyFile" />
-            <xs:element name="KeyContainer" />
-            <xs:element name="DelaySign" />
-            <xs:element name="CLRUnmanagedCodeCheck" />
-            <xs:element name="SectionAlignment" />
-            <xs:element name="CLRSupportLastError" />
-            <xs:element name="ImageHasSafeExceptionHandlers" />
-          </xs:choice>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-    <xs:complexType name="ResourceCompile">
-      <xs:complexContent>
-        <xs:extension base="msb:SimpleItemType">
-          <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="Culture" />
-            <xs:element name="PreprocessorDefinitions" />
-            <xs:element name="UndefinePreprocessorDefinitions" />
-            <xs:element name="AdditionalIncludeDirectories" />
-            <xs:element name="IgnoreStandardIncludePath" />
-            <xs:element name="ShowProgress" />
-            <xs:element name="NullTerminateStrings" />
-            <xs:element name="SuppressStartupBanner" />
-            <xs:element name="ResourceOutputFileName" />
-          </xs:choice>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-    <xs:complexType name="PreBuildEventItem" >
-      <xs:complexContent>
-        <xs:extension base="msb:SimpleItemType">
-            <xs:choice minOccurs="0" maxOccurs="unbounded">
-              <xs:element name="Message" />
-              <xs:element name="Command" />
-            </xs:choice>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-    <xs:complexType name="PostBuildEventItem" >
-      <xs:complexContent>
-        <xs:extension base="msb:SimpleItemType">
-            <xs:choice minOccurs="0" maxOccurs="unbounded">
-              <xs:element name="Message" />
-              <xs:element name="Command" />
-            </xs:choice>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <!-- Similar trick for Importance -->
+  <xs:simpleType name="importance">
+    <xs:union memberTypes="msb:non_empty_string">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="high" />
+          <xs:enumeration value="normal" />
+          <xs:enumeration value="low" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <!-- Similar trick for Architecture -->
+  <xs:simpleType name="architecture">
+    <xs:union memberTypes="msb:non_empty_string">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="*" />
+          <xs:enumeration value="CurrentArchitecture" />
+          <xs:enumeration value="x86" />
+          <xs:enumeration value="x64" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <!-- Similar trick for Runtime -->
+  <xs:simpleType name="runtime">
+    <xs:union memberTypes="msb:non_empty_string">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="*" />
+          <xs:enumeration value="CurrentRuntime" />
+          <xs:enumeration value="CLR2" />
+          <xs:enumeration value="CLR4" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <!-- ======================================================================================= -->
+  <!-- These types are used to enable Tasks and TaskItems global elements to exist in the schema.
+       They cannot both be declared as "Link" Elements of differing types in global scope. -->
+  <xs:complexType name="LinkItem">
+    <xs:complexContent>
+      <xs:extension base="msb:SimpleItemType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="AdditionalDependencies" />
+          <xs:element name="OutputFile" />
+          <xs:element name="AssemblyDebug" />
+          <xs:element name="SubSystem" />
+          <xs:element name="ShowProgress" />
+          <xs:element name="GenerateDebugInformation" />
+          <xs:element name="EnableCOMDATFolding" />
+          <xs:element name="OptimizeReferences" />
+          <xs:element name="Version" />
+          <xs:element name="Driver"/>
+          <xs:element name="RandomizedBaseAddress" />
+          <xs:element name="SuppressStartupBanner" />
+          <xs:element name="AdditionalLibraryDirectories" />
+          <xs:element name="Profile" />
+          <xs:element name="LinkStatus" />
+          <xs:element name="FixedBaseAddress"/>
+          <xs:element name="DataExecutionPrevention" />
+          <xs:element name="SwapRunFromCD"/>
+          <xs:element name="SwapRunFromNET" />
+          <xs:element name="RegisterOutput" />
+          <xs:element name="AllowIsolation" />
+          <xs:element name="EnableUAC" />
+          <xs:element name="UACExecutionLevel" />
+          <xs:element name="UACUIAccess" />
+          <xs:element name="PreventDllBinding" />
+          <xs:element name="IgnoreStandardIncludePath"/>
+          <xs:element name="GenerateMapFile" />
+          <xs:element name="IgnoreEmbeddedIDL" />
+          <xs:element name="TypeLibraryResourceID" />
+          <xs:element name="LinkErrorReporting" />
+          <xs:element name="MapExports"/>
+          <xs:element name="TargetMachine" />
+          <xs:element name="TreatLinkerWarningAsErrors" />
+          <xs:element name="ForceFileOutput" />
+          <xs:element name="CreateHotPatchableImage" />
+          <xs:element name="SpecifySectionAttributes" />
+          <xs:element name="MSDOSStubFileName" />
+          <xs:element name="IgnoreAllDefaultLibraries" />
+          <xs:element name="IgnoreSpecificDefaultLibraries" />
+          <xs:element name="ModuleDefinitionFile" />
+          <xs:element name="AddModuleNamesToAssembly" />
+          <xs:element name="EmbedManagedResourceFile" />
+          <xs:element name="ForceSymbolReferences" />
+          <xs:element name="DelayLoadDLLs" />
+          <xs:element name="AssemblyLinkResource" />
+          <xs:element name="AdditionalManifestDependencies" />
+          <xs:element name="StripPrivateSymbols" />
+          <xs:element name="MapFileName" />
+          <xs:element name="MinimumRequiredVersion" />
+          <xs:element name="HeapReserveSize" />
+          <xs:element name="HeapCommitSize" />
+          <xs:element name="StackReserveSize" />
+          <xs:element name="StackCommitSize" />
+          <xs:element name="LargeAddressAware" />
+          <xs:element name="TerminalServerAware" />
+          <xs:element name="FunctionOrder" />
+          <xs:element name="ProfileGuidedDatabase" />
+          <xs:element name="LinkTimeCodeGeneration" />
+          <xs:element name="MidlCommandFile" />
+          <xs:element name="MergedIDLBaseFileName" />
+          <xs:element name="TypeLibraryFile" />
+          <xs:element name="EntryPointSymbol" />
+          <xs:element name="BaseAddress" />
+          <xs:element name="ProgramDatabaseFile"/>
+          <xs:element name="SupportUnloadOfDelayLoadedDLL" />
+          <xs:element name="SupportNobindOfDelayLoadedDLL" />
+          <xs:element name="ImportLibrary" />
+          <xs:element name="MergeSections" />
+          <xs:element name="CLRThreadAttribute" />
+          <xs:element name="CLRImageType" />
+          <xs:element name="KeyFile" />
+          <xs:element name="KeyContainer" />
+          <xs:element name="DelaySign" />
+          <xs:element name="CLRUnmanagedCodeCheck" />
+          <xs:element name="SectionAlignment" />
+          <xs:element name="CLRSupportLastError" />
+          <xs:element name="ImageHasSafeExceptionHandlers" />
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ResourceCompile">
+    <xs:complexContent>
+      <xs:extension base="msb:SimpleItemType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="Culture" />
+          <xs:element name="PreprocessorDefinitions" />
+          <xs:element name="UndefinePreprocessorDefinitions" />
+          <xs:element name="AdditionalIncludeDirectories" />
+          <xs:element name="IgnoreStandardIncludePath" />
+          <xs:element name="ShowProgress" />
+          <xs:element name="NullTerminateStrings" />
+          <xs:element name="SuppressStartupBanner" />
+          <xs:element name="ResourceOutputFileName" />
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PreBuildEventItem" >
+    <xs:complexContent>
+      <xs:extension base="msb:SimpleItemType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="Message" />
+          <xs:element name="Command" />
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PostBuildEventItem" >
+    <xs:complexContent>
+      <xs:extension base="msb:SimpleItemType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="Message" />
+          <xs:element name="Command" />
+        </xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
 </xs:schema>

--- a/src/XMakeCommandLine/Microsoft.Build.xsd
+++ b/src/XMakeCommandLine/Microsoft.Build.xsd
@@ -1,50 +1,49 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema targetNamespace="http://schemas.microsoft.com/developer/msbuild/2003" 
+<xs:schema targetNamespace="http://schemas.microsoft.com/developer/msbuild/2003"
 xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:msb="http://schemas.microsoft.com/developer/msbuild/2003"
 elementFormDefault="qualified">
 
-    <!-- =================== IMPORT COMMON SCHEMA =========================== -->
-    <xs:include schemaLocation="MSBuild\Microsoft.Build.CommonTypes.xsd"/>
+  <!-- =================== IMPORT COMMON SCHEMA =========================== -->
+  <xs:include schemaLocation="MSBuild\Microsoft.Build.CommonTypes.xsd"/>
 
-    <!-- ========= ADD CUSTOM ITEMS, PROPERTIES, AND TASKS BELOW ======= -->
-    <!-- Note that these will be in the msbuild namespace. A future version of
-        msbuild may require that custom itemtypes, properties, and tasks be in a 
-        custom namespace, but currently msbuild only supports the msbuild namespace. -->
-    
-    <!-- example custom itemtype with particular meta-data required-->
-    <!--<xs:element name="MyItem" substitutionGroup="msb:Item">
+  <!-- ========= ADD CUSTOM ITEMS, PROPERTIES, AND TASKS BELOW ======= -->
+  <!-- Note that these will be in the msbuild namespace. A future version of
+       msbuild may require that custom itemtypes, properties, and tasks be in a
+       custom namespace, but currently msbuild only supports the msbuild namespace. -->
+
+  <!-- example custom itemtype with particular meta-data required-->
+  <!--<xs:element name="MyItem" substitutionGroup="msb:Item">
         <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:SimpleItemType">
-                    <xs:sequence maxOccurs="1">
-                        <xs:choice>
-                            <xs:element name="MyMetaData" type="xs:string"/>
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
+          <xs:complexContent>
+            <xs:extension base="msb:SimpleItemType">
+              <xs:sequence maxOccurs="1">
+                <xs:choice>
+                  <xs:element name="MyMetaData" type="xs:string"/>
+                </xs:choice>
+              </xs:sequence>
+            </xs:extension>
+          </xs:complexContent>
         </xs:complexType>
-    </xs:element>-->
-    
-    <!-- Example custom itemtype with NO meta-data -->
-    <!--<xs:element name="MySimpleItem" type="msb:SimpleItemType" substitutionGroup="msb:Item"/>-->
-    
-    <!-- Example custom itemtype with ANY meta-data -->
-    <!--<xs:element name="MyFlexibleItem" type="msb:GenericItemType" substitutionGroup="msb:Item"/>-->
+      </xs:element>-->
 
-    <!-- example custom property that allows string content only-->
-    <!--<xs:element name="MySimpleProperty" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>-->
+  <!-- Example custom itemtype with NO meta-data -->
+  <!--<xs:element name="MySimpleItem" type="msb:SimpleItemType" substitutionGroup="msb:Item"/>-->
 
-    <!-- example custom task with single required parameter-->
-    <!--<xs:element name="MyTask" substitutionGroup="msb:Task">
+  <!-- Example custom itemtype with ANY meta-data -->
+  <!--<xs:element name="MyFlexibleItem" type="msb:GenericItemType" substitutionGroup="msb:Item"/>-->
+
+  <!-- example custom property that allows string content only-->
+  <!--<xs:element name="MySimpleProperty" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>-->
+
+  <!-- example custom task with single required parameter-->
+  <!--<xs:element name="MyTask" substitutionGroup="msb:Task">
         <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="msb:TaskType">
-                    <xs:attribute name="MyParameter" type="xs:boolean" use="required"/>
-                </xs:extension>
-            </xs:complexContent>
+          <xs:complexContent>
+            <xs:extension base="msb:TaskType">
+              <xs:attribute name="MyParameter" type="xs:boolean" use="required"/>
+            </xs:extension>
+          </xs:complexContent>
         </xs:complexType>
-    </xs:element>-->
-    
+      </xs:element>-->
 </xs:schema>


### PR DESCRIPTION
So, I was looking at the XML schema files today, and I noticed that the indentation wasn't terribly consistent, which may have something to do with the fact that your .editorconfig file has `indent_size = 4` in the `[*]` section, which blindly overrides ALL editor defaults for anything not speciifcally listed later in the file (and `.xsd` files aren't).

So I polished off a PR I made to avoid that in Roslyn, dotnet/roslyn#6943, and then I re-indented your XML schema files to 2-space indents (as VS defaults to), and I manually re-aligned your multi-line comments (which for some reason VS doesn't touch inside when reformatting -- not even to move subsequent lines the same number of columns left or right that the comment-start sequence was moved).

If for some reason you really *did* want them to have 4-space indentation, and the parts with 2-space were in error, I can revise the commits appropriately.

(I also noticed that a number of your MSBuild files -- targets files and/or props files -- are inexplicably also indented in 4-space increments, despite being explicitly assigned `indent_size = 2` further down.  But they have a lot more multiline comments, and weren't even my initial itch, so I decided to leave them for later.)