### PR TITLE
Enable FEATURE_APPDOMAIN for mono builds

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -197,8 +197,8 @@
   <PropertyGroup Condition="'$(NetCoreSurface)' != 'true'">
     <DefineConstants>$(DefineConstants);FEATURE_APARTMENT_STATE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APM</DefineConstants>
-    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>
-    <FeatureAppDomain Condition="'$(MonoBuild)' != 'true'">true</FeatureAppDomain>
+    <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>
+    <FeatureAppDomain>true</FeatureAppDomain>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOADFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateDictionary(ref _buildProcessEnvironment, StringComparer.OrdinalIgnoreCase);
             translator.TranslateCulture(ref _culture);
             translator.TranslateCulture(ref _uiCulture);
-#if FEATURE_APPDOMAIN
+#if FEATURE_BINARY_SERIALIZATION
             translator.TranslateDotNet(ref _appDomainSetup);
 #endif
             translator.Translate(ref _lineNumberOfTask);

--- a/src/XMakeTasks/GenerateResource.cs
+++ b/src/XMakeTasks/GenerateResource.cs
@@ -1794,6 +1794,7 @@ namespace Microsoft.Build.Tasks
 
                         return true;
                     }
+#if FEATURE_BINARY_SERIALIZATION
                     catch (SerializationException e)
                     {
                         Log.LogMessageFromResources
@@ -1808,6 +1809,7 @@ namespace Microsoft.Build.Tasks
 
                         return true;
                     }
+#endif
                     catch (Exception e)
                     {
                         // DDB#9819
@@ -1858,6 +1860,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool NeedSeparateAppDomainBasedOnSerializedType(XmlReader reader)
         {
+#if FEATURE_BINARY_SERIALIZATION
             while (reader.Read())
             {
                 if (reader.NodeType == XmlNodeType.Element)
@@ -1881,6 +1884,7 @@ namespace Microsoft.Build.Tasks
 
             // We didn't find any element at all -- the .resx is malformed.
             // Return true to err on the side of caution. Error will appear later.
+#endif
             return true;
         }
 #endif

--- a/src/XMakeTasks/GenerateResource.cs
+++ b/src/XMakeTasks/GenerateResource.cs
@@ -807,7 +807,7 @@ namespace Microsoft.Build.Tasks
                                     OutputResources = outputResources;
                                 }
 
-#if FEATURE_APPDOMAIN
+#if FEATURE_BINARY_SERIALIZATION
                                 // Get portable library cache info (and if needed, marshal it to this AD).
                                 List<ResGenDependencies.PortableLibraryFile> portableLibraryCacheInfo = process.PortableLibraryCacheInfo;
                                 for (int i = 0; i < portableLibraryCacheInfo.Count; i++)


### PR DESCRIPTION
In some places in the code, there was an assumption that
FEATURE_APPDOMAIN and FEATURE_BINARY_SERIALIZATION
are always enabled/disabled together, which breaks the build
if you only enable FEATURE_APPDOMAIN. This fixes those issues
before enabling appdomain on mono.

Without this things like CodeTaskFactory don't work, TaskRegistry just
throws an error.