### PR TITLE
Removed help message for /debug in #426

### DIFF
--- a/src/XMakeCommandLine/CommandLineSwitches.cs
+++ b/src/XMakeCommandLine/CommandLineSwitches.cs
@@ -48,7 +48,9 @@ namespace Microsoft.Build.CommandLine
             OldOM,
 #endif
             DistributedFileLogger,
+#if FEATURE_MSBUILD_DEBUGGER
             Debugger,
+#endif
             DetailedSummary,
             NumberOfParameterlessSwitches
         }
@@ -214,8 +216,9 @@ namespace Microsoft.Build.CommandLine
             new ParameterlessSwitchInfo(  new string[] { "oldom" },                         ParameterlessSwitch.OldOM,                 null, null    ),
 #endif
             new ParameterlessSwitchInfo(  new string[] { "distributedfilelogger", "dfl" },  ParameterlessSwitch.DistributedFileLogger, null, null    ),
-
+#if FEATURE_MSBUILD_DEBUGGER
             new ParameterlessSwitchInfo(  new string[] { "debug", "d" },         ParameterlessSwitch.Debugger,                         null, "DebuggerEnabled"),
+#endif
             new ParameterlessSwitchInfo(  new string[] { "detailedsummary", "ds" },         ParameterlessSwitch.DetailedSummary,       null , null   )
         };
 
@@ -839,7 +842,7 @@ namespace Microsoft.Build.CommandLine
             }
         }
 
-        #region Flag Lightup Support
+#region Flag Lightup Support
         /// <summary>
         /// Read a lightup key from either HKLM or HKCU depending on what is passed in root.
         /// The key may either be a string, in which case it needs to be like "true" or "false"
@@ -916,6 +919,6 @@ namespace Microsoft.Build.CommandLine
             parameterlessSwitch.lightUpKeyResult = ReadLightupBool(parameterlessSwitch.lightUpKey);
             return parameterlessSwitch.lightUpKeyResult;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1802,7 +1802,9 @@ namespace Microsoft.Build.CommandLine
                         preprocessWriter = ProcessPreprocessSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Preprocess]);
                     }
 
+#if FEATURE_MSBUILD_DEBUGGER
                     debugger = commandLineSwitches.IsParameterlessSwitchSet(CommandLineSwitches.ParameterlessSwitch.Debugger);
+#endif
                     detailedSummary = commandLineSwitches.IsParameterlessSwitchSet(CommandLineSwitches.ParameterlessSwitch.DetailedSummary);
 
                     // figure out which loggers are going to listen to build events


### PR DESCRIPTION
New build is not showing the debug message, it's handled by a condition  in `ShowHelpMessage()`.

I have removed the condition and debug message. 

