### PR TITLE
Update Exec task to only use UTF8 when required.

### DIFF
--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -33,16 +33,20 @@ namespace Microsoft.Build.Tasks
             // Console-based output uses the current system OEM code page by default. Note that we should not use Console.OutputEncoding
             // here since processes we run don't really have much to do with our console window (and also Console.OutputEncoding
             // doesn't return the OEM code page if the running application that hosts MSBuild is not a console application).
-            // Note: 8/12/15 - Changed encoding to use UTF8 when OS version is greater than or equal to 6.1 (Windows 7)
-            _standardOutputEncoding = GetEncodingWithOsFallback();
-            _standardErrorEncoding = GetEncodingWithOsFallback();
+            // If the cmd file contains non-ANSI characters encoding may change.
+            _standardOutputEncoding = EncodingUtilities.CurrentSystemOemEncoding;
+            _standardErrorEncoding = EncodingUtilities.CurrentSystemOemEncoding;
         }
 
         #endregion
 
         #region Fields
 
-        // Are the ecodings for StdErr and StdOut streams valid
+        private const string UseUtf8Always = "ALWAYS";
+        private const string UseUtf8Never = "NEVER";
+        private const string UseUtf8Detect = "DETECT";
+
+        // Are the encodings for StdErr and StdOut streams valid
         private bool _encodingParametersValid = true;
         private string _workingDirectory;
         private ITaskItem[] _outputs;
@@ -70,7 +74,7 @@ namespace Microsoft.Build.Tasks
         /// Enable the pipe of the standard out to an item (StandardOutput).
         /// </summary>
         /// <Remarks>
-        /// Even thought this is called a pipe, it is infact a Tee.  Use StandardOutputImportance to adjust the visibility of the stdout.
+        /// Even thought this is called a pipe, it is in fact a Tee.  Use StandardOutputImportance to adjust the visibility of the stdout.
         /// </Remarks>
         public bool ConsoleToMSBuild { get; set; }
 
@@ -122,6 +126,14 @@ namespace Microsoft.Build.Tasks
         {
             get { return _standardErrorEncoding; }
         }
+
+        /// <summary>
+        /// Whether or not to use UTF8 encoding for the cmd file and console window.
+        /// Values: Always, Never, Detect
+        /// If set to Detect, the current code page will be used unless it cannot represent 
+        /// the Command string. In that case, UTF-8 is used.
+        /// </summary>
+        public string UseUtf8Encoding { get; set; }
 
         /// <summary>
         /// Project visible property specifying the encoding of the captured task standard output stream
@@ -191,6 +203,8 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private void CreateTemporaryBatchFile()
         {
+            var encoding = BatchFileEncoding();
+
             // Temporary file with the extension .Exec.bat
             _batchFile = FileUtilities.GetTemporaryFile(".exec.cmd");
 
@@ -200,7 +214,8 @@ namespace Microsoft.Build.Tasks
             // just the OEM version.
             // See http://www.microsoft.com/globaldev/getWR/steps/wrg_codepage.mspx for a discussion of ANSI vs OEM
             // Note: 8/12/15 - Switched to use UTF8 on OS newer than 6.1 (Windows 7)
-            using (StreamWriter sw = new StreamWriter(_batchFile, false, GetEncodingWithOsFallback()))
+            // Note: 1/12/16 - Only use UTF8 when we detect we need to or the user specifies 'Always'
+            using (StreamWriter sw = new StreamWriter(_batchFile, false, encoding))
             {
                 // In some wierd setups, users may have set an env var actually called "errorlevel"
                 // this would cause our "exit %errorlevel%" to return false.
@@ -217,11 +232,15 @@ namespace Microsoft.Build.Tasks
                 sw.WriteLine("set errorlevel=dummy");
                 sw.WriteLine("set errorlevel=");
 
-                // We probably have to change the code page to UTF8 (65001) for non-ansi characters to work.
-                if (EncodingUtilities.CurrentSystemOemEncoding.CodePage != sw.Encoding.CodePage)
+                // We may need to change the code page and console encoding.
+                if (encoding.CodePage != EncodingUtilities.CurrentSystemOemEncoding.CodePage)
                 {
                     // Output to nul so we don't change output and logs.
-                    sw.WriteLine(string.Format(@"%SystemRoot%\System32\chcp.com {0}>nul", sw.Encoding.CodePage));
+                    sw.WriteLine(string.Format(@"%SystemRoot%\System32\chcp.com {0}>nul", encoding.CodePage));
+
+                    // Ensure that the console encoding is correct.
+                    _standardOutputEncoding = encoding;
+                    _standardErrorEncoding = encoding;
                 }
 
                 // if the working directory is a UNC path, bracket the exec command with pushd and popd, because pushd
@@ -245,7 +264,7 @@ namespace Microsoft.Build.Tasks
                 // 2) also because of another (or perhaps the same) bug in the Process class, when we use pushd/popd for a
                 //    UNC path, even if the command fails, the exit code comes back as 0 (seemingly reflecting the success
                 //    of popd) -- the statement below fixes that too
-                // 3) the above described behaviour is most likely bugs in the Process class because batch files in a
+                // 3) the above described behavior is most likely bugs in the Process class because batch files in a
                 //    console window do not hide or change the exit code a.k.a. errorlevel, esp. since the popd command is
                 //    a no-fail command, and it never changes the previous errorlevel
                 sw.WriteLine("exit %errorlevel%");
@@ -561,19 +580,72 @@ namespace Microsoft.Build.Tasks
         private static readonly Encoding s_utf8WithoutBom = new UTF8Encoding(false);
 
         /// <summary>
-        /// Get encoding based on OS. This will fall back to previous behavior on any OS before Windows 7.
-        /// If the OS is greater than or equal to Windows 7, UTF8 encoding will be used for the cmd file.
+        /// Find the encoding for the batch file.
         /// </summary>
-        /// <remarks>UTF8 w/o BOM is used because cmd.exe does not like a BOM in a .cmd file.</remarks>
-        /// <returns>Encoding to use</returns>
-        private Encoding GetEncodingWithOsFallback()
+        /// <remarks>
+        /// The "best" encoding is the current OEM encoding, unless it's not capable of representing
+        /// the characters we plan to put in the file. If it isn't, we can fall back to UTF-8.
+        ///
+        /// Why not always UTF-8? Because tools don't always handle it well. See
+        /// https://github.com/Microsoft/msbuild/issues/397
+        /// </remarks>
+        private Encoding BatchFileEncoding()
         {
-            // Windows 7 (6.1) or greater
+            var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
+            string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? UseUtf8Detect : UseUtf8Encoding;
+
+            // UTF8 is only supposed in Windows 7 (6.1) or greater.
             var windows7 = new Version(6, 1);
 
-            return Environment.OSVersion.Version >= windows7
-                ? s_utf8WithoutBom
-                : EncodingUtilities.CurrentSystemOemEncoding;
+            if (Environment.OSVersion.Version < windows7)
+            {
+                useUtf8 = UseUtf8Never;
+            }
+
+            switch (useUtf8.ToUpperInvariant())
+            {
+                case UseUtf8Always:
+                    return s_utf8WithoutBom;
+                case UseUtf8Never:
+                    return EncodingUtilities.CurrentSystemOemEncoding;
+                default:
+                    return CanEncodeString(defaultEncoding.CodePage, Command + WorkingDirectory)
+                        ? defaultEncoding
+                        : s_utf8WithoutBom;
+            }
+        }
+
+        /// <summary>
+        /// Checks to see if a string can be encoded in a specified code page.
+        /// </summary>
+        /// <remarks>Internal for testing purposes.</remarks>
+        /// <param name="codePage">Code page for encoding.</param>
+        /// <param name="stringToEncode">String to encode.</param>
+        /// <returns>True if the string can be encoded in the specified code page.</returns>
+        internal static bool CanEncodeString(int codePage, string stringToEncode)
+        {
+            // We have a System.String that contains some characters. Get a lossless representation
+            // in byte-array form.
+            var unicodeEncoding = new UnicodeEncoding();
+            var unicodeBytes = unicodeEncoding.GetBytes(stringToEncode);
+
+            // Create an Encoding using the desired code page, but throws if there's a
+            // character that can't be represented.
+            var systemEncoding = Encoding.GetEncoding(codePage, EncoderFallback.ExceptionFallback,
+                DecoderFallback.ExceptionFallback);
+
+            try
+            {
+                var oemBytes = Encoding.Convert(unicodeEncoding, systemEncoding, unicodeBytes);
+
+                // If Convert didn't throw, we can represent everything in the desired encoding.
+                return true;
+            }
+            catch (EncoderFallbackException)
+            {
+                // If a fallback encoding was attempted, we need to go to Unicode.
+                return false;
+            }
         }
     }
 }

--- a/src/XMakeTasks/UnitTests/Exec_Tests.cs
+++ b/src/XMakeTasks/UnitTests/Exec_Tests.cs
@@ -286,29 +286,106 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Tests that Exec still executes properly when there's a non-ansi character in the command
+        /// Tests that Exec still executes properly when there's a non-ANSI character in the command
         /// </summary>
         [Fact]
         public void ExecTaskUnicodeCharacterInCommand()
         {
+            RunExec(true, new UTF8Encoding(false).EncodingName);
+        }
+
+        /// <summary>
+        /// Tests that Exec task will choose the default code page when UTF8 is not needed.
+        /// </summary>
+        [Fact]
+        public void ExecTaskWithoutUnicodeCharacterInCommand()
+        {
+            RunExec(false, EncodingUtilities.CurrentSystemOemEncoding.EncodingName);
+        }
+
+        /// <summary>
+        /// Exec task will use UTF8 when UTF8 Always is specified (with non-ANSI characters in the Command)
+        /// </summary>
+        [Fact]
+        public void ExecTaskUtf8AlwaysWithNonAnsi()
+        {
+            RunExec(true, new UTF8Encoding(false).EncodingName, "Always");
+        }
+
+        /// <summary>
+        /// Exec task will use UTF8 when UTF8 Always is specified (without non-ANSI characters in the Command)
+        /// </summary>
+        [Fact]
+        public void ExecTaskUtf8AlwaysWithAnsi()
+        {
+            RunExec(false, new UTF8Encoding(false).EncodingName, "Always");
+        }
+
+        /// <summary>
+        /// Exec task will NOT use UTF8 when UTF8 Never is specified and non-ANSI characters are in the Command
+        /// <remarks>Exec task will fail as the cmd processor will not be able to run the command.</remarks>
+        /// </summary>
+        [Fact]
+        public void ExecTaskUtf8NeverWithNonAnsi()
+        {
+            RunExec(true, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, "Never", false);
+        }
+
+        /// <summary>
+        /// Exec task will NOT use UTF8 when UTF8 Never is specified and only ANSI characters are in the Command
+        /// </summary>
+        [Fact]
+        public void ExecTaskUtf8NeverWithAnsi()
+        {
+            RunExec(false, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, "Never");
+        }
+
+
+        /// <summary>
+        /// Helper function to run the Exec task with or without ANSI characters in the Command and check for an expected encoding.
+        /// </summary>
+        /// <param name="includeNonAnsiInCommand">True to include non-ANSI characters in the Command</param>
+        /// <param name="expectedEncoding">Expected EncodingName</param>
+        /// <param name="useUtf8">Optional parameter to specify the UseUtf8Encoding on the Exec task</param>
+        /// <param name="expectSuccess">Optional parameter if the Exec task should succeed or not. Default true.</param>
+        /// <returns></returns>
+        private void RunExec(bool includeNonAnsiInCommand, string expectedEncoding, string useUtf8 = null, bool expectSuccess = true)
+        {
+            string ansiCharacters = "test";
             string nonAnsiCharacters = "\u521B\u5EFA";
-            string folder = Path.Combine(Path.GetTempPath(), nonAnsiCharacters);
+            string folder = Path.Combine(Path.GetTempPath(), includeNonAnsiInCommand ? nonAnsiCharacters : ansiCharacters);
             string command = Path.Combine(folder, "test.cmd");
+
+            Exec exec;
 
             try
             {
                 Directory.CreateDirectory(folder);
                 File.WriteAllText(command, "echo [hello]");
-                Exec exec = PrepareExec(command);
+                exec = PrepareExec(command);
 
-                Assert.True(exec.Execute()); // "Task should have succeeded"
-                ((MockEngine)exec.BuildEngine).AssertLogContains("[hello]");
+                if (!string.IsNullOrEmpty(useUtf8))
+                {
+                    exec.UseUtf8Encoding = useUtf8;
+                }
+
+                Assert.Equal(expectSuccess, exec.Execute());
+
+                if (expectSuccess)
+                {
+                    ((MockEngine) exec.BuildEngine).AssertLogContains("[hello]");
+                }
+
+                Assert.Equal(expectedEncoding, exec.StdOutEncoding);
+                Assert.Equal(expectedEncoding, exec.StdErrEncoding);
             }
             finally
             {
                 if (Directory.Exists(folder))
                     Directory.Delete(folder, true);
             }
+
+            return;
         }
 
         [Fact]
@@ -584,6 +661,22 @@ namespace Microsoft.Build.UnitTests
 
             //Both two lines should had gone to stdout
             Assert.Equal(2, exec.ConsoleOutput.Length);
+        }
+
+        /// <summary>
+        /// Test the CanEncode method with and without ANSI characters to determine if they can be encoded 
+        /// in the current system encoding.
+        /// </summary>
+        [Fact]
+        public void CanEncodeTest()
+        {
+            var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
+
+            string nonAnsiCharacters = "\u521B\u5EFA";
+            string pathWithAnsiCharacters = @"c:\windows\system32\cmd.exe";
+
+            Assert.False(Exec.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters));
+            Assert.True(Exec.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters));
         }
     }
 


### PR DESCRIPTION
Proposed change for #397. This should revert the change to the existing behavior (will not change the code page) in almost all cases, but still allow for those who do have non-ANSI characters in their Command. This solution seems a little unfortunate, and we are open to additional input if anyone has a better idea. I tried to implement it with an escape hatch (setting Never or Always on the task) so the user has more control if absolutely necessary.

Exec task was previously changed to use UTF8 code page because of an issue
running commands that contained non-ANSI characters. This turned out to be
problematic with some older tools that did not correctly support the cmd
code page change. With this change, we will only change the code page when
the command the Exec task is running cannot be represented by the current
code page. In that case, we will switch to UTF8.

Added a parameter to allow the user to override this behavior and Always
or Never use UTF8 encoding. The default value if not specified is Detect
which will use UTF8 only when it would otherwise fail.

Closes #397