### PR TITLE
RAR name mismatch message with Assembly name

### DIFF
--- a/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/XMakeTasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1193,7 +1193,7 @@ namespace Microsoft.Build.Tasks
 
             // If there is a list of assemblyFiles that was considered but then rejected,
             // show information about them.
-            LogAssembliesConsideredAndRejected(reference, importance);
+            LogAssembliesConsideredAndRejected(reference, fusionName, importance);
 
             if (!reference.IsBadImage)
             {
@@ -1549,7 +1549,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         /// <param name="reference">The reference.</param>
         /// <param name="importance">The importance of the message.</param>
-        private void LogAssembliesConsideredAndRejected(Reference reference, MessageImportance importance)
+        private void LogAssembliesConsideredAndRejected(Reference reference, string fusionName, MessageImportance importance)
         {
             if (reference.AssembliesConsideredAndRejected != null)
             {
@@ -1602,7 +1602,7 @@ namespace Microsoft.Build.Tasks
                                 break;
                             }
                         case NoMatchReason.FusionNamesDidNotMatch:
-                            Log.LogMessageFromResources(importance, "ResolveAssemblyReference.EightSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch", location.FileNameAttempted, location.AssemblyName.FullName));
+                            Log.LogMessageFromResources(importance, "ResolveAssemblyReference.EightSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch", location.FileNameAttempted, location.AssemblyName.FullName, fusionName));
                             break;
 
                         case NoMatchReason.TargetHadNoFusionName:

--- a/src/XMakeTasks/Strings.resx
+++ b/src/XMakeTasks/Strings.resx
@@ -1342,7 +1342,9 @@
     </comment>
   </data>
   <data name="ResolveAssemblyReference.ConsideredAndRejectedBecauseFusionNamesDidntMatch">
-    <value>Considered "{0}", but its name "{1}" didn't match.</value>
+    <value>Considered "{0}",
+			but its name "{1}"
+			didn't match the expected name "{2}".</value>
   </data>
   <data name="ResolveAssemblyReference.ConsideredAndRejectedBecauseNoFile">
     <value>Considered "{0}", but it didn't exist.</value>


### PR DESCRIPTION
Update error message with expected, actual and target `Assembly` name

    Considered "....expected....",
        but its name "....actual....".
    Didn't match the expected version  "..assembly name."

Issue #502 
