### PR TITLE
#460 - Memory leak fix.

### DIFF
--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -308,6 +308,14 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Finalizer. During GC all items that were saved in strong cache during project loading will be removed.
+        /// </summary>
+        ~ProjectCollection()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
         /// Handler to receive which project got added to the project collection.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Justification = "This has been API reviewed")]
@@ -1489,6 +1497,9 @@ namespace Microsoft.Build.Evaluation
                 ShutDownLoggingService();
                 Tracing.Dump();
             }
+
+            //releasing cached items from strong reference cache for projects loaded into current collection
+            ProjectRootElementCache.Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
I investigated issue described in the provided thread. It's easy to reproduce it by creating ```Project``` in a following way (this code is copied from Roslyn and than modified to show the point):
```csharp
public async Task Foo()
{
     string path = @"...some project link";
     var properties = new Dictionary<string, string>();

     for (int i = 0; i < 100; i++)
     {
          var xmlReader = XmlReader.Create(await ReadFileAsync(path, CancellationToken.None).ConfigureAwait(false), s_xmlSettings);
          var collection = new ProjectCollection();
          var xml = ProjectRootElement.Create(xmlReader, collection);
          xml.FullPath = path;

          var project = new Project(
                    xml,
                    properties,
                    toolsVersion: null,
                    projectCollection: collection);
     }
}
```
Whole memory will be consumed by cached items in ```ProjectStringCache```. There no mechanism of freeing cache data automatically if the references to instances of ```ProjectCollection``` and ```Project``` classes will be lost. The only way to handle this is to call ```ProjectCollection.UnloadProject()``` or ```ProjectCollection.UnloadAllProjects()``` manually. 

It seems that in Roslyn they ended up with some kind of a workaround by wrapping ```Project``` in ```ProjectFile``` class with destructor:
```csharp
~ProjectFile()
{
     try
     {
          // unload project so collection will release global strings
          _loadedProject.ProjectCollection.UnloadAllProjects();
     }
     catch
     {
     }
}
```

So solution that I propose is pretty much simple. I just implemented Dispose pattern for ```ProjectCollection``` to clear all this stuff on GC.