### PR TITLE
Adding custom UpdateBuildValues target

### DIFF
--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -22,7 +22,10 @@
   <Import Project="..\dir.traversal.targets" />
 
   <Import Project="$(ToolsDir)packages.targets" Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'" />
-  <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />
+  
+  <!-- TODO: Use UpdateBuildValues target from BuildTools > version 206
+  <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />-->
+  <Import Project="$(RepoRoot)\targets\UpdateBuildValues.targets" Condition="Exists('$(RepoRoot)\targets\UpdateBuildValues.targets')" />
 
   <PropertyGroup Condition="Exists('$(ToolsDir)packages.targets') and '$(ImportGetNuGetPackageVersions)' != 'false'">
     <TraversalBuildDependsOn>

--- a/targets/UpdateBuildValues.targets
+++ b/targets/UpdateBuildValues.targets
@@ -1,0 +1,54 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Taken from https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
+       TODO: Remove when we update BuildTools > 206 -->
+  <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="GetNextRevisionNumber"
+    BeforeTargets="Build;BuildAllProjects"
+    Condition="'$(UpdateBuildValues)' == 'true'"
+    >
+    <GetNextRevisionNumber
+      VersionPropsFile="$(SourceDir)BuildValues.props">
+      <Output PropertyName="RevisionNumber" TaskParameter="RevisionNumber" />
+    </GetNextRevisionNumber>
+  </Target>
+  <PropertyGroup>
+    <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>
+    <GitPushRemote Condition="'$(GitPushRemote)' == ''">origin</GitPushRemote>
+  </PropertyGroup>
+
+  <!-- Taken from https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CommitBuildValues.targets
+       TODO: Remove when we update BuildTools > 206 -->
+  <Target Name="CommitBuildValues"
+    AfterTargets="BuildPackages"
+    Condition="'$(UpdateBuildValues)' == 'true'"
+    >
+    <!-- configure the commit to show up as the dotnet bot -->
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git config user.name &quot;dotnet-bot&quot;" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git config user.email &quot;dotnet-bot@microsoft.com&quot;" />
+
+    <!-- commit and push to origin -->
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git checkout $(GitWorkingBranch)" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git push $(GitPushRemote) $(GitWorkingBranch)" />
+
+  </Target>
+</Project>


### PR DESCRIPTION
 - This is in BuildTools > 206, which causes many build issues. We will
   need to revert this change when we're able to take the new package.
 - I need this change because the GitPushRemote variable was added.