### PR TITLE
cibuild.sh: Use new version of mono_msbuild_bootstrap* for mono builds.

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -30,7 +30,7 @@ downloadMSBuildForMono()
         curl -sL -o $MSBUILD_ZIP "$MSBUILD_DOWNLOAD_URL"
 
         unzip -q $MSBUILD_ZIP -d $PACKAGES_DIR
-        find "$PACKAGES_DIR/mono-msbuild/bin/Unix/Debug-MONO" -name "*.exe" -exec chmod "+x" '{}' ';'
+        find "$PACKAGES_DIR/msbuild" -name "*.exe" -exec chmod "+x" '{}' ';'
         rm $MSBUILD_ZIP
     fi
 }
@@ -57,7 +57,7 @@ setMonoDir(){
 THIS_SCRIPT_PATH="`dirname \"$0\"`"
 PACKAGES_DIR="$THIS_SCRIPT_PATH/packages"
 TOOLS_DIR="$THIS_SCRIPT_PATH/Tools"
-MSBUILD_DOWNLOAD_URL="https://github.com/Microsoft/msbuild/releases/download/mono-hosted-msbuild-v0.1/mono-msbuild.zip"
+MSBUILD_DOWNLOAD_URL="https://github.com/Microsoft/msbuild/releases/download/mono-hosted-msbuild-v0.2/mono_msbuild_bootstrap_5e01f07.zip"
 MSBUILD_ZIP="$PACKAGES_DIR/msbuild.zip"
 HOME_DEFAULT="/tmp/msbuild-CI-home"
 
@@ -154,7 +154,7 @@ case $host in
     Mono)
         setMonoDir
         RUNTIME_HOST="${MONO_BIN_DIR}mono"
-        MSBUILD_EXE="$PACKAGES_DIR/mono-msbuild/bin/Unix/Debug-MONO/MSBuild.exe"
+        MSBUILD_EXE="$PACKAGES_DIR/msbuild/MSBuild.exe"
 
         downloadMSBuildForMono
         ;;


### PR DESCRIPTION
This fixes build with mono >= 4.4.x