### PR TITLE
Add intrinsic property function `IsOSPlatform(string os)`

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -364,6 +364,17 @@ namespace Microsoft.Build.Evaluation
             return false;
         }
 
+        internal static bool IsOSPlatform(string os)
+        {
+            switch (os.ToLower())
+            {
+                case "windows": return NativeMethodsShared.IsWindows;
+                case "osx": return NativeMethodsShared.IsOSX;
+                case "unix": return NativeMethodsShared.IsUnixLike;
+                default: return false;
+            }
+        }
+
         #region Debug only intrinsics
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Evaluation/Expander_Tests.cs
@@ -2826,6 +2826,36 @@ namespace Microsoft.Build.UnitTests.Evaluation
             Assert.Equal((~-43).ToString(), result);
         }
 
+        private void CheckOSPlatform(Func<string, bool> isOSPlatform, bool isWindows, bool isOSX, bool isUnix)
+        {
+            Assert.Equal(isWindows, isOSPlatform("Windows"));
+            Assert.Equal(isOSX, isOSPlatform("OSX"));
+            Assert.Equal(isUnix, isOSPlatform("Unix"));
+        }
+
+        [Fact]
+        public void PropertyFunctionStaticMethodIntrinsicIsOSPlatform()
+        {
+            PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+
+            Func<string, bool> isOSPlatform = os => bool.Parse(expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::IsOSPlatform(" + os + "))",
+                                                                 ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
+
+            if (NativeMethodsShared.IsWindows)
+            {
+                CheckOSPlatform(isOSPlatform, isWindows:true, isOSX:false, isUnix:false);
+            }
+            else if (NativeMethodsShared.IsOSX)
+            {
+                CheckOSPlatform(isOSPlatform, isWindows:false, isOSX:true, isUnix:true);
+            }
+            else
+            {
+                CheckOSPlatform(isOSPlatform, isWindows:false, isOSX:false, isUnix:true);
+            }
+        }
+
         /// <summary>
         /// Expand a property reference that has whitespace around the property name (should result in empty)
         /// </summary>


### PR DESCRIPTION
Usage:
    $([MSBuild]::IsOSPlatform(Windows))

Based on @dsplaisted's suggestion in issue #539 .