### PR TITLE
TaskHostConfiguration: Don't use _appDomainSetup unless FEATURE_APPDO…

### DIFF
--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Build.BackEnd
             translator.TranslateDictionary(ref _buildProcessEnvironment, StringComparer.OrdinalIgnoreCase);
             translator.TranslateCulture(ref _culture);
             translator.TranslateCulture(ref _uiCulture);
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_BINARY_SERIALIZATION && FEATURE_APPDOMAIN
             translator.TranslateDotNet(ref _appDomainSetup);
 #endif
             translator.Translate(ref _lineNumberOfTask);


### PR DESCRIPTION
…MAIN is available.

This actually fixes a previous "fix" (by yours truly),
9300223aaa2614bf5aa89b3dfd28da1fde1102f4, which changed the #if guard
from FEATURE_APPDOMAIN to FEATURE_BINARY_SERIALIZATION. But this code
requires both:

    translator.TranslateDotNet(ref _appDomainSetup);