### PR TITLE
Tasks: Fix overriding `ToolExe` from project files.

### DIFF
--- a/src/XMakeTasks/Al.cs
+++ b/src/XMakeTasks/Al.cs
@@ -307,12 +307,12 @@ namespace Microsoft.Build.Tasks
             // the SDK, which may or may not be installed. The following will look there.
             if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_InstallRoot")) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_Version")))
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest);
+                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
             }
 
             if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))
             {
-                pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolName, Log, true);
+                pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
             }
 
             return pathToTool;

--- a/src/XMakeTasks/AspNetCompiler.cs
+++ b/src/XMakeTasks/AspNetCompiler.cs
@@ -328,11 +328,11 @@ namespace Microsoft.Build.Tasks
             string pathToTool = null;
 
             // If ToolPath wasn't passed in, we want to default to the latest
-            pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest);
+            pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
 
             if (pathToTool == null)
             {
-                Log.LogErrorWithCodeFromResources("General.FrameworksFileNotFound", ToolName,
+                Log.LogErrorWithCodeFromResources("General.FrameworksFileNotFound", ToolExe,
                     ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
             }
 

--- a/src/XMakeTasks/LC.cs
+++ b/src/XMakeTasks/LC.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>path to lc.exe, null if not found</returns>
         protected override string GenerateFullPathToTool()
         {
-            string pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolName, Log, true);
+            string pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
             return pathToTool;
         }
 

--- a/src/XMakeTasks/ResGen.cs
+++ b/src/XMakeTasks/ResGen.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Build.Tasks
                                             SdkToolsPathUtility.FileInfoExists,
                                             MSBuildProcessorArchitecture.CurrentProcessArchitecture,
                                             SdkToolsPath,
-                                            ToolName,
+                                            ToolExe,
                                             Log,
                                             true /* log errors and warnings */
                                         );

--- a/src/XMakeTasks/SGen.cs
+++ b/src/XMakeTasks/SGen.cs
@@ -244,12 +244,12 @@ namespace Microsoft.Build.Tasks
             // the SDK, which may or may not be installed. The following will look there.
             if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_InstallRoot")) || !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_Version")))
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest);
+                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.VersionLatest);
             }
 
             if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))
             {
-                pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolName, Log, true);
+                pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
             }
 
             return pathToTool;

--- a/src/XMakeTasks/WinMDExp.cs
+++ b/src/XMakeTasks/WinMDExp.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Build.Tasks
 
             if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))
             {
-                pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolName, Log, true);
+                pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, Microsoft.Build.Utilities.ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
             }
 
             return pathToTool;


### PR DESCRIPTION
`ToolExe` can be overriden from project files. If not set, then it
falls back to `ToolName`. So, use `ToolExe` in `GenerateFullPathToTool`
instead of `ToolName`.