### PR TITLE
Fix shell injection issues in build.pl

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -104,9 +104,9 @@ if ($runTests) {
     # Find the nunit console program
     my $n = ($^O eq 'MSWin32') ? `where nunit-console` : `which nunit-console`;
     chomp $n;
-    
+
     die ("Tests are requested, but nunit-console was not found") unless -e $n;
-    
+
     # Resolve any links
     $nunitConsole = abs_path($n);
     # Use version 4 if found
@@ -123,9 +123,9 @@ if ($^O eq "MSWin32") {
     print "For MSBuild: got $n[0]\n";
     chomp @n;
     print "Chomped MSBuild: got $n[0]\n";
-    
+
     die ('Installed MSBuild was not found') unless -e $n[0];
-   
+
     # Resolve any links
     $installedBuild = abs_path($n[0]);
     $slash = '\\';
@@ -211,7 +211,7 @@ sub runbuild {
     push @switches, "p:BuildNugetPackage=true" if $createPackage;
 
     # Except on Windows, we need to specifiy 4.0 toolse
-    push @switches, "tv:4.0" if $overrideToolset; 
+    push @switches, "tv:4.0" if $overrideToolset;
 
     @switches = map { $switch.$_ } (
             @switches,
@@ -302,7 +302,7 @@ sub runtests {
     # Count the passed/failed tests by reading the output XML file
     my $testsFailed = 0;
     my $testsSucceeded = 0;
-    
+
     my $testRegex = qr!^\s*<test-case.+executed="True".+success="((?:True)|(?:False))"!;
 
     if (open my ($LOG), '<', $xmlResultFile) {

--- a/build.pl
+++ b/build.pl
@@ -13,9 +13,6 @@ use POSIX;
 use Symbol qw(gensym);
 use IPC::Open3 qw(open3);
 
-# set the timestamp in case we need to create a directory
-use constant DATETIME=>strftime('%Y-%m-%d_%H-%M-%S', localtime);
-
 # The source solution
 my $solutionToBuild = catfile($RealBin, 'build.proj');
 
@@ -152,7 +149,8 @@ if (!$buildRoot) {
     $buildRoot = canonpath($RealBin);
 }
 else {
-    $buildRoot = catfile(rel2abs($buildRoot), DATETIME);
+    $buildRoot = catfile(rel2abs($buildRoot),
+            strftime('%Y-%m-%d_%H-%M-%S', localtime));
     # Just make sure it's not a file
     die ("Verification root '$buildRoot' exists and is a file") if -f $buildRoot;
     make_path($buildRoot);
@@ -221,11 +219,11 @@ sub runbuild {
     push @switches, "tv:4.0" if $overrideToolset;
 
     @switches = map { $switch.$_ } (
-            @switches,
-            "p:Configuration=Debug" . ($^O eq "MSWin32" ? '' : '-MONO'),
-            "p:BinDir=$binDir",
-            "p:PackagesDir=$packagesDir",
-            'fl', "flp:LogFile=$logFile;V=diag", 'p:BuildSamples=false');
+        @switches,
+        "p:Configuration=Debug" . ($^O eq "MSWin32" ? '' : '-MONO'),
+        "p:BinDir=$binDir",
+        "p:PackagesDir=$packagesDir",
+        'fl', "flp:LogFile=$logFile;V=diag", 'p:BuildSamples=false');
 
     # Generate and print the command we run
     my @command = (@$program, @switches, $solutionToBuild);

--- a/build.pl
+++ b/build.pl
@@ -230,7 +230,7 @@ sub runbuild {
     # Run build, parsing it's output to count errors and warnings
     # Harakiri if can't run
     my $buildOutput = gensym;
-    open3(\*STDIN, $buildOutput, $buildOutput, @command)
+    my $pid = open3(\*STDIN, $buildOutput, $buildOutput, @command)
       or die "Cannot run $program, error $!";
     my $warningCount = 0;
     my $errorCount = 0;
@@ -242,6 +242,7 @@ sub runbuild {
 
     die "Failed to run $program, exit code $!" if $! != 0;
     close $buildOutput;
+    waitpid $pid, 0;
     my $exitCode = $? >> 8;
 
     # Search the log for the full output path
@@ -293,8 +294,9 @@ sub runtests {
     {
         my $outputHandle = gensym;
         open $outputHandle, '>', $outputFile or die "Could not open '$outputFile': $!";
-        open3 \*STDIN, $outputHandle, $outputHandle, @command;
+        my $pid = open3 \*STDIN, $outputHandle, $outputHandle, @command;
         close $outputHandle;
+        waitpid $pid, 0;
     }
 
     # Count the passed/failed tests by reading the output XML file


### PR DESCRIPTION
`build.pl` is vulnerable to shell command injection if there are metacharacters in various paths.  This patch fixes these issues.  It also does some cleanup of the Perl code.