### PR TITLE
Add PublicKeyToken to msbuildToolsets in app.config

### DIFF
--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -1,8 +1,7 @@
 ﻿<?xml version ="1.0"?>
 <configuration>
   <configSections>
-    <!-- Microsoft.Build.Engine instead of Microsoft.Build here because a task run under Microsoft.Build may load Microsoft.Build.Engine, which will attempt to read this section. -->
-    <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral" />
+    <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </configSections>
   <startup useLegacyV2RuntimeActivationPolicy="true">
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
   <configuration>
     <configSections>
-      <!-- Microsoft.Build.Engine instead of Microsoft.Build here because a task run under Microsoft.Build may load Microsoft.Build.Engine, which will attempt to read this section. -->
-      <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral" />
+      <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     </configSections>
     <startup useLegacyV2RuntimeActivationPolicy="true">
       <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />


### PR DESCRIPTION
Think it didn't have it in there when we weren't using the OSS signing and had no public key. Adding it back as it was causing some issues in VS not playing nice with binding redirects.

Also removed the comment that it should use Microsoft.Build.Engine since we're no longer compatible with Microsoft.Build.Engine anyway.