### PR TITLE
Do not create satellite assemblies in .NET Core

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -3277,7 +3277,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="GenerateSatelliteAssemblies"
           Inputs="$(MSBuildAllProjects);@(_SatelliteAssemblyResourceInputs);$(IntermediateOutputPath)$(TargetName)$(TargetExt)"
           Outputs="$(IntermediateOutputPath)%(Culture)\$(TargetName).resources.dll"
-          Condition="'@(_SatelliteAssemblyResourceInputs)' != ''">
+          Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(MSBuildRuntimeType)' != 'Core'">
 
     <MakeDir
         Directories="@(EmbeddedResource->'$(IntermediateOutputPath)%(Culture)')" />
@@ -3342,7 +3342,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <ItemGroup>
       <IntermediateSatelliteAssembliesWithTargetPath Include="$(IntermediateOutputPath)%(EmbeddedResource.Culture)\$(TargetName).resources.dll"
-                                                     Condition="'%(EmbeddedResource.Culture)' != ''">
+                                                     Condition="'%(EmbeddedResource.Culture)' != '' and '$(MSBuildRuntimeType)' != 'Core'">
         <Culture>%(EmbeddedResource.Culture)</Culture>
         <TargetPath>%(EmbeddedResource.Culture)\$(TargetName).resources.dll</TargetPath>
       </IntermediateSatelliteAssembliesWithTargetPath>


### PR DESCRIPTION
There is not currently an `al.exe` that works on Linux, so satellite
assemblies are not creatable there. Fortunately, they're not needed, so we
can just stop trying to create them when running .NET Core MSBuild.