### PR TITLE
$(OS) should return only two values - `Windows_NT` and `Unix` .

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Build.Shared
         {
             get
             {
-                return IsOSX ? "OSX" : (IsUnix ? "Unix" : "Windows_NT");
+                return IsWindows ? "Windows_NT" : "Unix";
             }
         }
 


### PR DESCRIPTION
Based on the discussion in issue #539, $(OS) property will return
`Windows_NT` whenever running on windows and `Unix` for any other OS.

NativeMethodsShared.OSName is used to set that property, hence this is
being changed.