### PR TITLE
Return only new outputs as metaproject outputs

### DIFF
--- a/src/XMakeBuildEngine/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/XMakeBuildEngine/Construction/Solution/SolutionProjectGenerator.cs
@@ -1144,7 +1144,7 @@ namespace Microsoft.Build.Construction
 
             ProjectTargetInstance target = metaprojectInstance.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, false /* legacy target returns behaviour */);
 
-            AddReferencesBuildTask(metaprojectInstance, target, targetName, outputItem);
+            AddReferencesBuildTask(metaprojectInstance, target, targetName, null /* No need to capture output */);
 
             // Add the task to build the actual project.
             AddProjectBuildTask(traversalProject, project, projectConfiguration, target, targetName, EscapingUtilities.Escape(project.AbsolutePath), String.Empty, outputItem);
@@ -1209,7 +1209,7 @@ namespace Microsoft.Build.Construction
             ProjectTargetInstance newTarget = metaprojectInstance.AddTarget(targetName ?? "Build", ComputeTargetConditionForWebProject(project), null, null, null, null, "GetFrameworkPathAndRedistList", false /* legacy target returns behaviour */);
 
             // Build the references
-            AddReferencesBuildTask(metaprojectInstance, newTarget, targetName, null);
+            AddReferencesBuildTask(metaprojectInstance, newTarget, targetName, null /* No need to capture output */);
 
             if (targetName == "Clean")
             {

--- a/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -625,7 +625,7 @@ EndGlobal
 
         /// <summary>
         /// Generated project metaproj should declare its outputs for relay.
-        /// Here B depends on C and D
+        /// Here B depends on C (via solution dep only) and D (via ProjectReference only)
         /// </summary>
         /// <seealso href="https://github.com/Microsoft/msbuild/issues/69">
         /// MSBuild should generate metaprojects that relay the outputs of the individual MSBuild invocations
@@ -696,9 +696,9 @@ EndGlobal
                             <PropertyGroup>
                                 <ProjectGuid>{B6E7E06F-FC0B-48F1-911A-55E0E1566F00}</ProjectGuid>
                             </PropertyGroup>
-                            <Target Name='Build' Outputs='@(ComputedAnswer)'>
+                            <Target Name='Build' Outputs='@(ComputedPunctuation)'>
                                 <ItemGroup>
-                                    <ComputedAnswer Include='42' />
+                                    <ComputedPunctuation Include='!!!' />
                                 </ItemGroup>
                             </Target>
                         </Project>


### PR DESCRIPTION
Fix for #396.  Detailed description in the commit message.

@olivierdagenais I'd appreciate it if you could take a look at this.  I made some pretty big changes to the `SolutionConfigurationWithDependenciesRelaysItsOutputs` test that I *think* capture the correct intent of [the Connect bug](https://connect.microsoft.com/VisualStudio/feedback/details/1176406/msbuild-targetoutputs-does-not-include-projects-with-explicit-project-dependencies-listed) and #69, but they're very different from what was there before.

Note: I untabified some of the embedded MSBuild in the test, so looking at this with [?w=1](https://github.com/Microsoft/msbuild/pull/402/files?w=1) is recommended.