### PR TITLE
Fix ToolName for AL and LC - al.exe and lc.exe respectively

### DIFF
--- a/src/XMakeTasks/Al.cs
+++ b/src/XMakeTasks/Al.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                return NativeMethodsShared.IsWindows ? "AL.exe" : "al";
+                return "al.exe";
             }
         }
 

--- a/src/XMakeTasks/LC.cs
+++ b/src/XMakeTasks/LC.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                return "LC.exe";
+                return "lc.exe";
             }
         }
 


### PR DESCRIPTION
- the name and case matches what mono uses and should be fine for
  windows