### PR TITLE
Fix some issues with OSX build

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -10,11 +10,7 @@
     <add key="myget.org buildtools v3" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="myget.org nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="myget.org dotnet-core v3" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="myget.org buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
-    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
-    <add key="myget.org dotnet-corefxtestdata" value="https://www.myget.org/F/dotnet-corefxtestdata/" />
-    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
-    <add key="myget.org aspnet vnext" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
-    <add key="nuget.org v2" value="https://nuget.org/api/v2/" />
+    <add key="myget.org aspnet vnext v3" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
+    <add key="myget.org aspnet vnext" value="https://www.myget.org/F/aspnetvnext/" />
   </packageSources>
 </configuration>

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -26,6 +26,7 @@ downloadMSBuild(){
         curl -sL -o $MSBUILD_ZIP "$MSBUILD_DOWNLOAD_URL"
 
         unzip -q $MSBUILD_ZIP -d $PACKAGES_DIR
+        find "$PACKAGES_DIR/mono-msbuild/bin/Unix/Debug-MONO" -name "*.exe" -exec chmod "+x" '{}' ';'
         rm $MSBUILD_ZIP
     fi
 }

--- a/dir.props
+++ b/dir.props
@@ -36,7 +36,7 @@
     <DnxDir Condition="'$(OsEnvironment)'=='Unix'">dnx-coreclr-linux-x64</DnxDir>
     <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta8</DnxVersion>
     <DnxDir Condition="'$(OsEnvironment)'=='OSX'">dnx-coreclr-darwin-x64</DnxDir>
-    <DnxVersion Condition="'$(OsEnvironment)'=='OSX'">1.0.0-rc2-16177</DnxVersion>
+    <DnxVersion Condition="'$(OsEnvironment)'=='OSX'">1.0.0-rc2-16357</DnxVersion>
 
     <!-- Output directories -->
     <BinDir>$(RepoRoot)bin$([System.IO.Path]::DirectorySeparatorChar)</BinDir>

--- a/src/.nuget/packageLoad.targets
+++ b/src/.nuget/packageLoad.targets
@@ -50,7 +50,8 @@
   <PropertyGroup>
     <SetDnxPackages Condition="'$(OsEnvironment)'=='Windows_NT'">set DNX_PACKAGES=$(PackagesCache) &amp;</SetDnxPackages>
     <SetDnxPackages Condition="'$(OsEnvironment)'!='Windows_NT'">export DNX_PACKAGES=$(PackagesCache) ;</SetDnxPackages>
-    <DnuRestoreCommand>$(SetDnxPackages) $(DnuToolPath) restore  --parallel </DnuRestoreCommand>
+    <DnuRestoreCommand Condition="'$(OS)'!='OSX'">$(SetDnxPackages) &quot;$(DnuToolPath)&quot; restore  --parallel </DnuRestoreCommand>
+    <DnuRestoreCommand Condition="'$(OS)'=='OSX'">ulimit -n 2500 ; $(SetDnxPackages) &quot;$(DnuToolPath)&quot; restore  --parallel </DnuRestoreCommand>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/.nuget/packages.OSX.config
+++ b/src/.nuget/packages.OSX.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="dnx-coreclr-darwin-x64" version="1.0.0-rc2-16177" />
+  <package id="dnx-coreclr-darwin-x64" version="1.0.0-rc2-16357" />
 </packages>


### PR DESCRIPTION
1. Remove some v2 sources from NuGet.Config
2. Update dnx package to rc2-16357 (the old package is no longer available)
3. Use 'ulimit -n 2500' to avoid 'Too many open files' error from dnx
4. Make sure mono compilers that come with the mono MSBuild bootstrap package have executable permission.