### PR TITLE
Disable windowsonly tests when running on !Windows platforms

### DIFF
--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void GetApiContractReferencesFindsWinMDs()
         {
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -3719,6 +3719,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ///     perf hit when loading large solutions.
             /// </summary>
             [Fact]
+            [PlatformSpecific(Xunit.PlatformID.Windows)]
             public void Exists()
             {
                 // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -8601,6 +8602,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Do the most basic AssemblyFoldersEx resolve.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExBasic()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8621,6 +8623,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify that higher alphabetical values for a component are chosen over lower alphabetic values of a component.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExVerifyComponentFolderSorting()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8642,6 +8645,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// with the letter "v", we should tolerate it and treat it as if it does.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExTargetFrameworkVersionDoesNotBeginWithV()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8666,6 +8670,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchDoesNotMatch()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8691,6 +8696,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchMSILX86()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8713,6 +8719,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify if there is a mismatch between what the project targets and the architecture of the resolved primary reference log a warning.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void VerifyProcessArchitectureMismatchWarning()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8737,6 +8744,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify if there is a mismatch between what the project targets and the architecture of the resolved primary reference log a warning.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void VerifyProcessArchitectureMismatchWarningDefault()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8760,6 +8768,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Verify if there is a mismatch between what the project targets and the architecture of the resolved primary reference log a error.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void VerifyProcessArchitectureMismatchError()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8787,6 +8796,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchNoneX86()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8807,6 +8817,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// has a MSIL architecture or a NONE architecture. NONE means you do not care what architecure is picked.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchNoneMix()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8835,6 +8846,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchMSILLastFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8860,6 +8872,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchNoneLastFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8884,6 +8897,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchX86FirstFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8907,6 +8921,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchX86MSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8929,6 +8944,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchX86None()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8951,6 +8967,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchNoneNone()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8972,6 +8989,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArcMSILNone()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -8993,6 +9011,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchNoneMSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9015,6 +9034,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchMSILMSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9037,6 +9057,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         ///
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExProcessorArchMatches()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9061,6 +9082,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// carry on and inspect those.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExTargetFrameworkVersionBogusValue()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9082,6 +9104,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Tolerate keys like v2.0.x86chk.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void Regress357227_AssemblyFoldersExAgainstRawDrop()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9102,6 +9125,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Matches that exist only in the HKLM hive.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExHKLM()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9121,6 +9145,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Matches that exist in both HKLM and HKCU should favor HKCU
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExHKCUTrumpsHKLM()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -9145,6 +9170,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// When matches that have v3.0 (future) and v2.0 (current) versions, the 2.0 version wins.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExFutureTargetNDPVersionsDontMatch()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9164,6 +9190,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// If there is no v2.0 (current target NDP) match, then v1.0 should match.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExMatchBackVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9183,6 +9210,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// If there is a 2.0 and a 1.0 then match 2.0.
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExCurrentTargetVersionTrumpsPastTargetVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9202,6 +9230,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// If a control has a service pack then that wins over the control itself
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExServicePackTrumpsBaseVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9222,6 +9251,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Test MaxOSVersion condition
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExConditionFilterMaxOS()
         {
             // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
@@ -9265,6 +9295,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Test MinOSVersion condition
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExConditionFilterMinOS()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -9577,6 +9608,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// Test Platform condition
         /// </summary>
         [Fact]
+        [PlatformSpecific(Xunit.PlatformID.Windows)]
         public void AssemblyFoldersExConditionFilterPlatform()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();

--- a/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
+++ b/src/XMakeTasks/UnitTests/ResolveAssemblyReference_Tests.cs
@@ -6694,6 +6694,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// <summary>
     /// Unit tests for the ResolveAssemblyReference task.
     /// </summary>
+    [PlatformSpecific(Xunit.PlatformID.Windows)]
     sealed public class WinMDTests : ResolveAssemblyReferenceTestFixture
     {
         #region AssemblyInformationIsWinMDFile Tests


### PR DESCRIPTION
These changes were in the code earlier, but seem to have been lost
in the nunit->xunit migration. But they are still relevant, so, adding them
again.