### PR TITLE
Adjusts so all command line propertied are logged when using diagnostic

### DIFF
--- a/src/XMakeCommandLine/CommandLineSwitches.cs
+++ b/src/XMakeCommandLine/CommandLineSwitches.cs
@@ -442,10 +442,19 @@ namespace Microsoft.Build.CommandLine
             {
                 // initialize its parameter storage
                 _parameterizedSwitches[(int)parameterizedSwitch].parameters = new ArrayList();
-            }
 
-            // save the switch text
-            _parameterizedSwitches[(int)parameterizedSwitch].commandLineArg = commandLineArg;
+                // save the switch text
+                _parameterizedSwitches[(int)parameterizedSwitch].commandLineArg = commandLineArg;
+            }
+            else
+            {
+                // append the switch text
+                _parameterizedSwitches[(int)parameterizedSwitch].commandLineArg = string.Concat(
+                        _parameterizedSwitches[(int)parameterizedSwitch].commandLineArg,
+                        " ",
+                        commandLineArg
+                    );
+            }
 
             // check if the switch has multiple parameters
             if (multipleParametersAllowed)

--- a/src/XMakeCommandLine/UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/CommandLineSwitches_Tests.cs
@@ -757,7 +757,7 @@ namespace Microsoft.Build.UnitTests
             // purposes of testing the SetParameterizedSwitch() method, it doesn't matter
             Assert.True(switches.SetParameterizedSwitch(CommandLineSwitches.ParameterizedSwitch.Verbosity, "/verbosity:\"diag\";minimal", "\"diag\";minimal", true, true));
 
-            Assert.Equal("/verbosity:\"diag\";minimal", switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Verbosity));
+            Assert.Equal("/v:q /verbosity:\"diag\";minimal", switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Verbosity));
             Assert.True(switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Verbosity));
 
             parameters = switches[CommandLineSwitches.ParameterizedSwitch.Verbosity];
@@ -800,7 +800,7 @@ namespace Microsoft.Build.UnitTests
             // more fake/missing parameters
             Assert.False(switches.SetParameterizedSwitch(CommandLineSwitches.ParameterizedSwitch.Target, "/t:A,\"\";B", "A,\"\";B", true, true));
 
-            Assert.Equal("/t:A,\"\";B", switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Target));
+            Assert.Equal("/t:\" /t:A,\"\";B", switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Target));
             Assert.True(switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Target));
 
             parameters = switches[CommandLineSwitches.ParameterizedSwitch.Target];
@@ -842,7 +842,7 @@ namespace Microsoft.Build.UnitTests
             // parameters, but for testing purposes this is fine
             Assert.True(switches.SetParameterizedSwitch(CommandLineSwitches.ParameterizedSwitch.Logger, "/LOGGER:\"\",asm;\"p,a;r\"", "\"\",asm;\"p,a;r\"", true, false));
 
-            Assert.Equal("/LOGGER:\"\",asm;\"p,a;r\"", switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Logger));
+            Assert.Equal("/l:\" /LOGGER:\"\",asm;\"p,a;r\"", switches.GetParameterizedSwitchCommandLineArg(CommandLineSwitches.ParameterizedSwitch.Logger));
             Assert.True(switches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Logger));
 
             parameters = switches[CommandLineSwitches.ParameterizedSwitch.Logger];


### PR DESCRIPTION
This PR relates to solve an issue reported to the CakeBuild system ( cake-build/cake#680 ).

Currently when running MSBuild and specifying multiple properties all aren't logged when diagnostic verbosity.
This might be by design? but when debugging and logging at least I and 1 more users find this a bit confusing when parts of the command line is omitted.

I tracked the issue to GetEquivalentCommandLineExceptProjectFile() in [./src/XMakeCommandLine/XMake.cs#L1840](https://github.com/Microsoft/msbuild/blob/a804b8a3e47f388a31272c0cf95da888f99a2457/src/XMakeCommandLine/XMake.cs#L1840)

And the value is set on each iteration in [./src/XMakeCommandLine/CommandLineSwitches.cs#L448](https://github.com/Microsoft/msbuild/blob/a804b8a3e47f388a31272c0cf95da888f99a2457/src/XMakeCommandLine/CommandLineSwitches.cs#L448) which of course results in last value always being used.

Repro instructions:

if you call MSBuild using the following parameters
```cmd
msbuild /m /v:diagnostic /p:Configuration="Release" /p:firstProperty=one /p:secondProperty=two /target:Build "C:/temp/dev/gh/Philo/example/src/Example.sln"
```
_*the verbose output will be something like*_
```
Microsoft (R) Build Engine version 14.0.24720.0
Copyright (C) Microsoft Corporation. All rights reserved.

C:/Program Files (x86)/MSBuild/14.0/Bin/amd64/MSBuild.exe /m /p:secondProperty=two /target:Build /v:diagnostic C:/temp/dev/gh/Philo/example/src/Example.sln
Build started 2016-02-10 17:08:05.
```
_*same in MSBuild 12*_
```
Microsoft (R) Build Engine version 12.0.31101.0
[Microsoft .NET Framework, version 4.0.30319.42000]
Copyright (C) Microsoft Corporation. All rights reserved.

C:/Program Files (x86)/MSBuild/12.0/Bin/amd64/MSBuild.exe /m /p:secondProperty=two /target:Build /v:diagnostic C:/temp/dev/gh/Philo/example/src/Example.sln
Build started 2016-02-10 17:01:51.
```
_*after the adjustments done in this PR output will be*_
```
Microsoft (R) Build Engine version 14.1.0.0
Copyright (C) Microsoft Corporation. All rights reserved.

C:/temp/dev/gh/devlead/msbuild/bin/Windows_NT/Debug/msbuild.exe /m /p:Configuration=Release /p:firstProperty=one /p:secondProperty=two /target:Build /v:diagnostic C:/temp/dev/gh/Philo/example/src/Example.sln
Build started 2016-02-10 16:29:57.
```
