### PR TITLE
NativeMethodsShared.IsOSX: Fix this for mono

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -517,7 +517,9 @@ namespace Microsoft.Build.Shared
         {
             get
             {
-#if FEATURE_OSVERSION
+#if MONO
+                return File.Exists("/usr/lib/libc.dylib");
+#elif FEATURE_OSVERSION
                 return Environment.OSVersion.Platform == PlatformID.MacOSX;
 #else
                 return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);


### PR DESCRIPTION
Due to historical reasons[1], Environment.OSVersion.Platform returns
a value of `Unix` even for OSX. So, instead check for existence of
    /usr/lib/libc.dylib