### PR TITLE
Port extensions path fallback

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -317,6 +317,14 @@ namespace Microsoft.Build.Shared
         /// </remarks>
         internal static int MAX_PATH = 260;
 
+        /// <summary>
+        /// OS name that can be used for the msbuildExtensionsPathSearchPaths element
+        /// for a toolset
+        /// </summary>
+        internal static string GetOSNameForExtensionsPath()
+        {
+            return IsOSX ? "osx" : (IsUnix ? "unix" : "windows");
+        }
         #endregion
 
         #region Set Error Mode (copied from BCL)

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -323,8 +323,13 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string GetOSNameForExtensionsPath()
         {
+#if XPLAT
             return IsOSX ? "osx" : (IsUnix ? "unix" : "windows");
+#else
+            return "windows";
+#endif
         }
+
         #endregion
 
         #region Set Error Mode (copied from BCL)

--- a/src/XMakeBuildEngine/Definition/ProjectCollection.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectCollection.cs
@@ -1645,14 +1645,36 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Reset the toolsets using the provided toolset reader, used by unit tests
+        /// </summary>
+        internal void ResetToolsetsForTests(ToolsetConfigurationReader configurationReaderForTestsOnly)
+        {
+            InitializeToolsetCollection(configReader:configurationReaderForTestsOnly);
+        }
+
+        /// <summary>
+        /// Reset the toolsets using the provided toolset reader, used by unit tests
+        /// <summary>
+        internal void ResetToolsetsForTests(ToolsetRegistryReader registryReaderForTestsOnly)
+        {
+            InitializeToolsetCollection(registryReader:registryReaderForTestsOnly);
+        }
+
+        /// <summary>
         /// Populate Toolsets with a dictionary of (toolset version, Toolset) 
         /// using information from the registry and config file, if any.  
         /// </summary>
-        private void InitializeToolsetCollection()
+        private void InitializeToolsetCollection(
+                ToolsetRegistryReader registryReader = null,
+                ToolsetConfigurationReader configReader = null)
         {
             _toolsets = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
 
-            _defaultToolsVersion = ToolsetReader.ReadAllToolsets(_toolsets, EnvironmentProperties, _globalProperties, _toolsetDefinitionLocations);
+            // We only want our local toolset (as defined in MSBuild.exe.config) when we're operating locally...
+            _defaultToolsVersion = ToolsetReader.ReadAllToolsets(_toolsets,
+                    registryReader,
+                    configReader,
+                    EnvironmentProperties, _globalProperties, _toolsetDefinitionLocations);
 
             _toolsetsVersion++;
         }

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -349,6 +349,20 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Returns a copy of the list of search paths for a MSBuildExtensionsPath* property kind.
+        /// </summary>
+        internal IList<string> GetMSBuildExtensionsPathSearchPathsFor(MSBuildExtensionsPathReferenceKind refKind)
+        {
+            IList<string> paths;
+            if (MSBuildExtensionsPathSearchPathsTable != null && MSBuildExtensionsPathSearchPathsTable.TryGetValue(refKind, out paths))
+            {
+                return new List<string>(paths);
+            }
+
+            return new List<string>();
+        }
+
+        /// <summary>
         /// Name of this toolset
         /// </summary>
         public string ToolsVersion
@@ -554,6 +568,14 @@ namespace Microsoft.Build.Evaluation
         internal string DefaultOverrideToolsVersion
         {
             get { return _defaultOverrideToolsVersion; }
+        }
+
+        /// <summary>
+        /// Map of MSBuildExtensionsPath properties to their list of fallback search paths
+        /// </summary>
+        internal Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> MSBuildExtensionsPathSearchPathsTable
+        {
+            get; set;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -49,6 +49,17 @@ namespace Microsoft.Build.Evaluation
         private bool _configurationReadAttempted = false;
 
         /// <summary>
+        /// Character used to separate search paths specified for MSBuildExtensionsPath* in
+        /// the config file
+        /// </summary>
+        private char _separatorForExtensionsPathSearchPaths = ';';
+
+        /// <summary>
+        /// map of MSBuildExtensionsPath property kind to list of fallback search paths, per toolsVersion
+        /// </summary>
+        private Dictionary<string, Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>> _kindToPathsCachePerToolsVersion;
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         internal ToolsetConfigurationReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties)
@@ -64,6 +75,7 @@ namespace Microsoft.Build.Evaluation
         {
             ErrorUtilities.VerifyThrowArgumentNull(readApplicationConfiguration, "readApplicationConfiguration");
             _readApplicationConfiguration = readApplicationConfiguration;
+            _kindToPathsCachePerToolsVersion = new Dictionary<string, Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -210,9 +222,69 @@ namespace Microsoft.Build.Evaluation
             yield break;
         }
 
+        /// <summary>
+        /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
+        /// </summary>
         protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
         {
-            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+            Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> kindToPathsCache;
+            var key = toolsVersion + ":" + os;
+            if (_kindToPathsCachePerToolsVersion.TryGetValue(key, out kindToPathsCache))
+            {
+                return kindToPathsCache;
+            }
+
+            // Read and populate the map
+            kindToPathsCache = new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+            _kindToPathsCachePerToolsVersion[key] = kindToPathsCache;
+
+            ToolsetElement toolsetElement = ConfigurationSection.Toolsets.GetElement(toolsVersion);
+            var propertyCollection = toolsetElement?.AllMSBuildExtensionPathsSearchPaths?.GetElement(os)?.PropertyElements;
+            if (propertyCollection == null || propertyCollection.Count == 0)
+            {
+                return kindToPathsCache;
+            }
+
+            var allPaths = new MSBuildExtensionsPathReferenceKind[] {
+                                MSBuildExtensionsPathReferenceKind.Default,
+                                MSBuildExtensionsPathReferenceKind.Path32,
+                                MSBuildExtensionsPathReferenceKind.Path64,
+                                MSBuildExtensionsPathReferenceKind.None
+                            };
+
+            foreach (MSBuildExtensionsPathReferenceKind kind in allPaths)
+            {
+                kindToPathsCache[kind] = ComputeDistinctListOfFallbackPathsFor(kind, propertyCollection);
+            }
+
+            return kindToPathsCache;
+        }
+
+        /// <summary>
+        /// Returns a list of the search paths for a given MSBuildExtensionsPathReferenceKind
+        /// </summary>
+        private List<string> ComputeDistinctListOfFallbackPathsFor(MSBuildExtensionsPathReferenceKind refKind, ToolsetElement.PropertyElementCollection propertyCollection)
+        {
+            var extnPaths = new List<string>();
+            var pathsFromConfig = propertyCollection.GetElement(refKind.StringRepresentation)?.Value;
+
+            //FIXME: handle ; in path on Unix
+            if (String.IsNullOrEmpty(pathsFromConfig))
+            {
+                return extnPaths;
+            }
+
+            var pathsTable = new HashSet<string>();
+            foreach (var extnPath in pathsFromConfig.Split(new char[]{_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (!pathsTable.Contains(extnPath))
+                {
+                    pathsTable.Add(extnPath);
+                    extnPaths.Add(extnPath);
+                }
+            }
+
+            return extnPaths;
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -210,6 +210,11 @@ namespace Microsoft.Build.Evaluation
             yield break;
         }
 
+        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        {
+            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+        }
+
         /// <summary>
         /// Reads the application configuration file.
         /// NOTE: this is abstracted into a method to support unit testing GetToolsetDataFromConfiguration().

--- a/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetLocalReader.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal class ToolsetLocalReader : ToolsetReader
+    {
+        private IElementLocation _sourceLocation = new RegistryLocation("ToolsetLocalReader");
+
+        internal ToolsetLocalReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties)
+           : base(environmentProperties, globalProperties)
+        {
+        }
+
+        protected override string DefaultOverrideToolsVersion
+        {
+            get
+            {
+                return MSBuildConstants.CurrentProductVersion;
+            }
+        }
+
+        protected override string DefaultToolsVersion
+        {
+            get
+            {
+                return MSBuildConstants.CurrentProductVersion;
+            }
+        }
+
+        protected override string MSBuildOverrideTasksPath
+        {
+            get
+            {
+                return FileUtilities.CurrentExecutableDirectory;
+            }
+        }
+
+        protected override IEnumerable<ToolsetPropertyDefinition> ToolsVersions
+        {
+            get
+            {
+                yield return new ToolsetPropertyDefinition(MSBuildConstants.CurrentProductVersion, string.Empty, _sourceLocation);
+            }
+        }
+
+        protected override IEnumerable<ToolsetPropertyDefinition> GetPropertyDefinitions(string toolsVersion)
+        {
+            yield return new ToolsetPropertyDefinition(MSBuildConstants.ToolsPath, FileUtilities.CurrentExecutableDirectory, _sourceLocation);
+        }
+
+        protected override IEnumerable<ToolsetPropertyDefinition> GetSubToolsetPropertyDefinitions(string toolsVersion, string subToolsetVersion)
+        {
+            return Enumerable.Empty<ToolsetPropertyDefinition>();
+        }
+
+        protected override IEnumerable<string> GetSubToolsetVersions(string toolsVersion)
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        {
+            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+        }
+    }
+}

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -277,6 +277,11 @@ namespace Microsoft.Build.Evaluation
         protected abstract IEnumerable<ToolsetPropertyDefinition> GetSubToolsetPropertyDefinitions(string toolsVersion, string subToolsetVersion);
 
         /// <summary>
+        /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
+        /// </summary>
+        protected abstract Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os);
+
+        /// <summary>
         /// Reads all the toolsets and populates the given ToolsetCollection with them
         /// </summary>
         private void ReadEachToolset
@@ -378,6 +383,7 @@ namespace Microsoft.Build.Evaluation
             try
             {
                 toolset = new Toolset(toolsVersion.Name, toolsPath == null ? binPath : toolsPath, properties, _environmentProperties, globalProperties, subToolsets, MSBuildOverrideTasksPath, DefaultOverrideToolsVersion);
+                toolset.MSBuildExtensionsPathSearchPathsTable = GetMSBuildExtensionPathsSearchPathsTable(toolsVersion.Name, GetOSNameForExtensionsPath());
             }
             catch (ArgumentException e)
             {
@@ -385,6 +391,120 @@ namespace Microsoft.Build.Evaluation
             }
 
             return toolset;
+        }
+
+        /// <summary>
+        /// OS name that can be used for the msbuildExtensionsPathSearchPaths element
+        /// for a toolset
+        /// </summary>
+        private static string GetOSNameForExtensionsPath()
+        {
+            if (NativeMethodsShared.IsWindows)
+            {
+                return "windows";
+            }
+
+            if (NativeMethodsShared.IsOSX)
+            {
+                return "osx";
+            }
+
+            return "unix";
+        }
+
+        /// <summary>
+        /// Create a dictionary with standard properties.
+        /// </summary>
+        private static PropertyDictionary<ProjectPropertyInstance> CreateStandardProperties(
+            PropertyDictionary<ProjectPropertyInstance> globalProperties,
+            string version,
+            string root,
+            string toolsPath)
+        {
+            // Create standard properties. On Mono they are well known
+            if (!NativeMethodsShared.IsMono)
+            {
+                return null;
+            }
+
+            PropertyDictionary<ProjectPropertyInstance> buildProperties =
+                new PropertyDictionary<ProjectPropertyInstance>();
+            AppendStandardProperties(buildProperties, globalProperties, version, root, toolsPath);
+            return buildProperties;
+        }
+
+        /// <summary>
+        /// Appends standard properties to a dictionary. These properties are read from
+        /// the registry under Windows (they are a part of a toolset definition).
+        /// </summary>
+        private static void AppendStandardProperties(
+            PropertyDictionary<ProjectPropertyInstance> properties,
+            PropertyDictionary<ProjectPropertyInstance> globalProperties,
+            string version,
+            string root,
+            string toolsPath)
+        {
+            if (NativeMethodsShared.IsMono)
+            {
+                var v4Dir = FrameworkLocationHelper.GetPathToDotNetFrameworkV40(DotNetFrameworkArchitecture.Current)
+                            + Path.DirectorySeparatorChar;
+                var v35Dir = FrameworkLocationHelper.GetPathToDotNetFrameworkV35(DotNetFrameworkArchitecture.Current)
+                             + Path.DirectorySeparatorChar;
+
+                if (root == null)
+                {
+                    var libraryPath = NativeMethodsShared.FrameworkBasePath;
+                    if (toolsPath.StartsWith(libraryPath))
+                    {
+                        root = Path.GetDirectoryName(toolsPath);
+                        if (toolsPath.EndsWith("bin"))
+                        {
+                            root = Path.GetDirectoryName(root);
+                        }
+                    }
+                    else
+                    {
+                        root = libraryPath;
+                    }
+                }
+
+                root += Path.DirectorySeparatorChar;
+
+                // Global properties cannot be overwritten
+                if (globalProperties["FrameworkSDKRoot"] == null && properties["FrameworkSDKRoot"] == null)
+                {
+                    properties.Set(ProjectPropertyInstance.Create("FrameworkSDKRoot", root, true, false));
+                }
+                if (globalProperties["MSBuildToolsRoot"] == null && properties["MSBuildToolsRoot"] == null)
+                {
+                    properties.Set(ProjectPropertyInstance.Create("MSBuildToolsRoot", root, true, false));
+                }
+                if (globalProperties["MSBuildFrameworkToolsPath"] == null
+                    && properties["MSBuildFrameworkToolsPath"] == null)
+                {
+                    properties.Set(ProjectPropertyInstance.Create("MSBuildFrameworkToolsPath", toolsPath, true, false));
+                }
+                if (globalProperties["MSBuildFrameworkToolsPath32"] == null
+                    && properties["MSBuildFrameworkToolsPath32"] == null)
+                {
+                    properties.Set(
+                        ProjectPropertyInstance.Create("MSBuildFrameworkToolsPath32", toolsPath, true, false));
+                }
+                if (globalProperties["MSBuildRuntimeVersion"] == null && properties["MSBuildRuntimeVersion"] == null)
+                {
+                    properties.Set(ProjectPropertyInstance.Create("MSBuildRuntimeVersion", version, true, false));
+                }
+                if (!string.IsNullOrEmpty(v35Dir) && globalProperties["SDK35ToolsPath"] == null
+                    && properties["SDK35ToolsPath"] == null)
+                {
+                    properties.Set(ProjectPropertyInstance.Create("SDK35ToolsPath", v35Dir, true, false));
+                }
+                if (!string.IsNullOrEmpty(v4Dir) && globalProperties["SDK40ToolsPath"] == null
+                    && properties["SDK40ToolsPath"] == null)
+                {
+                    properties.Set(ProjectPropertyInstance.Create("SDK40ToolsPath", v4Dir, true, false));
+                }
+            }
         }
 
         /// <summary>
@@ -530,4 +650,69 @@ namespace Microsoft.Build.Evaluation
             return path;
         }
     }
+
+    /// <summary>
+    /// struct representing a reference to MSBuildExtensionsPath* property
+    /// </summary>
+    internal struct MSBuildExtensionsPathReferenceKind
+    {
+
+        /// <summary>
+        /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath"
+        /// </summary>
+        public static readonly MSBuildExtensionsPathReferenceKind Default = new MSBuildExtensionsPathReferenceKind("MSBuildExtensionsPath");
+
+        /// <summary>
+        /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath32"
+        /// </summary>
+        public static readonly MSBuildExtensionsPathReferenceKind Path32 = new MSBuildExtensionsPathReferenceKind("MSBuildExtensionsPath32");
+
+        /// <summary>
+        /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath64"
+        /// </summary>
+        public static readonly MSBuildExtensionsPathReferenceKind Path64 = new MSBuildExtensionsPathReferenceKind("MSBuildExtensionsPath64");
+
+        /// <summary>
+        /// MSBuildExtensionsPathReferenceKind instance representing no MSBuildExtensionsPath* property reference
+        /// </summary>
+        public static readonly MSBuildExtensionsPathReferenceKind None = new MSBuildExtensionsPathReferenceKind(String.Empty);
+
+        private MSBuildExtensionsPathReferenceKind(string value)
+        {
+            StringRepresentation = value;
+        }
+
+        /// <summary>
+        /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
+        /// </summary>
+        public string StringRepresentation { get; private set; }
+
+        /// <summary>
+        /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
+        /// </summary>
+        public string MSBuildPropertyName => String.Format($"$({StringRepresentation})");
+
+        /// <summary>
+        /// Tries to find a reference to MSBuildExtensionsPath* property in the given string
+        /// </summary>
+        public static MSBuildExtensionsPathReferenceKind FindIn(string expression)
+        {
+            if (expression.IndexOf("$(MSBuildExtensionsPath)") >= 0)
+            {
+                return MSBuildExtensionsPathReferenceKind.Default;
+            }
+
+            if (expression.IndexOf("$(MSBuildExtensionsPath32)") >= 0)
+            {
+                return MSBuildExtensionsPathReferenceKind.Path32;
+            }
+
+            if (expression.IndexOf("$(MSBuildExtensionsPath64)") >= 0)
+            {
+                return MSBuildExtensionsPathReferenceKind.Path64;
+            }
+
+            return MSBuildExtensionsPathReferenceKind.None;
+        }
+     }
 }

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -402,16 +402,19 @@ namespace Microsoft.Build.Evaluation
             string root,
             string toolsPath)
         {
+#if XPLAT
             // Create standard properties. On Mono they are well known
             if (!NativeMethodsShared.IsMono)
+#endif
             {
                 return null;
             }
-
+#if XPLAT
             PropertyDictionary<ProjectPropertyInstance> buildProperties =
                 new PropertyDictionary<ProjectPropertyInstance>();
             AppendStandardProperties(buildProperties, globalProperties, version, root, toolsPath);
             return buildProperties;
+#endif
         }
 
         /// <summary>
@@ -425,6 +428,7 @@ namespace Microsoft.Build.Evaluation
             string root,
             string toolsPath)
         {
+#if XPLAT
             if (NativeMethodsShared.IsMono)
             {
                 var v4Dir = FrameworkLocationHelper.GetPathToDotNetFrameworkV40(DotNetFrameworkArchitecture.Current)
@@ -486,6 +490,7 @@ namespace Microsoft.Build.Evaluation
                     properties.Set(ProjectPropertyInstance.Create("SDK40ToolsPath", v4Dir, true, false));
                 }
             }
+#endif
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Build.Evaluation
             try
             {
                 toolset = new Toolset(toolsVersion.Name, toolsPath == null ? binPath : toolsPath, properties, _environmentProperties, globalProperties, subToolsets, MSBuildOverrideTasksPath, DefaultOverrideToolsVersion);
-                toolset.MSBuildExtensionsPathSearchPathsTable = GetMSBuildExtensionPathsSearchPathsTable(toolsVersion.Name, GetOSNameForExtensionsPath());
+                toolset.MSBuildExtensionsPathSearchPathsTable = GetMSBuildExtensionPathsSearchPathsTable(toolsVersion.Name, NativeMethodsShared.GetOSNameForExtensionsPath());
             }
             catch (ArgumentException e)
             {
@@ -391,25 +391,6 @@ namespace Microsoft.Build.Evaluation
             }
 
             return toolset;
-        }
-
-        /// <summary>
-        /// OS name that can be used for the msbuildExtensionsPathSearchPaths element
-        /// for a toolset
-        /// </summary>
-        private static string GetOSNameForExtensionsPath()
-        {
-            if (NativeMethodsShared.IsWindows)
-            {
-                return "windows";
-            }
-
-            if (NativeMethodsShared.IsOSX)
-            {
-                return "osx";
-            }
-
-            return "unix";
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
@@ -290,6 +290,14 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
+        /// </summary>
+        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        {
+            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+        }
+
+        /// <summary>
         /// Given a registry location containing a property name and value, create the ToolsetPropertyDefinition that maps to it
         /// </summary>
         /// <param name="toolsetWrapper">Wrapper for the key that we're getting values from</param>

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -612,6 +612,10 @@
     <value>MSB4144: Multiple definitions were found for the toolset "{0}". </value>
     <comment>{StrBegin="MSB4144: "}</comment>
   </data>
+  <data name="MultipleDefinitionsForSameExtensionsPathOS" UESanitized="false" Visibility="Public">
+      <value>MSB4225: Toolset contains multiple definitions of searchPaths for the OS "{0}" at "{1}".</value>
+    <comment>{StrBegin="MSB4225: "}</comment>
+  </data>
   <data name="MultipleDefinitionsForSameProperty" UESanitized="false" Visibility="Public">
     <value>MSB4145: Multiple definitions were found for the property "{0}".</value>
     <comment>{StrBegin="MSB4145: "}</comment>
@@ -1517,7 +1521,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4225.
+        Next message code should be MSB4226.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/XMakeBuildEngine/Resources/Strings.resx
+++ b/src/XMakeBuildEngine/Resources/Strings.resx
@@ -252,6 +252,12 @@
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
     </comment>
   </data>
+  <data name="SearchPathsForMSBuildExtensionsPath">
+      <value>Search paths being used for {0} are {1}</value>
+  </data>
+  <data name="TryingExtensionsPath">
+      <value>Trying to import {0} using extensions path {1}</value>
+  </data>
   <data name="OverrideTasksFileFailure" UESanitized="false" Visibility="Public">
     <value>MSB4194: The override tasks file could not be successfully loaded. {0}</value>
     <comment>
@@ -412,6 +418,14 @@
   <data name="ImportedProjectNotFound" UESanitized="false" Visibility="Public">
     <value>MSB4019: The imported project "{0}" was not found. Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk.</value>
     <comment>{StrBegin="MSB4019: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
+  </data>
+  <data name="ImportedProjectFromExtensionsPathNotFoundFromAppConfig" UESanitized="false" Visibility="Public">
+    <value>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</value>
+    <comment>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
+  </data>
+  <data name="ImportedProjectFromExtensionsPathNotFound" UESanitized="false" Visibility="Public">
+    <value>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</value>
+    <comment>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</comment>
   </data>
   <data name="IncorrectNumberOfFunctionArguments" UESanitized="false" Visibility="Public">
     <value>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</value>
@@ -1521,7 +1535,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4226.
+        Next message code should be MSB4227.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -7,7 +7,10 @@ using System.Text;
 using System.Collections.Generic;
 using System.Configuration;
 using Microsoft.Win32;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
 
 using ToolsetConfigurationSection = Microsoft.Build.Evaluation.ToolsetConfigurationSection;
 using Xunit;
@@ -82,6 +85,8 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.Count, 1);
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 0);
         }
 
         /// <summary>
@@ -179,6 +184,8 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.Count, 1);
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 0);
         }
         #endregion
 
@@ -489,5 +496,181 @@ namespace Microsoft.Build.UnitTests.Definition
 
         #endregion
         #endregion
+
+        #region Extensions Paths
+        /// <summary>
+        ///  Tests multiple extensions paths from the config file, specified for multiple OSes
+        /// </summary>
+        [Fact]
+        public void ExtensionPathsTest_Basic1()
+        {
+            // NOTE: for some reason, <configSections> MUST be the first element under <configuration>
+            // for the API to read it. The docs don't make this clear.
+
+            ToolsetConfigurationReaderTestHelper.WriteConfigFile(ObjectModelHelpers.CleanupFileContents(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""2.0"">
+                     <toolset toolsVersion=""2.0"">
+                       <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v2.0.x86ret\""/>
+                       <property name=""MSBuildToolsPath"" value=""D:\windows\Microsoft.NET\Framework\v2.0.x86ret\""/>
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
+                            <property name=""MSBuildExtensionsPath64"" value=""c:\foo64;c:\bar64""/>
+                         </searchPaths>
+                         <searchPaths os=""osx"">
+                            <property name=""MSBuildExtensionsPath"" value=""/tmp/foo""/>
+                            <property name=""MSBuildExtensionsPath32"" value=""/tmp/foo32;/tmp/bar32""/>
+                         </searchPaths>
+                         <searchPaths os=""unix"">
+                            <property name=""MSBuildExtensionsPath"" value=""/tmp/bar""/>
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                     </toolset>
+                   </msbuildToolsets>
+                 </configuration>"));
+
+            Configuration config = ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest();
+            ToolsetConfigurationSection msbuildToolsetSection = config.GetSection(s_msbuildToolsets) as ToolsetConfigurationSection;
+
+            Assert.Equal(msbuildToolsetSection.Default, "2.0");
+            Assert.Equal(1, msbuildToolsetSection.Toolsets.Count);
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).toolsVersion, "2.0");
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.Count, 2);
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
+                                   @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
+
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 3);
+            var allPaths = msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths;
+            Assert.Equal(allPaths.GetElement(0).OS, "windows");
+            Assert.Equal(allPaths.GetElement(0).PropertyElements.Count, 2);
+            Assert.Equal(allPaths.GetElement(0).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"c:\foo");
+            Assert.Equal(allPaths.GetElement(0).PropertyElements.GetElement("MSBuildExtensionsPath64").Value, @"c:\foo64;c:\bar64");
+
+            Assert.Equal(allPaths.GetElement(1).OS, "osx");
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.Count, 2);
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/foo");
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath32").Value, @"/tmp/foo32;/tmp/bar32");
+
+            Assert.Equal(allPaths.GetElement(2).OS, "unix");
+            Assert.Equal(allPaths.GetElement(2).PropertyElements.Count, 1);
+            Assert.Equal(allPaths.GetElement(2).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/bar");
+
+            var reader = GetStandardConfigurationReader();
+            Dictionary<string, Toolset> toolsets = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
+            string msbuildOverrideTasksPath = null;
+            string defaultOverrideToolsVersion = null;
+            string defaultToolsVersion = reader.ReadToolsets(toolsets, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
+
+            Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable = toolsets["2.0"].MSBuildExtensionsPathSearchPathsTable;
+            if (NativeMethodsShared.IsWindows)
+            {
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"c:\\foo"});
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path64, new string[] {"c:\\foo64", "c:\\bar64"});
+            }
+            else if (NativeMethodsShared.IsOSX)
+            {
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/foo"});
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path32, new string[] {"/tmp/foo32", "/tmp/bar32"});
+            }
+            else
+            {
+                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/bar"});
+            }
+        }
+
+        private void CheckPathsTable(Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable, MSBuildExtensionsPathReferenceKind kind, string[] expectedPaths)
+        {
+            Assert.True(pathsTable.ContainsKey(kind));
+            var paths = pathsTable[kind];
+            Assert.Equal(paths.Count, expectedPaths.Length);
+
+            for (int i = 0; i < paths.Count; i ++)
+            {
+                Assert.Equal(paths[i], expectedPaths[i]);
+            }
+        }
+
+        /// <summary>
+        /// more than 1 searchPaths elements with the same OS
+        /// </summary>
+        [Fact]
+        public void ExtensionsPathsTest_MultipleElementsWithSameOS()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() =>
+            {
+                ToolsetConfigurationReaderTestHelper.WriteConfigFile(ObjectModelHelpers.CleanupFileContents(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""4.0"">
+                     <toolset ToolsVersion=""2.0"">
+                       <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v3.5.x86ret\""/>
+
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
+                         </searchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\bar""/>
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                     </toolset>
+                   </msbuildToolsets>
+                 </configuration>"));
+
+                Configuration config = ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest();
+
+                ToolsetConfigurationSection msbuildToolsetSection = config.GetSection(s_msbuildToolsets) as ToolsetConfigurationSection;
+            }
+           );
+        }
+
+        /// <summary>
+        /// more than value is element found for a the same extensions path property name+os
+        /// </summary>
+        [Fact]
+        public void ExtensionsPathsTest_MultipleElementsWithSamePropertyNameForSameOS()
+        {
+            Assert.Throws<ConfigurationErrorsException>(() =>
+            {
+                ToolsetConfigurationReaderTestHelper.WriteConfigFile(ObjectModelHelpers.CleanupFileContents(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""4.0"">
+                     <toolset ToolsVersion=""2.0"">
+                       <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v3.5.x86ret\""/>
+
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""windows"">
+                            <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
+                            <property name=""MSBuildExtensionsPath"" value=""c:\bar""/>
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                     </toolset>
+                   </msbuildToolsets>
+                 </configuration>"));
+
+                Configuration config = ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest();
+
+                ToolsetConfigurationSection msbuildToolsetSection = config.GetSection(s_msbuildToolsets) as ToolsetConfigurationSection;
+            }
+           );
+        }
+
+        private ToolsetConfigurationReader GetStandardConfigurationReader()
+        {
+            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
+                ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+        }
+        #endregion
+
     }
 }

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -567,11 +567,14 @@ namespace Microsoft.Build.UnitTests.Definition
             string defaultToolsVersion = reader.ReadToolsets(toolsets, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
 
             Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable = toolsets["2.0"].MSBuildExtensionsPathSearchPathsTable;
+#if XPLAT
             if (NativeMethodsShared.IsWindows)
+#endif
             {
                 CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"c:\\foo"});
                 CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path64, new string[] {"c:\\foo64", "c:\\bar64"});
             }
+#if XPLAT
             else if (NativeMethodsShared.IsOSX)
             {
                 CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/foo"});
@@ -581,6 +584,7 @@ namespace Microsoft.Build.UnitTests.Definition
             {
                 CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/bar"});
             }
+#endif
         }
 
         private void CheckPathsTable(Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable, MSBuildExtensionsPathReferenceKind kind, string[] expectedPaths)

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                        <property name=""MSBuildToolsPath"" value="".""/>
                        <property name=""MSBuildBinPath"" value=""" + /*v4Folder*/"." + @"""/>
                        <msbuildExtensionsPathSearchPaths>
-                         <searchPaths os=""osx"">
+                         <searchPaths os=""" + NativeMethodsShared.GetOSNameForExtensionsPath() + @""">
                            <property name=""MSBuildExtensionsPath"" value=""{0}"" />
                            <property name=""MSBuildExtensionsPath32"" value=""{1}"" />
                            <property name=""MSBuildExtensionsPath64"" value=""{2}"" />
@@ -494,7 +494,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                        <property name=""MSBuildToolsPath"" value=""."" />
                        <property name=""MSBuildBinPath"" value=""."" />
                        <msbuildExtensionsPathSearchPaths>
-                         <searchPaths os=""osx"">
+                         <searchPaths os=""" + NativeMethodsShared.GetOSNameForExtensionsPath() + @""">
                            <property name=""" + extnPathPropertyName + @""" value=""" + combinedExtnDirs + @""" />
                          </searchPaths>
                        </msbuildExtensionsPathSearchPaths>

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -1,0 +1,573 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_SYSTEM_CONFIGURATION
+
+using System.Configuration;
+using Microsoft.Win32;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared;
+
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    /// <summary>
+    /// Unit tests for Importing from $(MSBuildExtensionsPath*)
+    /// </summary>
+    public class ImportFromMSBuildExtensionsPathTests : IDisposable
+    {
+        public void Dispose()
+        {
+            ToolsetConfigurationReaderTestHelper.CleanUp();
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathFound()
+        {
+            CreateAndBuildProjectForImportFromExtensionsPath("MSBuildExtensionsPath", (p, l) => Assert.True(p.Build()));
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathNotFound()
+        {
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), GetExtensionTargetsFileContent1());
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1, Path.Combine("tmp", "nonexistant")));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+
+                Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
+
+                logger.AssertLogContains("MSB4226");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void ConditionalImportFromExtensionsPathNotFound()
+        {
+            string extnTargetsFileContentWithCondition = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FooBar</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\bar\extn2.proj' Condition=""Exists('$(MSBuildExtensionsPath)\bar\extn2.proj')""/>
+                </Project>
+                ";
+
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContentWithCondition);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir1, Path.Combine("tmp", "nonexistant")},
+                                                            null,
+                                                            (p, l) => {
+                                                                Assert.True(p.Build());
+
+                                                                l.AssertLogContains("Running FromExtn");
+                                                                l.AssertLogContains("PropertyFromExtn1: FooBar");
+                                                            });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathCircularImportError()
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\foo\extn2.proj' />
+                </Project>
+                ";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn2'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='{0}'/>
+                </Project>
+                ";
+
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent1);
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn2.proj"),
+                                                            String.Format(extnTargetsFileContent2, mainProjectPath));
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath",
+                                                        new string[] {extnDir2, Path.Combine("tmp", "nonexistant"), extnDir1},
+                                                        null,
+                                                        (p, l) => l.AssertLogContains("MSB4210"));
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathWithWildCard()
+        {
+            string mainTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='Main'>
+                        <Message Text='Running Main'/>
+                    </Target>
+
+                    <Import Project='$(MSBuildExtensionsPath)\foo\*.proj'/>
+                </Project>";
+
+            string extnTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='{0}'>
+                        <Message Text='Running {0}'/>
+                    </Target>
+                </Project>
+                ";
+
+            // Importing should stop at the first extension path where a project file is found
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
+                                String.Format(extnTargetsFileContent, "FromExtn1"));
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"),
+                                String.Format(extnTargetsFileContent, "FromExtn2"));
+
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir1, Path.Combine("tmp", "nonexistant"), extnDir2},
+                                                    null,
+                                                    (p, l) => {
+                                                    Console.WriteLine (l.FullLog);
+                                                    Console.WriteLine ("checking FromExtn1");
+                                                        Assert.True(p.Build("FromExtn1"));
+                                                    Console.WriteLine ("checking FromExtn2");
+                                                        Assert.False(p.Build("FromExtn2"));
+                                                    Console.WriteLine ("checking logcontains");
+                                                        l.AssertLogContains(String.Format(MockLogger.GetString("TargetDoesNotExist"), "FromExtn2"));
+                                                    });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathWithWildCardNothingFound()
+        {
+            string extnTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\non-existant\*.proj'/>
+                </Project>
+                ";
+
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {Path.Combine("tmp", "nonexistant"), extnDir1},
+                                                    null, (p, l) => Assert.True(p.Build()));
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathInvalidFile()
+        {
+            string extnTargetsFileContent = @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >";
+
+            string extnDir1 = null;
+            string mainProjectPath = null;
+
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent);
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", extnDir1,
+                                                                                Path.Combine("tmp", "nonexistant")));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+
+                Assert.Throws<InvalidProjectFileException>(() => projColln.LoadProject(mainProjectPath));
+                logger.AssertLogContains("MSB4025");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathSearchOrder()
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromFirstFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromSecondFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+
+            // File with the same name available in two different extension paths, but the one from the first
+            // directory in MSBuildExtensionsPath environment variable should get loaded
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent1);
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"), extnTargetsFileContent2);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, "MSBuildExtensionsPath", new string[] {extnDir2, Path.Combine("tmp", "nonexistant"), extnDir1},
+                                                            null,
+                                                            (p, l) => {
+                                                                Assert.True(p.Build());
+
+                                                                l.AssertLogContains("Running FromExtn");
+                                                                l.AssertLogContains("PropertyFromExtn1: FromSecondFile");
+                                                            });
+        }
+
+        [Fact]
+        public void ImportFromExtensionsPathSearchOrder2()
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromFirstFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FromSecondFile</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                </Project>
+                ";
+
+            // File with the same name available in two different extension paths, but the one from the first
+            // directory in MSBuildExtensionsPath environment variable should get loaded
+            string extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"), extnTargetsFileContent1);
+            string extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("foo", "extn.proj"), extnTargetsFileContent2);
+            string mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+            // MSBuildExtensionsPath* property value has highest priority for the lookups
+            try {
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader("MSBuildExtensionsPath", Path.Combine("tmp", "non-existstant"), extnDir1));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+                var project = projColln.LoadProject(mainProjectPath);
+
+                project.SetProperty("MSBuildExtensionsPath", extnDir2);
+                project.ReevaluateIfNecessary();
+                Assert.True(project.Build());
+
+                logger.AssertLogContains("Running FromExtn");
+                logger.AssertLogContains("PropertyFromExtn1: FromSecondFile");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+                if (extnDir2 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir2, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public void ImportOrderFromExtensionsPath32()
+        {
+            CreateAndBuildProjectForImportFromExtensionsPath("MSBuildExtensionsPath32", (p, l) => Assert.True(p.Build()));
+        }
+
+        [Fact]
+        public void ImportOrderFromExtensionsPath64()
+        {
+            CreateAndBuildProjectForImportFromExtensionsPath("MSBuildExtensionsPath64", (p, l) => Assert.True(p.Build()));
+        }
+
+        // Use MSBuildExtensionsPath, MSBuildExtensionsPath32 and MSBuildExtensionsPath64 in the build
+        [Fact]
+        public void ImportFromExtensionsPathAnd32And64()
+        {
+            string extnTargetsFileContentTemplate = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='FromExtn{0}' DependsOnTargets='{1}'>
+                        <Message Text='Running FromExtn{0}'/>
+                    </Target>
+                    {2}
+                </Project>
+                ";
+
+            string v2Folder = NativeMethodsShared.IsWindows
+                                  ? @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret"
+                                  : Path.Combine(NativeMethodsShared.FrameworkBasePath, "2.0");
+
+            string v4Folder = NativeMethodsShared.IsWindows
+                                  ? @"D:\windows\Microsoft.NET\Framework\v4.0.x86ret"
+                                  : Path.Combine(NativeMethodsShared.FrameworkBasePath, "4.0");
+
+            var configFileContents = @"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""14.1"">
+                     <toolset toolsVersion=""14.1"">
+                       <property name=""MSBuildToolsPath"" value="".""/>
+                       <property name=""MSBuildBinPath"" value=""" + /*v4Folder*/"." + @"""/>
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""osx"">
+                           <property name=""MSBuildExtensionsPath"" value=""{0}"" />
+                           <property name=""MSBuildExtensionsPath32"" value=""{1}"" />
+                           <property name=""MSBuildExtensionsPath64"" value=""{2}"" />
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                      </toolset>
+                   </msbuildToolsets>
+                 </configuration>";
+
+            string extnDir1 = null, extnDir2 = null, extnDir3 = null;
+            string mainProjectPath = null;
+
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
+                                String.Format(extnTargetsFileContentTemplate, String.Empty, "FromExtn2", "<Import Project='$(MSBuildExtensionsPath32)\\bar\\extn2.proj' />"));
+                extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("bar", "extn2.proj"),
+                                String.Format(extnTargetsFileContentTemplate, 2, "FromExtn3", "<Import Project='$(MSBuildExtensionsPath64)\\xyz\\extn3.proj' />"));
+                extnDir3 = GetNewExtensionsPathAndCreateFile("extensions3", Path.Combine("xyz", "extn3.proj"),
+                                String.Format(extnTargetsFileContentTemplate, 3, String.Empty, String.Empty));
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent());
+
+                var configFilePath = ToolsetConfigurationReaderTestHelper.WriteConfigFile(String.Format(configFileContents, extnDir1, extnDir2, extnDir3));
+                var reader = GetStandardConfigurationReader();
+
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(reader);
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+
+                var project = projColln.LoadProject(mainProjectPath);
+                Assert.True(project.Build("Main"));
+                logger.AssertLogContains("Running FromExtn3");
+                logger.AssertLogContains("Running FromExtn2");
+                logger.AssertLogContains("Running FromExtn");
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+                if (extnDir2 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir2, recursive: true);
+                }
+                if (extnDir3 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir3, recursive: true);
+                }
+            }
+        }
+
+        void CreateAndBuildProjectForImportFromExtensionsPath(string extnPathPropertyName, Action<Project, MockLogger> action)
+        {
+            string extnDir1 = null, extnDir2 = null, mainProjectPath = null;
+            try {
+                extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
+                                    GetExtensionTargetsFileContent1(extnPathPropertyName));
+                extnDir2 = GetNewExtensionsPathAndCreateFile("extensions2", Path.Combine("bar", "extn2.proj"),
+                                    GetExtensionTargetsFileContent2(extnPathPropertyName));
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", GetMainTargetFileContent(extnPathPropertyName));
+
+                CreateAndBuildProjectForImportFromExtensionsPath(mainProjectPath, extnPathPropertyName, new string[] {extnDir1, extnDir2},
+                                                                null,
+                                                                action);
+            } finally {
+                if (extnDir1 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir1, recursive: true);
+                }
+                if (extnDir2 != null)
+                {
+                    FileUtilities.DeleteDirectoryNoThrow(extnDir2, recursive: true);
+                }
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+            }
+        }
+
+        void CreateAndBuildProjectForImportFromExtensionsPath(string mainProjectPath, string extnPathPropertyName, string[] extnDirs, Action<string[]> setExtensionsPath,
+                Action<Project, MockLogger> action)
+        {
+            try {
+                var projColln = new ProjectCollection();
+                projColln.ResetToolsetsForTests(WriteConfigFileAndGetReader(extnPathPropertyName, extnDirs));
+                var logger = new MockLogger();
+                projColln.RegisterLogger(logger);
+                var project = projColln.LoadProject(mainProjectPath);
+
+                action(project, logger);
+            } finally {
+                if (mainProjectPath != null)
+                {
+                    FileUtilities.DeleteNoThrow(mainProjectPath);
+                }
+
+                if (extnDirs != null)
+                {
+                    foreach (var extnDir in extnDirs)
+                    {
+                        FileUtilities.DeleteDirectoryNoThrow(extnDir, recursive: true);
+                    }
+                }
+            }
+        }
+
+        private ToolsetConfigurationReader WriteConfigFileAndGetReader(string extnPathPropertyName, params string[] extnDirs)
+        {
+            string combinedExtnDirs = extnDirs != null ? String.Join(";", extnDirs) : String.Empty;
+
+            var configFilePath = ToolsetConfigurationReaderTestHelper.WriteConfigFile(@"
+                 <configuration>
+                   <configSections>
+                     <section name=""msbuildToolsets"" type=""Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build"" />
+                   </configSections>
+                   <msbuildToolsets default=""14.1"">
+                     <toolset toolsVersion=""14.1"">
+                       <property name=""MSBuildToolsPath"" value=""."" />
+                       <property name=""MSBuildBinPath"" value=""."" />
+                       <msbuildExtensionsPathSearchPaths>
+                         <searchPaths os=""osx"">
+                           <property name=""" + extnPathPropertyName + @""" value=""" + combinedExtnDirs + @""" />
+                         </searchPaths>
+                       </msbuildExtensionsPathSearchPaths>
+                      </toolset>
+                   </msbuildToolsets>
+                 </configuration>");
+
+            return GetStandardConfigurationReader();
+        }
+
+        string GetNewExtensionsPathAndCreateFile(string extnDirName, string relativeFilePath, string fileContents)
+        {
+            var extnDir = Path.Combine(Path.GetTempPath(), extnDirName);
+            Directory.CreateDirectory(Path.Combine(extnDir, Path.GetDirectoryName(relativeFilePath)));
+            File.WriteAllText(Path.Combine(extnDir, relativeFilePath), fileContents);
+
+            return extnDir;
+        }
+
+        string GetMainTargetFileContent(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        {
+            string mainTargetsFileContent = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <Target Name='Main' DependsOnTargets='FromExtn'>
+                        <Message Text='PropertyFromExtn1: $(PropertyFromExtn1)'/>
+                    </Target>
+
+                    <Import Project='$({0})\foo\extn.proj'/>
+                </Project>";
+
+            return String.Format(mainTargetsFileContent, extensionsPathPropertyName);
+        }
+
+        string GetExtensionTargetsFileContent1(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        {
+            string extnTargetsFileContent1 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn1>FooBar</PropertyFromExtn1>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn'>
+                        <Message Text='Running FromExtn'/>
+                    </Target>
+                    <Import Project='$({0})\bar\extn2.proj'/>
+                </Project>
+                ";
+
+            return String.Format(extnTargetsFileContent1, extensionsPathPropertyName);
+        }
+
+        string GetExtensionTargetsFileContent2(string extensionsPathPropertyName="MSBuildExtensionsPath")
+        {
+            string extnTargetsFileContent2 = @"
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
+                    <PropertyGroup>
+                        <PropertyFromExtn2>Abc</PropertyFromExtn2>
+                    </PropertyGroup>
+
+                    <Target Name='FromExtn2'>
+                        <Message Text='Running FromExtn2'/>
+                    </Target>
+                </Project>
+                ";
+
+            return extnTargetsFileContent2;
+        }
+
+        private ToolsetConfigurationReader GetStandardConfigurationReader()
+        {
+            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
+                ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+        }
+    }
+}
+#endif

--- a/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/XMakeBuildEngine/UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Evaluation\Evaluator_Tests.cs" />
     <Compile Include="Evaluation\Expander_Tests.cs" />
     <Compile Include="Evaluation\ExpressionShredder_Tests.cs" />
+    <Compile Include="Evaluation\ImportFromMSBuildExtensionsPath_Tests.cs" />
     <Compile Include="Evaluation\Preprocessor_Tests.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache_Tests.cs" />
     <Compile Include="Evaluation\ProjectStringCache_Tests.cs" />

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -46,6 +46,13 @@
       </toolset>
       <toolset toolsVersion="4.0">
         <property name="MSBuildToolsPath" value="." />
+        <msbuildExtensionsPathSearchPaths>
+            <searchPaths os="osx">
+                <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+                <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+                <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            </searchPaths>
+        </msbuildExtensionsPathSearchPaths>
       </toolset>
     </msbuildToolsets>
   </configuration>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -37,6 +37,30 @@
     <msbuildToolsets default="15.1">
       <toolset toolsVersion="15.1">
         <property name="MSBuildToolsPath" value="." />
+        <property name="MSBuildToolsPath32" value="." />
+        <!--<property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A@InstallationFolder)" />-->
+        <property name="MSBuildRuntimeVersion" value="4.0.30319" />
+        <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
+        <property name="SDK35ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A\WinSDK-NetFx35Tools-x86@InstallationFolder)" />
+        <property name="SDK40ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A\WinSDK-NetFx40Tools-x86@InstallationFolder)" />
+
+        <!-- TODO: hacks (remove ..\ )-->
+        <property name="VSInstallRoot" value="$(MSBuildToolsPath)\..\..\.." />
+        <property name="MSBuildToolsRoot" value="$(VSInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath" value="$(VSInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath32" value="$(VSInstallRoot)\MSBuild" />
+        <property name="VCTargetsPath" value="$(VSInstallRoot)\Common7\IDE\VC\VCTargets" />
+        <property name="FrameworkSDKRoot" value="$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\" />
+
+        <msbuildExtensionsPathSearchPaths>
+          <searchPaths os="windows">
+            <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+          </searchPaths>
+        </msbuildExtensionsPathSearchPaths>
       </toolset>
       <toolset toolsVersion="14.0">
         <property name="MSBuildToolsPath" value="." />


### PR DESCRIPTION
Port of #478 (thanks @radical !) to master.

Tried to do minimal changes (merge conflicts + `#if` code that doesn't apply to master).

The goal here is to experiment shipping MSBuild out of the GAC / Registry / Program Files under Visual Studio. This would mean an `Import` to targets under `Program Files` would try under the MSBuild folder first then fallback.

Related to #558