### PR TITLE
Add support for resolving $(MSBuildExtensionsPath) with fallback sear…

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -253,8 +253,8 @@
     <FeatureSpecialFolders>true</FeatureSpecialFolders>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_INTERN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRONG_NAMES</DefineConstants>
-    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>
-    <FeatureSystemConfiguration Condition="'$(MonoBuild)' != 'true'">true</FeatureSystemConfiguration>
+    <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_CONFIGURATION</DefineConstants>
+    <FeatureSystemConfiguration>true</FeatureSystemConfiguration>
     <DefineConstants>$(DefineConstants);FEATURE_TASK_GENERATERESOURCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TASKHOST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ABORT</DefineConstants>

--- a/src/Shared/ToolsetElement.cs
+++ b/src/Shared/ToolsetElement.cs
@@ -157,6 +157,191 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Collection of all the search paths for MSBuildExtensionsPath*, per OS
+        /// </summary>
+        [ConfigurationProperty("msbuildExtensionsPathSearchPaths")]
+        public ExtensionsPathsElementCollection AllMSBuildExtensionPathsSearchPaths
+        {
+            get
+            {
+                return (ExtensionsPathsElementCollection)base["msbuildExtensionsPathSearchPaths"];
+            }
+        }
+
+        /// <summary>
+        /// Class representing all the per-OS search paths for MSBuildExtensionsPath*
+        /// </summary>
+        internal sealed class ExtensionsPathsElementCollection : ConfigurationElementCollection
+        {
+            /// <summary>
+            /// We use this dictionary to track whether or not we've seen a given
+            /// searchPaths definition before, since the .NET configuration classes
+            /// won't perform this check without respect for case.
+            /// </summary>
+            private Dictionary<string, string> _previouslySeenOS = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            /// <summary>
+            /// Type of the collection
+            /// This has to be public as cannot change access modifier when overriding
+            /// </summary>
+            public override ConfigurationElementCollectionType CollectionType
+            {
+                get
+                {
+                    return ConfigurationElementCollectionType.BasicMap;
+                }
+            }
+
+            /// <summary>
+            /// Throw exception if an element with a duplicate key is added to the collection
+            /// </summary>
+            protected override bool ThrowOnDuplicate
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Name of the element
+            /// </summary>
+            protected override string ElementName
+            {
+                get
+                {
+                    return "searchPaths";
+                }
+            }
+
+            /// <summary>
+            /// Gets an element with the specified name
+            /// </summary>
+            /// <param name="os">OS of the element</param>
+            /// <returns>element</returns>
+            public ExtensionsPathElement GetElement(string os)
+            {
+                return (ExtensionsPathElement)this.BaseGet(os);
+            }
+
+            /// <summary>
+            /// Gets an element based at the specified position
+            /// </summary>
+            /// <param name="index">position</param>
+            /// <returns>element</returns>
+            public ExtensionsPathElement GetElement(int index)
+            {
+                return (ExtensionsPathElement)this.BaseGet(index);
+            }
+
+            /// <summary>
+            /// Returns the key value for the given element
+            /// </summary>
+            /// <param name="element">element whose key is returned</param>
+            /// <returns>key</returns>
+            protected override object GetElementKey(ConfigurationElement element)
+            {
+                return ((ExtensionsPathElement)element).OS;
+            }
+
+            /// <summary>
+            /// Creates a new element of the collection
+            /// </summary>
+            /// <returns>Created element</returns>
+            protected override ConfigurationElement CreateNewElement()
+            {
+                return new ExtensionsPathElement();
+            }
+
+            /// <summary>
+            /// overridden so we can track previously seen elements
+            /// </summary>
+            protected override void BaseAdd(int index, ConfigurationElement element)
+            {
+                UpdateOSMap(element);
+
+                base.BaseAdd(index, element);
+            }
+
+            /// <summary>
+            /// overridden so we can track previously seen elements
+            /// </summary>
+            protected override void BaseAdd(ConfigurationElement element)
+            {
+                UpdateOSMap(element);
+
+                base.BaseAdd(element);
+            }
+
+            /// <summary>
+            /// Stores the name of the OS in a case-insensitive map
+            /// so we can detect if it is specified more than once but with
+            /// different case
+            /// </summary>
+            private void UpdateOSMap(ConfigurationElement element)
+            {
+                string os = GetElementKey(element).ToString();
+
+                if (_previouslySeenOS.ContainsKey(os))
+                {
+                    string locationString = String.Empty;
+                    if (!String.IsNullOrEmpty(element.ElementInformation.Source))
+                    {
+                        if (element.ElementInformation.LineNumber != 0)
+                        {
+                            locationString = String.Format("{0} ({1})", element.ElementInformation.Source, element.ElementInformation.LineNumber);
+                        }
+                        else
+                        {
+                            locationString = element.ElementInformation.Source;
+                        }
+                    }
+
+                    string message = ResourceUtilities.FormatResourceString("MultipleDefinitionsForSameExtensionsPathOS", os, locationString);
+
+                    throw new ConfigurationErrorsException(message, element.ElementInformation.Source, element.ElementInformation.LineNumber);
+                }
+
+                _previouslySeenOS.Add(os, string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Class representing searchPaths element for a single OS
+        /// </summary>
+        internal sealed class ExtensionsPathElement : ConfigurationElement
+        {
+            /// <summary>
+            /// OS attribute of the element
+            /// </summary>
+            [ConfigurationProperty("os", IsKey = true, IsRequired = true)]
+            public string OS
+            {
+                get
+                {
+                    return (string)base["os"];
+                }
+
+                set
+                {
+                    base["os"] = value;
+                }
+            }
+
+            /// <summary>
+            /// Property element collection
+            /// </summary>
+            [ConfigurationProperty("", IsDefaultCollection = true)]
+            public PropertyElementCollection PropertyElements
+            {
+                get
+                {
+                    return (PropertyElementCollection)base[""];
+                }
+            }
+        }
+
+        /// <summary>
         /// Class representing collection of property elements
         /// </summary>
         internal sealed class PropertyElementCollection : ConfigurationElementCollection

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -1660,16 +1660,50 @@ namespace Microsoft.Build.Evaluation
             _loggingService.OnlyLogCriticalEvents = onlyLogCriticalEvents;
         }
 
+#if FEATURE_SYSTEM_CONFIGURATION
+        /// <summary>
+        /// Reset the toolsets using the provided toolset reader, used by unit tests
+        /// </summary>
+        internal void ResetToolsetsForTests(ToolsetConfigurationReader configurationReaderForTestsOnly)
+        {
+            InitializeToolsetCollection(configReader:configurationReaderForTestsOnly);
+        }
+#endif
+
+#if FEATURE_WIN32_REGISTRY
+        /// <summary>
+        /// Reset the toolsets using the provided toolset reader, used by unit tests
+        /// <summary>
+        internal void ResetToolsetsForTests(ToolsetRegistryReader registryReaderForTestsOnly)
+        {
+            InitializeToolsetCollection(registryReader:registryReaderForTestsOnly);
+        }
+#endif
+
         /// <summary>
         /// Populate Toolsets with a dictionary of (toolset version, Toolset) 
         /// using information from the registry and config file, if any.  
         /// </summary>
-        private void InitializeToolsetCollection()
+        private void InitializeToolsetCollection(
+#if FEATURE_WIN32_REGISTRY
+                ToolsetRegistryReader registryReader = null,
+#endif
+#if FEATURE_SYSTEM_CONFIGURATION
+                ToolsetConfigurationReader configReader = null
+#endif
+                )
         {
             _toolsets = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
 
             // We only want our local toolset (as defined in MSBuild.exe.config) when we're operating locally...
-            _defaultToolsVersion = ToolsetReader.ReadAllToolsets(_toolsets, EnvironmentProperties, _globalProperties, _toolsetDefinitionLocations);
+            _defaultToolsVersion = ToolsetReader.ReadAllToolsets(_toolsets,
+#if FEATURE_WIN32_REGISTRY
+                    registryReader,
+#endif
+#if FEATURE_SYSTEM_CONFIGURATION
+                    configReader,
+#endif
+                    EnvironmentProperties, _globalProperties, _toolsetDefinitionLocations);
 
             _toolsetsVersion++;
         }

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -350,6 +350,20 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Returns a copy of the list of search paths for a MSBuildExtensionsPath* property kind.
+        /// </summary>
+        internal IList<string> GetMSBuildExtensionsPathSearchPathsFor(MSBuildExtensionsPathReferenceKind refKind)
+        {
+            IList<string> paths;
+            if (MSBuildExtensionsPathSearchPathsTable != null && MSBuildExtensionsPathSearchPathsTable.TryGetValue(refKind, out paths))
+            {
+                return new List<string>(paths);
+            }
+
+            return new List<string>();
+        }
+
+        /// <summary>
         /// Name of this toolset
         /// </summary>
         public string ToolsVersion
@@ -564,6 +578,14 @@ namespace Microsoft.Build.Evaluation
         internal string DefaultOverrideToolsVersion
         {
             get { return _defaultOverrideToolsVersion; }
+        }
+
+        /// <summary>
+        /// Map of MSBuildExtensionsPath properties to their list of fallback search paths
+        /// </summary>
+        internal Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> MSBuildExtensionsPathSearchPathsTable
+        {
+            get; set;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -210,6 +210,11 @@ namespace Microsoft.Build.Evaluation
             yield break;
         }
 
+        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        {
+            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+        }
+
         /// <summary>
         /// Reads the application configuration file.
         /// NOTE: this is abstracted into a method to support unit testing GetToolsetDataFromConfiguration().

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -5,6 +5,7 @@
 // <summary>A class used to read the Toolset configuration.</summary>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 
@@ -44,6 +45,17 @@ namespace Microsoft.Build.Evaluation
         private bool _configurationReadAttempted = false;
 
         /// <summary>
+        /// Character used to separate search paths specified for MSBuildExtensionsPath* in
+        /// the config file
+        /// </summary>
+        private char _separatorForExtensionsPathSearchPaths = ';';
+
+        /// <summary>
+        /// map of MSBuildExtensionsPath property kind to list of fallback search paths, per toolsVersion
+        /// </summary>
+        private Dictionary<string, Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>> _kindToPathsCachePerToolsVersion;
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         internal ToolsetConfigurationReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties)
@@ -59,6 +71,7 @@ namespace Microsoft.Build.Evaluation
         {
             ErrorUtilities.VerifyThrowArgumentNull(readApplicationConfiguration, "readApplicationConfiguration");
             _readApplicationConfiguration = readApplicationConfiguration;
+            _kindToPathsCachePerToolsVersion = new Dictionary<string, Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -210,9 +223,69 @@ namespace Microsoft.Build.Evaluation
             yield break;
         }
 
+        /// <summary>
+        /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
+        /// </summary>
         protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
         {
-            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+            Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> kindToPathsCache;
+            var key = toolsVersion + ":" + os;
+            if (_kindToPathsCachePerToolsVersion.TryGetValue(key, out kindToPathsCache))
+            {
+                return kindToPathsCache;
+            }
+
+            // Read and populate the map
+            kindToPathsCache = new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+            _kindToPathsCachePerToolsVersion[key] = kindToPathsCache;
+
+            ToolsetElement toolsetElement = ConfigurationSection.Toolsets.GetElement(toolsVersion);
+            var propertyCollection = toolsetElement?.AllMSBuildExtensionPathsSearchPaths?.GetElement(os)?.PropertyElements;
+            if (propertyCollection == null || propertyCollection.Count == 0)
+            {
+                return kindToPathsCache;
+            }
+
+            var allPaths = new MSBuildExtensionsPathReferenceKind[] {
+                                MSBuildExtensionsPathReferenceKind.Default,
+                                MSBuildExtensionsPathReferenceKind.Path32,
+                                MSBuildExtensionsPathReferenceKind.Path64,
+                                MSBuildExtensionsPathReferenceKind.None
+                            };
+
+            foreach (MSBuildExtensionsPathReferenceKind kind in allPaths)
+            {
+                kindToPathsCache[kind] = ComputeDistinctListOfFallbackPathsFor(kind, propertyCollection);
+            }
+
+            return kindToPathsCache;
+        }
+
+        /// <summary>
+        /// Returns a list of the search paths for a given MSBuildExtensionsPathReferenceKind
+        /// </summary>
+        private List<string> ComputeDistinctListOfFallbackPathsFor(MSBuildExtensionsPathReferenceKind refKind, ToolsetElement.PropertyElementCollection propertyCollection)
+        {
+            var extnPaths = new List<string>();
+            var pathsFromConfig = propertyCollection.GetElement(refKind.StringRepresentation)?.Value;
+
+            //FIXME: handle ; in path on Unix
+            if (String.IsNullOrEmpty(pathsFromConfig))
+            {
+                return extnPaths;
+            }
+
+            var pathsTable = new HashSet<string>();
+            foreach (var extnPath in pathsFromConfig.Split(new char[]{_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (!pathsTable.Contains(extnPath))
+                {
+                    pathsTable.Add(extnPath);
+                    extnPaths.Add(extnPath);
+                }
+            }
+
+            return extnPaths;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
@@ -68,5 +68,10 @@ namespace Microsoft.Build.Evaluation
         {
             return Enumerable.Empty<string>();
         }
+
+        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        {
+            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+        }
     }
 }

--- a/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
@@ -290,6 +290,14 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
+        /// </summary>
+        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        {
+            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+        }
+
+        /// <summary>
         /// Given a registry location containing a property name and value, create the ToolsetPropertyDefinition that maps to it
         /// </summary>
         /// <param name="toolsetWrapper">Wrapper for the key that we're getting values from</param>

--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using Microsoft.Build.Construction;
 #if FEATURE_MSBUILD_DEBUGGER
 using Microsoft.Build.Debugging;
@@ -1891,26 +1893,21 @@ namespace Microsoft.Build.Evaluation
             }
 #endif
 
-            if (EvaluateConditionCollectingConditionedProperties(importElement, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties, _projectRootElementCache))
+            List<ProjectRootElement> importedProjectRootElements = ExpandAndLoadImports(directoryOfImportingFile, importElement);
+
+            foreach (ProjectRootElement importedProjectRootElement in importedProjectRootElements)
             {
-                string importExpressionEscaped = _expander.ExpandIntoStringLeaveEscaped(importElement.Project, ExpanderOptions.ExpandProperties, importElement.ProjectLocation);
+                _data.RecordImport(importElement, importedProjectRootElement, importedProjectRootElement.Version);
 
-                List<ProjectRootElement> importedProjectRootElements = ExpandAndLoadImports(directoryOfImportingFile, importExpressionEscaped, importElement);
-
-                foreach (ProjectRootElement importedProjectRootElement in importedProjectRootElements)
-                {
-                    _data.RecordImport(importElement, importedProjectRootElement, importedProjectRootElement.Version);
-
-                    // This key should be unique, as duplicate imports were already discarded
+                // This key should be unique, as duplicate imports were already discarded
 #if FEATURE_MSBUILD_DEBUGGER
-                    if (DebuggerManager.DebuggingEnabled)
-                    {
-                        _importRelationships.Add(importedProjectRootElement, importElement.ContainingProject);
-                    }
+                if (DebuggerManager.DebuggingEnabled)
+                {
+                    _importRelationships.Add(importedProjectRootElement, importElement.ContainingProject);
+                }
 #endif
 
-                    PerformDepthFirstPass(importedProjectRootElement);
-                }
+                PerformDepthFirstPass(importedProjectRootElement);
             }
 
 #if FEATURE_MSBUILD_DEBUGGER
@@ -2026,16 +2023,173 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// If the project import references a $(MSBuildExtensionsPath*)
+        /// then this tries to find project files corresponding to that, using various search
+        /// paths. It relies on the ExpandAndLoadImportsFromUnescapedImportExpressionConditioned
+        /// to do the actual loading and parsing.
+        /// This is explained in detail in a comment with the method code.
+        ///
+        /// If the project import does not reference the $(MSBuildExtensionsPath*) property, then
+        /// it falls back to the default behavior.
+        ///
+        /// Caches the parsed import into the provided collection, so future
+        /// requests can be satisfied without re-parsing it.
+        /// </summary>
+        private List<ProjectRootElement> ExpandAndLoadImports(string directoryOfImportingFile, ProjectImportElement importElement)
+        {
+            var refKindInProject = MSBuildExtensionsPathReferenceKind.FindIn(importElement.Project);
+            var fallbackExtensionPaths = _data.Toolset.GetMSBuildExtensionsPathSearchPathsFor(refKindInProject);
+
+            // no reference or we need to lookup only the default path,
+            // so, use the Import path
+            if (fallbackExtensionPaths.Count == 0)
+            {
+                List<ProjectRootElement> projects;
+                var result = ExpandAndLoadImportsFromUnescapedImportExpressionConditioned(directoryOfImportingFile, importElement, importElement.Project, out projects);
+                return projects;
+            }
+
+            // $(MSBuildExtensionsPath*) usually resolves to a single value, single default path. This can be overridden
+            // by the usual property overriding techniques.
+            //
+            // Eg. <Import Project='$(MSBuildExtensionsPath)\foo\extn.proj' />
+            //
+            // But this feature allows that when it is used in an Import element, it will behave as a "search path", meaning
+            // that the relative project path "foo\extn.proj" will be searched for, in more than one location.
+            // Essentially, we will try to load that project file by trying multiple values (search paths) for the
+            // $(MSBuildExtensionsPath*) property.
+            //
+            // The various paths tried, in order are:
+            //
+            // 1. The value of the MSBuildExtensionsPath* property
+            //
+            // 2. Search paths available in the current toolset (via toolset.MSBuildExtensionsPathSearchPathsTable).
+            //    That may be loaded from app.config with a definition like:
+            //
+            //    <toolset .. >
+            //      <msbuildExtensionsPathSearchPaths>
+            //          <searchPaths os="osx">
+            //              <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/;/tmp/foo"/>
+            //              <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            //              <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            //          </searchPaths>
+            //      </msbuildExtensionsPathSearchPaths>
+            //    </toolset>
+            //
+            // This is available only when used in an Import element and it's Condition. So, the following common pattern
+            // would work:
+            //
+            //      <Import Project="$(MSBuildExtensionsPath)\foo\extn.proj" Condition="'Exists('$(MSBuildExtensionsPath)\foo\extn.proj')'" />
+            //
+            // The value of the MSBuildExtensionsPath* property, will always be "visible" with it's default value, example, when read or
+            // referenced anywhere else. This is a very limited support, so, it doesn't come in to effect if the explcit reference to
+            // the $(MSBuildExtensionsPath) property is not present in the Project attribute of the Import element. So, the following is
+            // not supported:
+            //
+            //      <PropertyGroup><ProjectPathForImport>$(MSBuildExtensionsPath)\foo\extn.proj</ProjectPathForImport></PropertyGroup>
+            //      <Import Project='$(ProjectPathForImport)' />
+            //
+
+            // Adding the value of $(MSBuildExtensionsPath*) property to the list of search paths
+            fallbackExtensionPaths.Insert(0, _data.GetProperty(refKindInProject.StringRepresentation).EvaluatedValue);
+
+            string extensionPropertyRefAsString = refKindInProject.MSBuildPropertyName;
+
+            _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "SearchPathsForMSBuildExtensionsPath",
+                                        extensionPropertyRefAsString,
+                                        String.Join(Path.PathSeparator.ToString(), fallbackExtensionPaths));
+
+            bool atleastOneExactFilePathWasLookedAtAndNotFound = false;
+
+            // Try every extension search path, till we get a Hit:
+            // 1. 1 or more project files loaded
+            // 2. 1 or more project files *found* but ignored (like circular, self imports)
+            foreach (var extensionPath in fallbackExtensionPaths)
+            {
+                if (!Directory.Exists(extensionPath))
+                {
+                    continue;
+                }
+
+                var newExpandedCondition = importElement.Condition.Replace(extensionPropertyRefAsString, extensionPath);
+                if (!EvaluateConditionCollectingConditionedProperties(importElement, newExpandedCondition, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties,
+                            _projectRootElementCache))
+                {
+                    continue;
+                }
+
+                var newExpandedImportPath = importElement.Project;
+                newExpandedImportPath = newExpandedImportPath.Replace(extensionPropertyRefAsString, extensionPath);
+
+                _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "TryingExtensionsPath", newExpandedImportPath, extensionPath);
+
+                List<ProjectRootElement> projects;
+                var result = ExpandAndLoadImportsFromUnescapedImportExpression(directoryOfImportingFile, importElement, newExpandedImportPath,
+                                        false, out projects);
+
+                if (result == LoadImportsResult.ProjectsImported)
+                {
+                    return projects;
+                }
+
+                if (result == LoadImportsResult.FoundFilesToImportButIgnored)
+                {
+                    // Circular, Self import cases are usually ignored
+                    // Since we have a semi-success here, we stop looking at
+                    // other paths
+                    return projects;
+                }
+
+                if (result == LoadImportsResult.TriedToImportButFileNotFound)
+                {
+                    atleastOneExactFilePathWasLookedAtAndNotFound = true;
+                }
+                // else if (result == LoadImportsResult.ImportExpressionResolvedToNothing) {}
+            }
+
+            // Found at least one project file for the Import, but no projects were loaded
+            // atleastOneExactFilePathWasLookedAtAndNotFound would be false, eg, if the expression
+            // was a wildcard and it resolved to zero files!
+            if (atleastOneExactFilePathWasLookedAtAndNotFound && (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) == 0)
+            {
+                ThrowForImportedProjectFromExtensionsPathNotFound(refKindInProject, importElement);
+            }
+
+            return new List<ProjectRootElement>();
+        }
+
+        /// <summary>
+        /// Load and parse the specified project import, which may have wildcards,
+        /// into one or more ProjectRootElements, if it's Condition evaluates to true
+        /// Caches the parsed import into the provided collection, so future
+        /// requests can be satisfied without re-parsing it.
+        /// </summary>
+        private LoadImportsResult ExpandAndLoadImportsFromUnescapedImportExpressionConditioned(string directoryOfImportingFile, ProjectImportElement importElement, string unescapedExpression,
+                                            out List<ProjectRootElement> projects, bool throwOnFileNotExistsError=true)
+        {
+            if (!EvaluateConditionCollectingConditionedProperties(importElement, ExpanderOptions.ExpandProperties, ParserOptions.AllowProperties, _projectRootElementCache))
+            {
+                projects = new List<ProjectRootElement>();
+                return LoadImportsResult.ConditionWasFalse;
+            }
+
+            return ExpandAndLoadImportsFromUnescapedImportExpression(directoryOfImportingFile, importElement, importElement.Project, throwOnFileNotExistsError, out projects);
+        }
+
+        /// <summary>
         /// Load and parse the specified project import, which may have wildcards,
         /// into one or more ProjectRootElements.
         /// Caches the parsed import into the provided collection, so future 
         /// requests can be satisfied without re-parsing it.
         /// </summary>
-        private List<ProjectRootElement> ExpandAndLoadImports(string directoryOfImportingFile, string importExpressionEscaped, ProjectImportElement importElement)
+        private LoadImportsResult ExpandAndLoadImportsFromUnescapedImportExpression(string directoryOfImportingFile, ProjectImportElement importElement, string unescapedExpression,
+                                            bool throwOnFileNotExistsError, out List<ProjectRootElement> imports)
         {
+            string importExpressionEscaped = _expander.ExpandIntoStringLeaveEscaped(unescapedExpression, ExpanderOptions.ExpandProperties, importElement.ProjectLocation);
             ElementLocation importLocationInProject = importElement.Location;
 
-            List<ProjectRootElement> imports = new List<ProjectRootElement>();
+            bool atleastOneImportIgnored = false;
+            imports = new List<ProjectRootElement>();
             string[] importFilesEscaped = null;
 
             try
@@ -2090,6 +2244,7 @@ namespace Microsoft.Build.Evaluation
                 if (String.Equals(_projectRootElement.FullPath, importFileUnescaped, StringComparison.OrdinalIgnoreCase) /* We are trying to import ourselves */)
                 {
                     _loggingService.LogWarning(_buildEventContext, null, new BuildEventFileInfo(importLocationInProject), "SelfImport", importFileUnescaped);
+                    atleastOneImportIgnored = true;
 
                     continue;
                 }
@@ -2114,6 +2269,7 @@ namespace Microsoft.Build.Evaluation
                         }
 
                         // Ignore this import and no more further processing on it.
+                        atleastOneImportIgnored = true;
                         continue;
                     }
                 }
@@ -2169,6 +2325,7 @@ namespace Microsoft.Build.Evaluation
                         }
 
                         // Since we have already seen this we need to not continue on in the processing.
+                        atleastOneImportIgnored = true;
                         continue;
                     }
                     else
@@ -2187,7 +2344,7 @@ namespace Microsoft.Build.Evaluation
                         // There's a specific message for file not existing
                         if (!File.Exists(importFileUnescaped))
                         {
-                            if ((_loadSettings & ProjectLoadSettings.IgnoreMissingImports) != 0)
+                            if (!throwOnFileNotExistsError || (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) != 0)
                             {
                                 continue;
                             }
@@ -2210,7 +2367,29 @@ namespace Microsoft.Build.Evaluation
                 _importsSeen.Add(importFileUnescaped, importElement);
             }
 
-            return imports;
+            if (imports.Count > 0)
+            {
+                return LoadImportsResult.ProjectsImported;
+            }
+
+            if (atleastOneImportIgnored)
+            {
+                return LoadImportsResult.FoundFilesToImportButIgnored;
+            }
+
+            if (importFilesEscaped.Length == 0)
+            {
+                // Expression resolved to "", eg. a wildcard
+                return LoadImportsResult.ImportExpressionResolvedToNothing;
+            }
+
+            // No projects were imported, none were ignored but we did have atleast
+            // one file to process, which means that we did try to load a file but
+            // failed w/o an exception escaping from here.
+            // We ignore only the file not existing error, so, that is the case here
+            // (if @throwOnFileNotExistsError==true, then it would have thrown
+            //  and we wouldn't be here)
+            return LoadImportsResult.TriedToImportButFileNotFound;
         }
 
         /// <summary>
@@ -2256,14 +2435,19 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private bool EvaluateCondition(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions)
         {
-            if (element.Condition.Length == 0)
+            return EvaluateCondition(element, element.Condition, expanderOptions, parserOptions);
+        }
+
+        private bool EvaluateCondition(ProjectElement element, string condition, ExpanderOptions expanderOptions, ParserOptions parserOptions)
+        {
+            if (condition.Length == 0)
             {
                 return true;
             }
 
             bool result = ConditionEvaluator.EvaluateCondition
                 (
-                element.Condition,
+                condition,
                 parserOptions,
                 _expander,
                 expanderOptions,
@@ -2276,24 +2460,29 @@ namespace Microsoft.Build.Evaluation
             return result;
         }
 
+        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCache projectRootElementCache = null)
+        {
+            return EvaluateConditionCollectingConditionedProperties(element, element.Condition, expanderOptions, parserOptions, projectRootElementCache);
+        }
+
         /// <summary>
         /// Evaluate a given condition, collecting conditioned properties.
         /// </summary>
-        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCache projectRootElementCache = null)
+        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, string condition, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCache projectRootElementCache = null)
         {
-            if (element.Condition.Length == 0)
+            if (condition.Length == 0)
             {
                 return true;
             }
 
             if (!_data.ShouldEvaluateForDesignTime)
             {
-                return EvaluateCondition(element, expanderOptions, parserOptions);
+                return EvaluateCondition(element, condition, expanderOptions, parserOptions);
             }
 
             bool result = ConditionEvaluator.EvaluateConditionCollectingConditionedProperties
                 (
-                element.Condition,
+                condition,
                 parserOptions,
                 _expander,
                 expanderOptions,
@@ -2325,5 +2514,82 @@ namespace Microsoft.Build.Evaluation
                 return _data.Directory;
             }
         }
+
+        /// <summary>
+        /// Throws InvalidProjectException because we failed to import a project from $(MSBuildExtensionsPath*)
+        /// <param name="refKindInProject">MSBuildExtensionsPath reference kind found in the Project attribute of the Import element</param>
+        /// <param name="importElement">The importing element for this import</param>
+        /// </summary>
+        private void ThrowForImportedProjectFromExtensionsPathNotFound(MSBuildExtensionsPathReferenceKind refKindInProject, ProjectImportElement importElement)
+        {
+            string extensionsPathPropValue = _data.GetProperty(refKindInProject.StringRepresentation).EvaluatedValue;
+
+            string importExpandedWithDefaultPath = _expander.ExpandIntoStringLeaveEscaped(
+                                                                    importElement.Project.Replace(refKindInProject.MSBuildPropertyName, extensionsPathPropValue),
+                                                                    ExpanderOptions.ExpandProperties, importElement.ProjectLocation);
+
+            string relativeProjectPath = FileUtilities.MakeRelative(extensionsPathPropValue, importExpandedWithDefaultPath);
+
+            var onlyFallbackSearchPaths = _data.Toolset.GetMSBuildExtensionsPathSearchPathsFor(refKindInProject);
+            string stringifiedListOfSearchPaths = StringifyList(onlyFallbackSearchPaths);
+
+#if FEATURE_SYSTEM_CONFIGURATION
+            string configLocation = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+
+            ProjectErrorUtilities.ThrowInvalidProject(importElement.ProjectLocation, "ImportedProjectFromExtensionsPathNotFoundFromAppConfig",
+                                                        importExpandedWithDefaultPath,
+                                                        relativeProjectPath,
+                                                        refKindInProject.MSBuildPropertyName,
+                                                        stringifiedListOfSearchPaths,
+                                                        configLocation);
+#else
+            ProjectErrorUtilities.ThrowInvalidProject(importElement.ProjectLocation, "ImportedProjectFromExtensionsPathNotFound",
+                                                        importExpandedWithDefaultPath,
+                                                        relativeProjectPath,
+                                                        refKindInProject.MSBuildPropertyName,
+                                                        stringifiedListOfSearchPaths);
+#endif
+        }
+
+        /// <summary>
+        /// Stringify a list of strings, like {"abc, "def", "foo"} to "abc, def and foo"
+        /// or {"abc"} to "abc"
+        /// <param name="strings">List of strings to stringify</param>
+        /// <returns>Stringified list</returns>
+        /// </summary>
+        private static string StringifyList(IList<string> strings)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < strings.Count - 1; i ++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                 }
+
+                sb.Append($"\"{strings[i]}\"");
+            }
+
+            if (strings.Count > 1)
+            {
+                sb.Append(" and ");
+            }
+
+            sb.Append($"\"{strings[strings.Count - 1]}\"");
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Represents result of attempting to load imports (ExpandAndLoadImportsFromUnescapedImportExpression*)
+    /// </summary>
+    internal enum LoadImportsResult
+    {
+        ProjectsImported,
+        FoundFilesToImportButIgnored,
+        TriedToImportButFileNotFound,
+        ImportExpressionResolvedToNothing,
+        ConditionWasFalse
     }
 }

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -252,6 +252,12 @@
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
     </comment>
   </data>
+  <data name="SearchPathsForMSBuildExtensionsPath">
+      <value>Search paths being used for {0} are {1}</value>
+  </data>
+  <data name="TryingExtensionsPath">
+      <value>Trying to import {0} using extensions path {1}</value>
+  </data>
   <data name="OverrideTasksFileFailure" UESanitized="false" Visibility="Public">
     <value>MSB4194: The override tasks file could not be successfully loaded. {0}</value>
     <comment>
@@ -412,6 +418,14 @@
   <data name="ImportedProjectNotFound" UESanitized="false" Visibility="Public">
     <value>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</value>
     <comment>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
+  </data>
+  <data name="ImportedProjectFromExtensionsPathNotFoundFromAppConfig" UESanitized="false" Visibility="Public">
+    <value>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</value>
+    <comment>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
+  </data>
+  <data name="ImportedProjectFromExtensionsPathNotFound" UESanitized="false" Visibility="Public">
+    <value>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</value>
+    <comment>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="IncorrectNumberOfFunctionArguments" UESanitized="false" Visibility="Public">
     <value>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</value>
@@ -1527,7 +1541,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4226.
+        Next message code should be MSB4227.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -612,6 +612,10 @@
     <value>MSB4144: Multiple definitions were found for the toolset "{0}". </value>
     <comment>{StrBegin="MSB4144: "}</comment>
   </data>
+  <data name="MultipleDefinitionsForSameExtensionsPathOS" UESanitized="false" Visibility="Public">
+      <value>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</value>
+    <comment>{StrBegin="MSB4225: "}</comment>
+  </data>
   <data name="MultipleDefinitionsForSameProperty" UESanitized="false" Visibility="Public">
     <value>MSB4145: Multiple definitions were found for the property "{0}".</value>
     <comment>{StrBegin="MSB4145: "}</comment>
@@ -1523,7 +1527,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4225.
+        Next message code should be MSB4226.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -5,11 +5,15 @@
 
 using System.Configuration;
 using Microsoft.Win32;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
 
 using ToolsetConfigurationSection = Microsoft.Build.Evaluation.ToolsetConfigurationSection;
 using Xunit;
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Build.UnitTests.Definition
 {
@@ -81,6 +85,8 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.Count, 1);
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 0);
         }
 
         /// <summary>
@@ -178,6 +184,8 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.Count, 1);
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 0);
         }
         #endregion
 
@@ -492,6 +500,182 @@ namespace Microsoft.Build.UnitTests.Definition
 
         #endregion
         #endregion
+
+        #region Extensions Paths
+        /// <summary>
+        ///  Tests multiple extensions paths from the config file, specified for multiple OSes
+        /// </summary>
+        [Fact]
+        public void ExtensionPathsTest_Basic1()
+        {
+            // NOTE: for some reason, <configSections> MUST be the first element under <configuration>
+            // for the API to read it. The docs don't make this clear.
+
+            ToolsetConfigurationReaderTestHelper.WriteConfigFile(ObjectModelHelpers.CleanupFileContents(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""2.0"">
+                     <toolset toolsVersion=""2.0"">
+                       <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v2.0.x86ret\""/>
+                       <property name=""MSBuildToolsPath"" value=""D:\windows\Microsoft.NET\Framework\v2.0.x86ret\""/>
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
+                            <property name=""MSBuildExtensionsPath64"" value=""c:\foo64;c:\bar64""/>
+                         </searchPaths>
+                         <searchPaths os=""osx"">
+                            <property name=""MSBuildExtensionsPath"" value=""/tmp/foo""/>
+                            <property name=""MSBuildExtensionsPath32"" value=""/tmp/foo32;/tmp/bar32""/>
+                         </searchPaths>
+                         <searchPaths os=""unix"">
+                            <property name=""MSBuildExtensionsPath"" value=""/tmp/bar""/>
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                     </toolset>
+                   </msbuildToolsets>
+                 </configuration>"));
+
+            Configuration config = ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest();
+            ToolsetConfigurationSection msbuildToolsetSection = config.GetSection(s_msbuildToolsets) as ToolsetConfigurationSection;
+
+            Assert.Equal(msbuildToolsetSection.Default, "2.0");
+            Assert.Equal(1, msbuildToolsetSection.Toolsets.Count);
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).toolsVersion, "2.0");
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.Count, 2);
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
+                                   @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 3);
+            var allPaths = msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths;
+            Assert.Equal(allPaths.GetElement(0).OS, "windows");
+            Assert.Equal(allPaths.GetElement(0).PropertyElements.Count, 2);
+            Assert.Equal(allPaths.GetElement(0).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"c:\foo");
+            Assert.Equal(allPaths.GetElement(0).PropertyElements.GetElement("MSBuildExtensionsPath64").Value, @"c:\foo64;c:\bar64");
+
+            Assert.Equal(allPaths.GetElement(1).OS, "osx");
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.Count, 2);
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/foo");
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath32").Value, @"/tmp/foo32;/tmp/bar32");
+
+            Assert.Equal(allPaths.GetElement(2).OS, "unix");
+            Assert.Equal(allPaths.GetElement(2).PropertyElements.Count, 1);
+            Assert.Equal(allPaths.GetElement(2).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/bar");
+
+            var reader = GetStandardConfigurationReader();
+            Dictionary<string, Toolset> toolsets = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
+            string msbuildOverrideTasksPath = null;
+            string defaultOverrideToolsVersion = null;
+            string defaultToolsVersion = reader.ReadToolsets(toolsets, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
+
+            Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable = toolsets["2.0"].MSBuildExtensionsPathSearchPathsTable;
+            if (NativeMethodsShared.IsWindows)
+            {
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"c:\\foo"});
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path64, new string[] {"c:\\foo64", "c:\\bar64"});
+            }
+            else if (NativeMethodsShared.IsOSX)
+            {
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/foo"});
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path32, new string[] {"/tmp/foo32", "/tmp/bar32"});
+            }
+            else
+            {
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/bar"});
+            }
+        }
+
+        private void CheckPathsTable(Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable, MSBuildExtensionsPathReferenceKind kind, string[] expectedPaths)
+        {
+            Assert.True(pathsTable.ContainsKey(kind));
+            var paths = pathsTable[kind];
+            Assert.Equal(paths.Count, expectedPaths.Length);
+
+            for (int i = 0; i < paths.Count; i ++)
+            {
+                Assert.Equal(paths[i], expectedPaths[i]);
+            }
+        }
+
+        /// <summary>
+        /// more than 1 searchPaths elements with the same OS
+        /// </summary>
+        [Fact]
+        public void ExtensionsPathsTest_MultipleElementsWithSameOS()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() =>
+            {
+                ToolsetConfigurationReaderTestHelper.WriteConfigFile(ObjectModelHelpers.CleanupFileContents(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""4.0"">
+                     <toolset ToolsVersion=""2.0"">
+                       <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v3.5.x86ret\""/>
+
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
+                         </searchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\bar""/>
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                     </toolset>
+                   </msbuildToolsets>
+                 </configuration>"));
+
+                Configuration config = ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest();
+
+                ToolsetConfigurationSection msbuildToolsetSection = config.GetSection(s_msbuildToolsets) as ToolsetConfigurationSection;
+            }
+           );
+        }
+
+        /// <summary>
+        /// more than value is element found for a the same extensions path property name+os
+        /// </summary>
+        [Fact]
+        public void ExtensionsPathsTest_MultipleElementsWithSamePropertyNameForSameOS()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() =>
+            {
+                ToolsetConfigurationReaderTestHelper.WriteConfigFile(ObjectModelHelpers.CleanupFileContents(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""4.0"">
+                     <toolset ToolsVersion=""2.0"">
+                       <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v3.5.x86ret\""/>
+
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
+                            <property name=""MSBuildExtensionsPath"" value=""c:\bar""/>
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                     </toolset>
+                   </msbuildToolsets>
+                 </configuration>"));
+
+                Configuration config = ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest();
+
+                ToolsetConfigurationSection msbuildToolsetSection = config.GetSection(s_msbuildToolsets) as ToolsetConfigurationSection;
+            }
+           );
+        }
+
+        private ToolsetConfigurationReader GetStandardConfigurationReader()
+        {
+            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
+                ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+        }
+        #endregion
+
     }
 }
 #endif

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -189,6 +189,7 @@ namespace Microsoft.Build.UnitTests.Definition
         /// name attribute is missing from toolset element 
         /// </summary>
         [Fact]
+        [Trait("Category", "mono-osx-failing")]
         public void ToolsVersionTest_NameNotSpecified()
         {
             Assert.Throws<ConfigurationErrorsException>(() =>
@@ -247,6 +248,7 @@ namespace Microsoft.Build.UnitTests.Definition
         /// empty toolset element 
         /// </summary>
         [Fact]
+        [Trait("Category", "mono-osx-failing")]
         public void ToolsVersionTest_EmptyElement()
         {
             Assert.Throws<ConfigurationErrorsException>(() =>
@@ -314,6 +316,7 @@ namespace Microsoft.Build.UnitTests.Definition
         ///  name attribute is missing
         /// </summary>
         [Fact]
+        [Trait("Category", "mono-osx-failing")]
         public void PropertyTest_NameNotSpecified()
         {
             Assert.Throws<ConfigurationErrorsException>(() =>
@@ -393,6 +396,7 @@ namespace Microsoft.Build.UnitTests.Definition
         ///  property element is an empty element
         /// </summary>
         [Fact]
+        [Trait("Category", "mono-osx-failing")]
         public void PropertyTest_EmptyElement()
         {
             Assert.Throws<ConfigurationErrorsException>(() =>

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -1,0 +1,573 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_SYSTEM_CONFIGURATION
+
+using System.Configuration;
+using Microsoft.Win32;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
+
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    /// <summary>
+    /// Unit tests for Importing from $(MSBuildExtensionsPath*)
+    /// </summary>
+    public class ImportFromMSBuildExtensionsPathTests : IDisposable
+    {
+        public void Dispose()
+        {
+            ToolsetConfigurationReaderTestHelper.CleanUp();
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathFound()
+        {
+            CreateAndBuildProjectForImportFromExtensionsPath("MSBuildExtensionsPath", (p, l) => Assert.True(p.Build()));
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathNotFound()
+        {
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), GetExtensionTargetsFileContent1());
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1, Path.Combine("tmp", "nonexistant")));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+
+                Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
+
+                logger.AssertLogContains("MSB4226");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void ConditionalImportFromExtensionsPathNotFound()
+        {
+            string extnTargetsFileContentWithCondition = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FooBar</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\bar\extn2.proj' Condition=""Exists('$(MSBuildExtensionsPath)\bar\extn2.proj')""/>
+                </Project>
+                ";
+
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContentWithCondition);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir1, Path.Combine("tmp", "nonexistant")},
+                                                            null,
+                                                            (p, l) => {
+                                                                Assert.True(p.Build());
+
+                                                                l.AssertLogContains("Running FromExtn");
+                                                                l.AssertLogContains("PropertyFromExtn1: FooBar");
+                                                            });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathCircularImportError()
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\foo\extn2.proj' />
+                </Project>
+                ";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn2'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='{0}'/>
+                </Project>
+                ";
+
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent1);
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn2.proj"),
+                                                            String.Format(extnTargetsFileContent2, mainProjectPath));
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath",
+                                                        new string[] {extnDir2, Path.Combine("tmp", "nonexistant"), extnDir1},
+                                                        null,
+                                                        (p, l) => l.AssertLogContains("MSB4210"));
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathWithWildCard()
+        {
+            string mainTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='Main'>
+                        <Message Text='Running Main'/>
+                    </Target>
+
+                    <Import Project='$(MSBuildExtensionsPath)\foo\*.proj'/>
+                </Project>";
+
+            string extnTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='{0}'>
+                        <Message Text='Running {0}'/>
+                    </Target>
+                </Project>
+                ";
+
+            // Importing should stop at the first extension path where a project file is found
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
+                                String.Format(extnTargetsFileContent, "FromExtn1"));
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"),
+                                String.Format(extnTargetsFileContent, "FromExtn2"));
+
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir1, Path.Combine("tmp", "nonexistant"), extnDir2},
+                                                    null,
+                                                    (p, l) => {
+                                                    Console.WriteLine (l.FullLog);
+                                                    Console.WriteLine ("checking FromExtn1");
+                                                        Assert.True(p.Build("FromExtn1"));
+                                                    Console.WriteLine ("checking FromExtn2");
+                                                        Assert.False(p.Build("FromExtn2"));
+                                                    Console.WriteLine ("checking logcontains");
+                                                        l.AssertLogContains(String.Format(MockLogger.GetString("TargetDoesNotExist"), "FromExtn2"));
+                                                    });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathWithWildCardNothingFound()
+        {
+            string extnTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\non-existant\*.proj'/>
+                </Project>
+                ";
+
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {Path.Combine("tmp", "nonexistant"), extnDir1},
+                                                    null, (p, l) => Assert.True(p.Build()));
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathInvalidFile()
+        {
+            string extnTargetsFileContent = @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >";
+
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1,
+                                                                                Path.Combine("tmp", "nonexistant")));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+
+                Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
+                logger.AssertLogContains("MSB4025");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathSearchOrder()
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromFirstFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromSecondFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+
+            // File with the same name available in two different extension paths, but the one from the first
+            // directory in MSBuildExtensionsPath environment variable should get loaded
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent1);
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"), extnTargetsFileContent2);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir2, Path.Combine("tmp", "nonexistant"), extnDir1},
+                                                            null,
+                                                            (p, l) => {
+                                                                Assert.True(p.Build());
+
+                                                                l.AssertLogContains("Running FromExtn");
+                                                                l.AssertLogContains("PropertyFromExtn1: FromSecondFile");
+                                                            });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathSearchOrder2()
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromFirstFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromSecondFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+            // File with the same name available in two different extension paths, but the one from the first
+            // directory in MSBuildExtensionsPath environment variable should get loaded
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent1);
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"), extnTargetsFileContent2);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            // MSBuildExtensionsPath* property value has highest priority for the lookups
+            try {
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", Path.Combine("tmp", "non-existstant"), extnDir1));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+                var project = projColln.LoadProject(mainProjectPath);
+
+                project.SetProperty("MSBuildExtensionsPath", extnDir2);
+                project.ReevaluateIfNecessary();
+                Assert.True(project.Build());
+
+                logger.AssertLogContains("Running FromExtn");
+                logger.AssertLogContains("PropertyFromExtn1: FromSecondFile");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+                if (extnDir2 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir2, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void ImportOrderFromExtensionsPath32()
+        {
+            CreateAndBuildProjectForImportFromExtensionsPath("MSBuildExtensionsPath32", (p, l) => Assert.True(p.Build()));
+        }
+
+        [Fact]
+        public void ImportOrderFromExtensionsPath64()
+        {
+            CreateAndBuildProjectForImportFromExtensionsPath("MSBuildExtensionsPath64", (p, l) => Assert.True(p.Build()));
+        }
+
+        // Use MSBuildExtensionsPath, MSBuildExtensionsPath32 and MSBuildExtensionsPath64 in the build
+        [Fact]
+        public void ImportFromExtensionsPathAnd32And64()
+        {
+            string extnTargetsFileContentTemplate = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn{0}' DependsOnTargets='{1}'>
+                        <Message Text='Running FromExtn{0}'/>
+                    </Target>
+                    {2}
+                </Project>
+                ";
+
+            string v2Folder = NativeMethodsShared.IsWindows
+                                  ? @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret"
+                                  : Path.Combine(NativeMethodsShared.FrameworkBasePath, "2.0");
+
+            string v4Folder = NativeMethodsShared.IsWindows
+                                  ? @"D:\windows\Microsoft.NET\Framework\v4.0.x86ret"
+                                  : Path.Combine(NativeMethodsShared.FrameworkBasePath, "4.0");
+
+            var configFileContents = @"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""14.1"">
+                     <toolset toolsVersion=""14.1"">
+                       <property name=""MSBuildToolsPath"" value="".""/>
+                       <property name=""MSBuildBinPath"" value=""" + /*v4Folder*/"." + @"""/>
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""osx"">
+                           <property name=""MSBuildExtensionsPath"" value=""{0}"" />
+                           <property name=""MSBuildExtensionsPath32"" value=""{1}"" />
+                           <property name=""MSBuildExtensionsPath64"" value=""{2}"" />
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                      </toolset>
+                   </msbuildToolsets>
+                 </configuration>";
+
+            string extnDir1 = null, extnDir2 = null, extnDir3 = null;
+            string mainProjectPath = null;
+
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
+                                String.Format(extnTargetsFileContentTemplate, String.Empty, "FromExtn2", "<Import Project='$(MSBuildExtensionsPath32)\\bar\\extn2.proj' />"));
+                extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("bar", "extn2.proj"),
+                                String.Format(extnTargetsFileContentTemplate, 2, "FromExtn3", "<Import Project='$(MSBuildExtensionsPath64)\\xyz\\extn3.proj' />"));
+                extnDir3 = GetNewExtensionsPathAndCreateFile("extensions3", Path.Combine("xyz", "extn3.proj"),
+                                String.Format(extnTargetsFileContentTemplate, 3, String.Empty, String.Empty));
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+                var configFilePath = ToolsetConfigurationReaderTestHelper.WriteConfigFile(String.Format(configFileContents, extnDir1, extnDir2, extnDir3));
+                var reader = GetStandardConfigurationReader();
+
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(reader);
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+
+                var project = projColln.LoadProject(mainProjectPath);
+                Assert.True(project.Build("Main"));
+                logger.AssertLogContains("Running FromExtn3");
+                logger.AssertLogContains("Running FromExtn2");
+                logger.AssertLogContains("Running FromExtn");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+                if (extnDir2 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir2, recursive: true);
+                }
+                if (extnDir3 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir3, recursive: true);
+                }
+            }
+        }
+
+        void CreateAndBuildProjectForImportFromExtensionsPath(string extnPathPropertyName, Action<Project, MockLogger> action)
+        {
+            string extnDir1 = null, extnDir2 = null, mainProjectPath = null;
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
+                                    GetExtensionTargetsFileContent1(extnPathPropertyName));
+                extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("bar", "extn2.proj"),
+                                    GetExtensionTargetsFileContent2(extnPathPropertyName));
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent(extnPathPropertyName));
+
+                CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, extnPathPropertyName, new string[] {extnDir1, extnDir2},
+                                                                null,
+                                                                action);
+            } finally {
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+                if (extnDir2 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir2, recursive: true);
+                }
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+            }
+        }
+
+        void CreateAndBuildProjectForImportFromExtensionsPath(string mainProjectPath, string extnPathPropertyName, string[] extnDirs, Action<string[]> setExtensionsPath,
+                Action<Project, MockLogger> action)
+        {
+            try {
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader(extnPathPropertyName, extnDirs));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+                var project = projColln.LoadProject(mainProjectPath);
+
+                action(project, logger);
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+
+                if (extnDirs != null)
+                {
+                    foreach (var extnDir in extnDirs)
+                    {
+                        FileUtilities.DeleteDirectoryNoThrow(extnDir, recursive: true);
+                    }
+                }
+            }
+        }
+
+        private ToolsetConfigurationReader WriteConfigFileAndGetReader(string extnPathPropertyName, params string[] extnDirs)
+        {
+            string combinedExtnDirs = extnDirs != null ? String.Join(";", extnDirs) : String.Empty;
+
+            var configFilePath = ToolsetConfigurationReaderTestHelper.WriteConfigFile(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""14.1"">
+                     <toolset toolsVersion=""14.1"">
+                       <property name=""MSBuildToolsPath"" value=""."" />
+                       <property name=""MSBuildBinPath"" value=""."" />
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""osx"">
+                           <property name=""" + extnPathPropertyName + @""" value=""" + combinedExtnDirs + @""" />
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                      </toolset>
+                   </msbuildToolsets>
+                 </configuration>");
+
+            return GetStandardConfigurationReader();
+        }
+
+        string GetNewExtensionsPathAndCreateFile(string extnDirName, string relativeFilePath, string fileContents)
+        {
+            var extnDir = Path.Combine(Path.GetTempPath(), extnDirName);
+            Directory.CreateDirectory(Path.Combine(extnDir, Path.GetDirectoryName(relativeFilePath)));
+            File.WriteAllText(Path.Combine(extnDir, relativeFilePath), fileContents);
+
+            return extnDir;
+        }
+
+        string GetMainTargetFileContent(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        {
+            string mainTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='Main' DependsOnTargets='FromExtn'>
+                        <Message Text='PropertyFromExtn1: $(PropertyFromExtn1)'/>
+                    </Target>
+
+                    <Import Project='$({0})\foo\extn.proj'/>
+                </Project>";
+
+            return String.Format(mainTargetsFileContent, extensionsPathPropertyName);
+        }
+
+        string GetExtensionTargetsFileContent1(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FooBar</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$({0})\bar\extn2.proj'/>
+                </Project>
+                ";
+
+            return String.Format(extnTargetsFileContent1, extensionsPathPropertyName);
+        }
+
+        string GetExtensionTargetsFileContent2(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        {
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn2>Abc</PropertyFromExtn2>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn2'>
+                        <Message Text='Running FromExtn2'/>
+                    </Target>
+                </Project>
+                ";
+
+            return extnTargetsFileContent2;
+        }
+
+        private ToolsetConfigurationReader GetStandardConfigurationReader()
+        {
+            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
+                ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+        }
+    }
+}
+#endif

--- a/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Evaluation\Evaluator_Tests.cs" />
     <Compile Include="Evaluation\Expander_Tests.cs" />
     <Compile Include="Evaluation\ExpressionShredder_Tests.cs" />
+    <Compile Include="Evaluation\ImportFromMSBuildExtensionsPath_Tests.cs" />
     <Compile Include="Evaluation\Preprocessor_Tests.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache_Tests.cs" />
     <Compile Include="Evaluation\ProjectStringCache_Tests.cs" />

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -37,6 +37,13 @@
     <msbuildToolsets default="14.1">
       <toolset toolsVersion="14.1">
         <property name="MSBuildToolsPath" value="." />
+        <msbuildExtensionsPathSearchPaths>
+            <searchPaths os="osx">
+                <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+                <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+                <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            </searchPaths>
+        </msbuildExtensionsPathSearchPaths>
       </toolset>
     </msbuildToolsets>
   </configuration>


### PR DESCRIPTION
…ch paths.

In Mono's xbuild, $(MSBuildExtensionsPath) is $mono_prefix/lib/mono/xbuild.
On OS X, this is:

    `/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild`

Consequently, when resolving an Import for
$(MSBuildExtensionsPath)\Foo\Abc.targets, the following path will be checked:

    `/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild/Foo/Abc.targets`

This works, but has a problem when upgrading the Mono.framework package:
a *new* /Library/Frameworks/Mono.framework/Versions/@VERSION@ directory
is created, so anything installed into the previous directory will be
"lost". The file is still there, but xbuild will no longer find it.

To address this upgrade scenario, Mono's xbuild also checks a fallback path:

    `/Library/Frameworks/Mono.framework/External/xbuild`

This location is not within a versioned framework directory, and thus files
installed into it will survive Mono.framework package upgrades.

Unfortunately, this means that $(MSBuildExtensionsPath) on xbuild is no longer
a single directory; it is a set of directories, and xbuild will check each
directory to see if the file exists:

/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild/Foo/Abc.targets
/Library/Frameworks/Mono.framework/External/xbuild/Foo/Abc.targets
...

Mono would like to eventually migrate to MSBuild instead of xbuild, which
requires bringing xbuild's fallback support to MSBuild.

These search paths can now be specified in the app.config like:

      <toolset toolsVersion="14.1">

        <msbuildExtensionsPathSearchPaths>
            <searchPaths os="osx">
                <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/;/tmp/foo"/>
                <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
                <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
            </searchPaths>
        </msbuildExtensionsPathSearchPaths>

      </toolset>