### PR TITLE
#368 fixed Scanner to consume correct close paren.

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/Conditionals/Scanner.cs
+++ b/src/XMakeBuildEngine/Evaluation/Conditionals/Scanner.cs
@@ -457,15 +457,24 @@ namespace Microsoft.Build.Evaluation
             // Maybe we need to generate an error for invalid characters in itemgroup name?
             // For now, just let item evaluation handle the error.
             bool fInReplacement = false;
+            int parenToClose = 0;
             while (_parsePoint < _expression.Length)
             {
                 if (_expression[_parsePoint] == '\'')
                 {
                     fInReplacement = !fInReplacement;
                 }
+                else if (_expression[_parsePoint] == '(' && !fInReplacement)
+                {
+                    parenToClose++;
+                }
                 else if (_expression[_parsePoint] == ')' && !fInReplacement)
                 {
-                    break;
+                    if (parenToClose == 0)
+                    {
+                        break;
+                    }
+                    else { parenToClose--; }
                 }
                 _parsePoint++;
             }

--- a/src/XMakeBuildEngine/UnitTests/Parser_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Parser_Tests.cs
@@ -216,6 +216,28 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void ItemFuncParseTest()
+        {
+            Console.WriteLine("ItemFuncParseTest()");
+
+            Parser p = new Parser();
+            GenericExpressionNode tree;
+
+            tree = p.Parse("@(item->foo('ab'))", 
+                ParserOptions.AllowProperties | ParserOptions.AllowItemLists, _elementLocation);
+            Assert.IsType<StringExpressionNode>(tree);
+            Assert.Equal("@(item->foo('ab'))", tree.GetUnexpandedValue(null));
+
+            tree = p.Parse("!@(item->foo())", 
+                ParserOptions.AllowProperties | ParserOptions.AllowItemLists, _elementLocation);
+            Assert.IsType<NotExpressionNode>(tree);
+
+            tree = p.Parse("(@(item->foo('ab')) and @(item->foo('bc')))", 
+                ParserOptions.AllowProperties | ParserOptions.AllowItemLists, _elementLocation);
+            Assert.IsType<AndExpressionNode>(tree);
+        }
+
+        [Fact]
         public void MetadataParseTest()
         {
             Console.WriteLine("FunctionCallParseTest()");


### PR DESCRIPTION
I suppose there is a bug in a method ```ParseInternalItemList```. It just reads token to the first closing paren, which is causing creation of incorrect token ```@(MainEmbeddedFiles->AnyHaveMetadataValue('Filename', 'UserControl1')``` instead ```@(MainEmbeddedFiles->AnyHaveMetadataValue('Filename', 'UserControl1'))```. 

I made a fix and add some unit tests. @rainersigwald can you take a look on my solution?