### PR TITLE
Show full class and method name in output results

### DIFF
--- a/src/xunit.runner.json
+++ b/src/xunit.runner.json
@@ -2,5 +2,5 @@
   "shadowCopy": false,
   "maxParallelThreads": 1,
   "parallelizeAssembly": false,
-  "methodDisplay": "method"
+  "methodDisplay": "classAndMethod"
 }


### PR DESCRIPTION
This is so that the Jenkins plugin that gathers xUnit test results shows the correct test names, because the converter trims the first portion of the test name, assuming that it is prefixed with the full class name