### PR TITLE
CommandLineTest: Use correct path to 'cat' on !Windows

### DIFF
--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -796,9 +796,13 @@ namespace Microsoft.Build.UnitTests
         }
 
 #if FEATURE_SPECIAL_FOLDERS
-        private string _pathToArbitraryBogusFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe"); // OK on 64 bit as well
+        private string _pathToArbitraryBogusFile = NativeMethodsShared.IsWindows // OK on 64 bit as well
+                                                        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "notepad.exe")
+                                                        : "/bin/cat";
 #else
-        private string _pathToArbitraryBogusFile = Path.Combine(FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.System), NativeMethodsShared.IsWindows ? "notepad.exe" : "cat"); // OK on 64 bit as well
+        private string _pathToArbitraryBogusFile = NativeMethodsShared.IsWindows // OK on 64 bit as well
+                                                        ? Path.Combine(FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.System), "notepad.exe")
+                                                        : "/bin/cat";
 #endif
 
         /// <summary>


### PR DESCRIPTION
Environment.SpecialFolder.System resolves to "" on Mono, so, instead
hardcode the path to "/bin/cat" on !Windows