### PR TITLE
Stub log to avoid CI failing on master for crossplatform

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-echo "This is master branch. Crossplatform is not supported"
+printf "\n\nThis is master branch. Crossplatform is not supported\n\n"
+
+printf "Stub log to avoid non windows CI failures on master and pull requests targetting master due to missing msbuild.log." > msbuild.log
+
 exit 0


### PR DESCRIPTION
The CI on master for Ubuntu and OSX was failing due to missing msbuild.log file (we don't build crossplatform on master).

Since I could not find a way to differentiate PRs targeting master from the ones targeting xplat within the netci.groovy script, I updated the stub cibuild.sh to output stub logs.

@mmitche 