### PR TITLE
dir.props: Update mono build to target 4.6 instead of 4.5.1

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <!-- This is to workaround an issue with a dependent assembly (Microsoft.Build.Tasks.CodeAnalysis.dll)
          copying its dependencies (which are in the GAC). -->
     <DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
@@ -159,8 +158,7 @@
     <PlatformTarget>$(RuntimeArchitecture)</PlatformTarget>
     <ImportGetNuGetPackageVersions Condition="'$(OS)' != 'Windows_NT'">false</ImportGetNuGetPackageVersions>
     <NuGetTargetMoniker Condition="'$(NetCoreBuild)' == 'true'">DNXCore,Version=v5.0</NuGetTargetMoniker>
-    <NuGetTargetMoniker Condition="'$(MonoBuild)' == 'true'">.NETFramework,Version=v4.5.1</NuGetTargetMoniker>
-    <NuGetTargetMoniker Condition="'$(NetCoreBuild)' != 'true' and '$(MonoBuild)' != 'true'">.NETFramework,Version=v4.6</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NetCoreBuild)' != 'true'">.NETFramework,Version=v4.6</NuGetTargetMoniker>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT' and '$(MonoBuild)' != 'true'">
@@ -179,11 +177,12 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
 
-  <!-- .NET Core build support -->
+  <!-- Both Mono and windows/full framework builds -->
   <PropertyGroup Condition="'$(NetCoreBuild)' != 'true'">
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
 
+  <!-- .NET Core build support -->
   <PropertyGroup Condition="'$(NetCoreBuild)' == 'true'">
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>DNXCore</TargetFrameworkIdentifier>


### PR DESCRIPTION
This also fixes the build for mono/osx.

The build would break because mcs was getting duplicate references like:

    1. /reference:/Users/ankit/dev/misc/lib/mono/4.5-api/Facades/System.IO.dll
    2. /reference:/Users/ankit/.nuget/packages/System.IO/4.0.10/ref/dotnet/System.IO.dll

Ref(1) was resolved because of `ImplictlyExpandDesignTimeFacades`, and
Ref(2) came from the task `PrereleaseResolveNugetPackages`. This task
reads from the project.lock.json (generated by `dnu restore`), and for
4.5.1 case these assemblies were marked to have the assemblies from the
package be used. This is not the case for 4.6, where these assemblies
instead have entries like `ref/net45/_._`, effectively suggesting that
the assembly should be resolved from the GAC instead.

There are newer version of these package (like System.IO) available,
which seem to fix this, but it seems to be in flux.

Instead, we just target 4.6 completely for mono builds, which is the
same as the build for Windows and CoreCLR.

This also means that you cannot use mono < 4.4.x to build, since .net
4.6 API will become available only with mono 4.4.0 . But that is OK as
we cannot really get a useful build with the older mono anyway.

This does not affect CoreCLR builds that use mono host.

Issue: #514