### PR TITLE
[RFC] Add support for fallback search paths for Target frameworks

### DIFF
--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1579,6 +1579,21 @@ namespace Microsoft.Build.Utilities
         /// <returns>Collection of reference assembly locations.</returns>
         public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget)
         {
+            return GetPathToStandardLibraries(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile, platformTarget, null);
+        }
+
+        /// <summary>
+        /// Returns the path to mscorlib and system.dll
+        /// </summary>
+        /// <param name="targetFrameworkIdentifier">Identifier being targeted</param>
+        /// <param name="targetFrameworkVersion">Version being targeted</param>
+        /// <param name="targetFrameworkProfile">Profile being targeted</param>
+        /// <param name="platformTarget">What is the targeted platform, this is used to determine where we should look for the standard libraries. Note, this parameter is only used for .net frameworks less than 4.0</param>
+        /// <param name="targetFrameworkRootPath">Root directory where the target framework will be looked for. Uses default path if this is null</param>
+        /// <exception cref="ArgumentNullException">When the frameworkName is null</exception>
+        /// <returns>Collection of reference assembly locations.</returns>
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget, string targetFrameworkRootPath)
+        {
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier, "targetFrameworkIdentifier");
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, "targetFrameworkVersion");
 
@@ -1614,7 +1629,7 @@ namespace Microsoft.Build.Utilities
                 // location, if so then we can just use what ever version they passed in because it should be MSIL now and not bit specific.
             }
 
-            IList<string> referenceAssemblyDirectories = GetPathToReferenceAssemblies(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile);
+            IList<string> referenceAssemblyDirectories = GetPathToReferenceAssemblies(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile, targetFrameworkRootPath);
             // Check each returned reference assembly directory for one containing mscorlib.dll
             // When we find it (most of the time it will be the first in the set) we'll
             // return that directory.
@@ -1645,13 +1660,35 @@ namespace Microsoft.Build.Utilities
         /// <returns>Collection of reference assembly locations.</returns>
         public static IList<String> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile)
         {
+            return GetPathToReferenceAssemblies(targetFrameworkIdentifier, targetFrameworkVersion, targetFrameworkProfile, null);
+        }
+
+        /// <summary>
+        /// Returns the paths to the reference assemblies location for the given target framework.
+        /// This method will assume the requested ReferenceAssemblyRoot path will be the ProgramFiles directory specified by Environment.SpecialFolder.ProgramFiles
+        /// In additon when the .NETFramework or .NET Framework targetFrameworkIdentifiers are seen and targetFrameworkVersion is 2.0, 3.0, 3.5 or 4.0 we will return the correctly chained reference assembly paths
+        /// for the legacy .net frameworks. This chaining will use the existing GetPathToDotNetFrameworkReferenceAssemblies to build up the list of reference assembly paths.
+        /// </summary>
+        /// <param name="targetFrameworkIdentifier">Identifier being targeted</param>
+        /// <param name="targetFrameworkVersion">Version being targeted</param>
+        /// <param name="targetFrameworkProfile">Profile being targeted</param>
+        /// <param name="targetFrameworkRootPath">Root directory which will be used to calculate the reference assembly path. The references assemblies will be
+        /// generated in the following way TargetFrameworkRootPath\TargetFrameworkIdentifier\TargetFrameworkVersion\SubType\TargetFrameworkSubType.
+        /// Uses the default path if this is null.
+        /// </param>
+        /// <exception cref="ArgumentNullException">When the frameworkName is null</exception>
+        /// <returns>Collection of reference assembly locations.</returns>
+        public static IList<String> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetFrameworkRootPath)
+        {
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkVersion, "targetFrameworkVersion");
             ErrorUtilities.VerifyThrowArgumentLength(targetFrameworkIdentifier, "targetFrameworkIdentifier");
             ErrorUtilities.VerifyThrowArgumentNull(targetFrameworkProfile, "targetFrameworkProfile");
 
             Version frameworkVersion = ConvertTargetFrameworkVersionToVersion(targetFrameworkVersion);
             FrameworkNameVersioning targetFrameworkName = new FrameworkNameVersioning(targetFrameworkIdentifier, frameworkVersion, targetFrameworkProfile);
-            return GetPathToReferenceAssemblies(targetFrameworkName);
+            if (String.IsNullOrEmpty(targetFrameworkRootPath))
+                targetFrameworkRootPath = FrameworkLocationHelper.programFilesReferenceAssemblyLocation;
+            return GetPathToReferenceAssemblies(targetFrameworkRootPath, targetFrameworkName);
         }
 
 

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 
@@ -195,6 +197,11 @@ namespace Microsoft.Build.Utilities
         /// Cache the list of supported frameworks
         /// </summary>
         private static List<string> s_targetFrameworkMonikers = null;
+
+        /// <summary>
+        /// List of fallback paths where to look for Target frameworks
+        /// </summary>
+        private static Lazy<ReadOnlyCollection<string>> s_fallbackTargetFrameworkRootPathsLazy = new Lazy<ReadOnlyCollection<string>>(() => GetFallbackTargetFrameworkRootPaths(), isThreadSafe:true);
 
         private const string retailConfigurationName = "Retail";
         private const string neutralArchitectureName = "Neutral";
@@ -1932,6 +1939,12 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Returns the paths to the reference assemblies location for the given framework version relative to a given targetFrameworkRoot.
         /// The method will not check to see if the path exists or not.
+        ///
+        /// To find the given framework, it looks through various paths, which are (in order):
+        ///
+        /// 1. @targetFrameworkRootPath parameter
+        /// 2. Any fallback paths specified in the app.config as a property named `TargetFrameworkRootPathSearchPaths$(OSName)`
+        ///
         /// </summary>
         /// <param name="targetFrameworkRootPath">Root directory which will be used to calculate the reference assembly path. The references assemblies will be
         /// generated in the following way TargetFrameworkRootPath\TargetFrameworkIdentifier\TargetFrameworkVersion\SubType\TargetFrameworkSubType.
@@ -1945,6 +1958,32 @@ namespace Microsoft.Build.Utilities
             //Verify the framework class passed in is not null. Other than being null the class will ensure it is consistent and the internal state is correct
             ErrorUtilities.VerifyThrowArgumentNull(frameworkName, "frameworkName");
 
+            var searchPaths = new List<string>(s_fallbackTargetFrameworkRootPathsLazy.Value);
+            searchPaths.Insert(0, targetFrameworkRootPath);
+
+            foreach (var path in searchPaths)
+            {
+                var asmList = GetPathToReferenceAssembliesActual(path, frameworkName);
+                if (asmList.Count > 0)
+                {
+                    return asmList;
+                }
+            }
+
+            return new List<string>();
+        }
+
+        /// <summary>
+        /// Returns the paths to the reference assemblies location for the given framework version relative to a given targetFrameworkRoot.
+        /// The method will not check to see if the path exists or not.
+        /// </summary>
+        /// <param name="targetFrameworkRootPath">Root directory which will be used to calculate the reference assembly path. The references assemblies will be
+        /// generated in the following way TargetFrameworkRootPath\TargetFrameworkIdentifier\TargetFrameworkVersion\SubType\TargetFrameworkSubType.
+        /// </param>
+        /// <param name="frameworkName">A frameworkName class which represents a TargetFrameworkMoniker. This cannot be null.</param>
+        /// <returns>Collection of reference assembly locations.</returns>
+        private static IList<String> GetPathToReferenceAssembliesActual(string targetFrameworkRootPath, FrameworkNameVersioning frameworkName)
+        {
             string referenceAssemblyCacheKey = GenerateReferenceAssemblyCacheKey(targetFrameworkRootPath, frameworkName);
             CreateReferenceAssemblyPathsCache();
 
@@ -1995,6 +2034,37 @@ namespace Microsoft.Build.Utilities
             }
 
             return dotNetFrameworkReferenceAssemblies;
+        }
+
+        private static ReadOnlyCollection<string> GetFallbackTargetFrameworkRootPaths()
+        {
+            //
+            // - We need to read the fallback paths from the Toolset defined in app.config .
+            // - ToolsetElement is a source file shared by Microsoft.Build and Microsoft.Build.Utilities.Core
+            //
+            // - If we try to read the toolset from the config file, like:
+            //      var msbuildSection = configuration.GetSection("msbuildToolsets")
+            //   then `msbuildSection` has a type `Microsoft.Build::Microsoft.Build.Evaluation.ToolsetConfigurationSection`,
+            //   since that is the type specified in the config file as:
+            //
+            //   <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=14.1.0.0, Culture=neutral" />
+            //
+            //   To be able to extract the relevant property from this `ToolsetConfigurationSection`, we would need to
+            //   cast it to a concrete type like:
+            //
+            //      var toolsetConfigSection = (ToolsetConfigurationSection) configuration.GetSection("msbuildToolsets")
+            //
+            //   but this will fail since, the `(ToolsetConfigurationSection)` has the assembly identity of `Microsoft.Build.Utilities.Core`,
+            //   since this code is in that assembly (this file!).
+            //
+            //   Also, since these types are internal, using `extern alias` won't really help here.
+            //   So, we use reflection. This method should really get called only once, so, it shouldn't matter
+            //   for performance.
+            //
+            Assembly buildAsm = Assembly.Load(new AssemblyName("Microsoft.Build"));
+            var type = buildAsm.GetType("Microsoft.Build.Shared.FrameworkLocationHelper");
+            var mi = type.GetMethod("GetTargetFrameworkRootFallbackPaths", BindingFlags.NonPublic | BindingFlags.Static);
+            return new ReadOnlyCollection<string>((IList<string>)mi.Invoke(null, new object[] { CurrentToolsVersion } ));
         }
 
         /// <summary>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -37,6 +37,7 @@
     <msbuildToolsets default="14.1">
       <toolset toolsVersion="14.1">
         <property name="MSBuildToolsPath" value="." />
+        <property name="TargetFrameworkRootPathSearchPathsOSX" value="/Library/Frameworks/Mono.framework/External/xbuild-frameworks/" />
         <msbuildExtensionsPathSearchPaths>
             <searchPaths os="osx">
                 <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -78,7 +78,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- The FrameworkPathOverride is required for the inproc visual basic compiler to initialize when targeting target frameworks less than 4.0. If .net 2.0 is not installed then the property value above will not provide the location
              of mscorlib. This is also true if the build author overrides this property to some other directory which does not contain mscorlib.dll. In the case we cannot find mscorlib.dll at the correct location
              we need to find a directory which does contain mscorlib to allow the inproc compiler to initialize and give us the chance to show certain dialogs in the IDE (which only happen after initialization).-->
-    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget)))</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath)))</FrameworkPathOverride>
     <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
   </PropertyGroup>
 


### PR DESCRIPTION
Currently, target frameworks are looked up in the default location or a
path specified by $(TargetFrameworkRootPath). It would be useful to be
able to look for these frameworks in more than one location. For
example, in case of Xamarin products on OSX, mobile specific frameworks
are installed in
`/Library/Frameworks/Mono.framework/External/xbuild-frameworks` and the
.NET ones are installed in
`/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks`
.

With support for fallback search paths, a lookup for a target framework will follow the order:

    1. $(TargetFrameworkRootPath) or Default location is $(TargetFrameworkRootPath) is ''
    2. Fallback search paths

These fallback search paths can be set in app.config, per os, like:
```
<msbuildToolsets default="14.1">
  <toolset toolsVersion="14.1">
    <property name="TargetFrameworkRootPathSearchPathsOSX" value="/tmp/foo;/tmp/bar" />
    <property name="TargetFrameworkRootPathSearchPathsWindows" value="C:\tmp\foo;C:\tmp\bar" />
    ...
```

This is a RFC, and not complete as tests for this feature are yet to be added.