### PR TITLE
#439 - Removed usage "Microsoft.Win32.Registry" from project.json.

### DIFF
--- a/src/Utilities/UnitTests/project.json
+++ b/src/Utilities/UnitTests/project.json
@@ -22,7 +22,6 @@
         "System.Console": "4.0.0-rc2-23712",
         "System.Diagnostics.Process": "4.1.0-rc2-23712",
         "Microsoft.Win32.Primitives":  "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -20,7 +20,6 @@
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives": "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "System.Xml.XPath.XmlDocument": "4.0.1-rc2-23712"
       },
       "imports": "portable-net451+win81"

--- a/src/XMakeBuildEngine/UnitTests/project.json
+++ b/src/XMakeBuildEngine/UnitTests/project.json
@@ -30,7 +30,6 @@
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "System.Xml.XPath.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives":  "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
         "System.Reflection.Metadata": "1.1.0"

--- a/src/XMakeBuildEngine/project.json
+++ b/src/XMakeBuildEngine/project.json
@@ -34,7 +34,6 @@
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "System.Xml.XPath.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives": "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712"
       },

--- a/src/XMakeCommandLine/UnitTests/project.json
+++ b/src/XMakeCommandLine/UnitTests/project.json
@@ -28,7 +28,6 @@
         "System.Threading.ThreadPool": "4.0.10-rc2-23712",
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives":  "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
         "System.Reflection.Metadata": "1.1.0"

--- a/src/XMakeCommandLine/project.json
+++ b/src/XMakeCommandLine/project.json
@@ -24,7 +24,6 @@
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "System.Xml.XPath.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives":  "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712"
       },

--- a/src/XMakeTasks/UnitTests/project.json
+++ b/src/XMakeTasks/UnitTests/project.json
@@ -30,7 +30,6 @@
         "System.Threading.ThreadPool": "4.0.10-rc2-23712",
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives":  "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
         "System.Reflection.Metadata": "1.1.0"

--- a/src/XMakeTasks/project.json
+++ b/src/XMakeTasks/project.json
@@ -32,7 +32,6 @@
         "System.Threading.ThreadPool": "4.0.10-rc2-23712",
         "System.Xml.XmlDocument": "4.0.1-rc2-23712",
         "Microsoft.Win32.Primitives":  "4.0.1-rc2-23712",
-        "Microsoft.Win32.Registry": "4.0.0-rc2-23712",
         "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712"
       },


### PR DESCRIPTION
As advertised just removed usage of "Microsoft.Win32.Registry" from ...\msbuild\src\Utilities\project.json and ...\msbuild\src\XMakeTasks\project.json (#439).
