### PR TITLE
Only archive CI tests for windows

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -31,6 +31,10 @@ def project = GithubProject
                         batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" && RebuildWithLocalMSBuild.cmd")
                     }
                 }
+
+                // Add xunit result archiving
+                Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml')
+
                 break;
             case 'OSX':
                 newJob.with{
@@ -38,6 +42,9 @@ def project = GithubProject
                         shell("./cibuild.sh --scope Compile")
                     }
                 }
+
+                //no test archiving yet
+
                 break;
             case 'Ubuntu':
                 newJob.with{
@@ -45,13 +52,14 @@ def project = GithubProject
                         shell("./cibuild.sh --scope Compile")
                     }
                 }
+
+                //no test archiving yet
+
                 break;
         }
         
         Utilities.setMachineAffinity(newJob, osName)
         Utilities.standardJobSetup(newJob, project, isPR, branch)
-        // Add xunit result archiving
-        Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml')
         // Add archiving of logs
         Utilities.addArchival(newJob, 'msbuild.log')
         // Add trigger


### PR DESCRIPTION
Linux and OSX do not yet run tests, they just compile.
Moved the line instead of passing skipIfNoTestFiles  = true to
addXunitDotNetResults as a sanity measure to ensure we do not loose the
test phase by mistake and not notice it. :)

@mmitche: would merging this to master cause the Jenkins projects to be silently recreated/updated or will they get duplicated? (if they get duplicated, is there a method we could call in the netci script to clean previous projects?)