### PR TITLE
Simplify FindMSBuildExe using FileUtilities logic

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/XMakeBuildEngine/BackEnd/BuildManager/BuildParameters.cs
@@ -956,7 +956,7 @@ namespace Microsoft.Build.Execution
                 _detailedSummary = true;
             }
 
-            FindMSBuildExe();
+            _nodeExeLocation = FindMSBuildExe();
         }
 
         /// <summary>
@@ -975,30 +975,22 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// This method determines where MSBuild.Exe is and sets the NodeExePath to that by default.
         /// </summary>
-        private void FindMSBuildExe()
+        private string FindMSBuildExe()
         {
+            string location = _nodeExeLocation;
+
             // Use the location specified by the user in code.
-            if (_nodeExeLocation != null && CheckMSBuildExeExistsAt(_nodeExeLocation))
+            if (!string.IsNullOrEmpty(location) && CheckMSBuildExeExistsAt(location))
             {
-                return;
+                return location;
             }
 
-            // Use the location specified in the environment.
-            // MSBUILD_EXE_PATH optionally contains the full path to msbuild.exe, and if present
-            // overrides the rest
-            string path = Environment.GetEnvironmentVariable("MSBUILD_EXE_PATH");
-            if (path != null && CheckMSBuildExeExistsAt(path))
-            {
-                _nodeExeLocation = path;
-                return;
-            }
+            // Try what we think is the current executable path.
+            location = FileUtilities.CurrentExecutablePath;
 
-            // Use the default location of the directory from which the engine was loaded.
-            path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "MSBuild.exe");
-            if (path != null && CheckMSBuildExeExistsAt(path))
+            if (CheckMSBuildExeExistsAt(location))
             {
-                _nodeExeLocation = path;
-                return;
+                return location;
             }
 
             // Get the location pointed to by the MSBuildToolsPath in the "current" ToolsVersion 
@@ -1007,56 +999,16 @@ namespace Microsoft.Build.Execution
             EnsureToolsets();
             Toolset currentToolset = _toolsetProvider.GetToolset(MSBuildConstants.CurrentToolsVersion);
 
-            if (currentToolset != null)
+            if (currentToolset != null && !string.IsNullOrEmpty(currentToolset.ToolsPath))
             {
-                path = Path.Combine(currentToolset.ToolsPath, "MSBuild.exe");
-                if (path != null && CheckMSBuildExeExistsAt(path))
+                location = Path.Combine(currentToolset.ToolsPath, "MSBuild.exe");
+                if (CheckMSBuildExeExistsAt(location))
                 {
-                    _nodeExeLocation = path;
-                    return;
+                    return location;
                 }
             }
 
-            // Search in the location of any assemblies we have loaded.
-            foreach (System.Reflection.Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (!assembly.IsDynamic)
-                {
-                    try
-                    {
-                        path = Path.GetDirectoryName(assembly.Location);
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ExceptionHandling.IsCriticalException(ex))
-                        {
-                            throw;
-                        }
-
-                        // In some circumstances, assembly.Location throws NotSupportedException (ex. when 
-                        // it's an anonymous dynamic assembly -- which we're already protecting against, but 
-                        // there could be other examples we don't know of). If there's an error here, we really don't 
-                        // care -- it's just one fewer place we can look for the path to MSBuild.exe.  So 
-                        // just continue. 
-                        continue;
-                    }
-
-                    if (CheckMSBuildExeExistsAt(Path.Combine(path, "MSBuild.exe")))
-                    {
-                        _nodeExeLocation = Path.Combine(path, "MSBuild.exe");
-                        return;
-                    }
-                }
-            }
-
-            // Search in the framework directory.  Checks the COMPLUS_INSTALL_ROOT among other things.
-            path = FrameworkLocationHelper.PathToDotNetFrameworkV40;
-            if (path != null && CheckMSBuildExeExistsAt(Path.Combine(path, "MSBuild.exe")))
-            {
-                _nodeExeLocation = Path.Combine(path, "MSBuild.exe");
-            }
-
-            // Well, we just can't find it.  Maybe they will only build in-proc and won't need it...
+            return location;
         }
 
         /// <summary>
@@ -1067,7 +1019,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private bool CheckMSBuildExeExistsAt(string path)
         {
-            if (s_msbuildExeKnownToExistAt != null && String.Equals(path, s_msbuildExeKnownToExistAt, StringComparison.OrdinalIgnoreCase))
+            if (s_msbuildExeKnownToExistAt != null && string.Equals(path, s_msbuildExeKnownToExistAt, StringComparison.OrdinalIgnoreCase))
             {
                 // We found it there last time: it must exist there.
                 return true;


### PR DESCRIPTION
 - Remove final fall-back that will point to MSBuild in the Framework
   directory.
 - Remove checking loaded assembly locations as framework assemblies (e.g.
   mscorlib) are located next to MSBuild v4.

In both of these cases, finding/running MSBuild.exe from the framework
directory (MSBuild v4) will cause issues.