### PR TITLE
Tied to issue #400, logtaskinputs setting on projectinstance object

### DIFF
--- a/src/XMakeBuildEngine/Instance/ProjectInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectInstance.cs
@@ -1817,6 +1817,11 @@ namespace Microsoft.Build.Execution
             if (loggers != null)
             {
                 parameters.Loggers = (loggers is ICollection<ILogger>) ? ((ICollection<ILogger>)loggers) : new List<ILogger>(loggers);
+
+                // Enables task parameter logging based on whether any of the loggers attached
+                // to the Project have their verbosity set to Diagnostic. If no logger has
+                // been set to log diagnostic then the existing/default value will be persisted.
+                parameters.LogTaskInputs = parameters.LogTaskInputs || loggers.Any(logger => logger.Verbosity == LoggerVerbosity.Diagnostic);
             }
 
             if (remoteLoggers != null)


### PR DESCRIPTION
Added in foreach loop in projecttaskinstance in order to check individual loggers for verbosity setting; if diagnostic, then set logtaskinputs to true, following implementation approach as used in XMake.