### PR TITLE
NativeMethodsShared.OSName: Fix the case of OSX

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Build.Shared
         {
             get
             {
-                return IsUnix ? "Unix" : (IsOSX ? "OSX" : "Windows_NT");
+                return IsOSX ? "OSX" : (IsUnix ? "Unix" : "Windows_NT");
             }
         }
 


### PR DESCRIPTION
OSX is also a Unix, so check for the less generic kind first. So, change

    return IsUnix ? "Unix" : (IsOSX ? "OSX" : "Windows_NT")
to
    return IsOSX ? "OSX" : (IsUnix ? "Unix" : "Windows_NT")