### PR TITLE
Read toolsets from msbuild.exe.config file when in VS

### DIFF
--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -294,6 +294,15 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private static Configuration ReadApplicationConfiguration()
         {
+            var msbuildExeConfig = FileUtilities.CurrentExecutableConfigurationFilePath;
+
+            // When running in VS, try to open MSBuild.exe.config first (if it exists)
+            if (FileUtilities.RunningInVisualStudio && File.Exists(msbuildExeConfig))
+            {
+                var configFile = new ExeConfigurationFileMap { ExeConfigFilename = msbuildExeConfig };
+                return ConfigurationManager.OpenMappedExeConfiguration(configFile, ConfigurationUserLevel.None);
+            }
+
             return ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
         }
     }


### PR DESCRIPTION
 - When we're in devenv process, read the config file from msbuild rather
   than devenv.exe.config.
 - Fixed a bug with the running tests check. Previously this value was
   always true.