### PR TITLE
Fix mono/OSX build

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -239,7 +239,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PERFORMANCE_COUNTERS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
+    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PFX_SIGNING</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REFLECTION_EMIT_DEBUG_INFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRY_TOOLSETS</DefineConstants>

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateDictionary(ref _buildProcessEnvironment, StringComparer.OrdinalIgnoreCase);
             translator.TranslateCulture(ref _culture);
             translator.TranslateCulture(ref _uiCulture);
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_BINARY_SERIALIZATION && FEATURE_APPDOMAIN
             translator.TranslateDotNet(ref _appDomainSetup);
 #endif
             translator.Translate(ref _lineNumberOfTask);

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -328,6 +328,7 @@ namespace Microsoft.Build.BackEnd
             {
                 nodeStream.Connect(timeout);
 
+#if !MONO
                 if (NativeMethodsShared.IsWindows)
                 {
                     // Verify that the owner of the pipe is us.  This prevents a security hole where a remote node has
@@ -351,6 +352,7 @@ namespace Microsoft.Build.BackEnd
                     }
 
                 }
+#endif
 
                 CommunicationsUtilities.Trace("Writing handshake to pipe {0}", pipeName);
                 nodeStream.WriteLongForHandshake(hostHandshake);

--- a/src/XMakeBuildEngine/BackEnd/Node/NodeConfiguration.cs
+++ b/src/XMakeBuildEngine/BackEnd/Node/NodeConfiguration.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _nodeId);
             translator.Translate(ref _buildParameters, BuildParameters.FactoryForDeserialization);
             translator.TranslateArray(ref _forwardingLoggers, LoggerDescription.FactoryForTranslation);
-#if FEATURE_APPDOMAIN
+#if FEATURE_BINARY_SERIALIZATION && FEATURE_APPDOMAIN
             translator.TranslateDotNet(ref _appDomainSetup);
 #endif
         }


### PR DESCRIPTION
- Disable FEATURE_PIPE_SECURITY for mono builds
- #if out a PipeSecurity use
- s,FEATURE_APPDOMAIN,FEATURE_BINARY_SERIALIZATION,
    for using INodePacketTranslator.TranslateDotNet

Issue #531 