### PR TITLE
Fix issue #491 - test breakage on CI

### DIFF
--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     /// </summary>
     public class Preprocessor_Tests : IDisposable
     {
+        private static string CurrentDirectoryXmlCommentFriendly => Directory.GetCurrentDirectory().Replace("--", "__");
+
         public Preprocessor_Tests()
         {
             Setup();
@@ -92,7 +94,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"" InitialTargets=""i1;i2"">
@@ -100,14 +102,14 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");
@@ -136,7 +138,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"" InitialTargets=""i2"">
@@ -144,14 +146,14 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");
@@ -180,7 +182,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"" InitialTargets=""i1"">
@@ -188,14 +190,14 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");
@@ -224,7 +226,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
@@ -232,7 +234,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -242,7 +244,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");
@@ -272,7 +274,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
@@ -387,7 +389,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -430,7 +432,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
@@ -442,7 +444,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -452,7 +454,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
   <!--</ImportGroup>-->
@@ -488,7 +490,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
@@ -500,7 +502,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -510,14 +512,14 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   <Import Project=""p3"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p3
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p3
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -527,7 +529,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
   <!--</ImportGroup>-->
@@ -561,7 +563,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
      @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"" DefaultTargets=""d1"">
@@ -569,28 +571,28 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   <Import Project=""p3"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p3
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p3
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");
@@ -622,7 +624,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
      @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"" DefaultTargets=""d2"">
@@ -630,28 +632,28 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   <Import Project=""p2"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p2
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p2
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   <Import Project=""p3"">
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p3
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p3
 ============================================================================================================================================
 -->
   <!--
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");
@@ -682,7 +684,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
     @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
@@ -736,7 +738,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
         @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
 ============================================================================================================================================
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
@@ -769,7 +771,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 ============================================================================================================================================
   </Import>
 
-" + Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + @"p1
+" + CurrentDirectoryXmlCommentFriendly + Path.DirectorySeparatorChar + @"p1
 ============================================================================================================================================
 -->
 </Project>");


### PR DESCRIPTION
These tests include the current directory inside an xml comment. If the
path happens to contain `--`, which is not allowed inside xml comments,
then these tests break. This showed up on CI servers where the path did
include these characters!

Issue: https://github.com/Microsoft/msbuild/issues/491