### PR TITLE
Fix regression in use of PipeSecurity

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -239,7 +239,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PERFORMANCE_COUNTERS</DefineConstants>
-    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PFX_SIGNING</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REFLECTION_EMIT_DEBUG_INFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REGISTRY_TOOLSETS</DefineConstants>

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -17,7 +17,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using System.Security;
-#if FEATURE_SECURITY_PERMISSIONS
+#if FEATURE_SECURITY_PERMISSIONS || FEATURE_PIPE_SECURITY
 using System.Security.AccessControl;
 #endif
 using System.Security.Principal;

--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Build.BackEnd
         private void ValidateRemotePipeSecurityOnWindows(NamedPipeClientStream nodeStream)
         {
             SecurityIdentifier identifier = WindowsIdentity.GetCurrent().Owner;
-#if !FEATURE_PIPE_SECURITY
+#if FEATURE_PIPE_SECURITY
             PipeSecurity remoteSecurity = nodeStream.GetAccessControl();
 #else
             var remoteSecurity = new PipeSecurity(nodeStream.SafePipeHandle, System.Security.AccessControl.AccessControlSections.Access |


### PR DESCRIPTION
- commit 583a73e21ac36093e285d473eefec701d9f60d5f was incorrect,
  see https://github.com/Microsoft/msbuild/pull/560#discussion_r59051335

  Essentially, FEATURE_PIPE_SECURITY means that `PipeSecurity` is
  available in the framework. Revert the earlier fix.

- this patch also enables FEATURE_PIPE_SECURITY for mono builds

- Fixes windows build broken by the regression