### PR TITLE
ResGen Cache Serialization Fix

### DIFF
--- a/src/XMakeCommandLine/XMake.cs
+++ b/src/XMakeCommandLine/XMake.cs
@@ -1984,7 +1984,7 @@ namespace Microsoft.Build.CommandLine
 #if !STANDALONEBUILD
             else
             {
-                StartLocalNodeOldOM(nodeNumber);
+                StartLocalNodeOldOM(nodeModeNumber);
             }
 #endif
         }

--- a/src/XMakeTasks/Dependencies.cs
+++ b/src/XMakeTasks/Dependencies.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Tasks
         /// Hashtable of other dependency files.
         /// Key is filename and value is DependencyFile.
         /// </summary>
-        private Hashtable _dependencies = new Hashtable();
+        private Hashtable dependencies = new Hashtable();
 
         /// <summary>
         /// Look up a dependency file. Return null if its not there.
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal DependencyFile GetDependencyFile(string filename)
         {
-            return (DependencyFile)_dependencies[filename];
+            return (DependencyFile)dependencies[filename];
         }
 
 
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal void AddDependencyFile(string filename, DependencyFile file)
         {
-            _dependencies[filename] = file;
+            dependencies[filename] = file;
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal void RemoveDependencyFile(string filename)
         {
-            _dependencies.Remove(filename);
+            dependencies.Remove(filename);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal void Clear()
         {
-            _dependencies.Clear();
+            dependencies.Clear();
         }
     }
 }

--- a/src/XMakeTasks/StateFileBase.cs
+++ b/src/XMakeTasks/StateFileBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Tasks
         // Current version for serialization. This should be changed when breaking changes
         // are made to this class.
         // Note: Consider that changes can break VS2015 RTM which did not have a version check.
-        private const byte CurrentSerializationVersion = 2;
+        private const byte CurrentSerializationVersion = 3;
 
         // Version this instance is serialized with.
         private byte _serializedVersion = CurrentSerializationVersion;


### PR DESCRIPTION
### Update ResGen Serialization Compat for RTM and U1
_602201c_ When reverting the CodeFormatter private field name changes (#314), the Dependencies class was missed. This causes an incompatibility going from  Update 1 back to RTM and causes a null ref. This change fixes the compat issue (rename the field) and updates the serialization version to ensure U1 -> U2 works as expected.

### Rename field for internal build.
_c863538_ Looks like the field was renamed for STANDALONEBUILD but not otherwise.Correcting this.