### PR TITLE
Update pkgdef to add binding redirection

### DIFF
--- a/src/Framework/Microsoft.Build.Framework.pkgdef
+++ b/src/Framework/Microsoft.Build.Framework.pkgdef
@@ -1,6 +1,7 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{604B5E67-4DE2-41A7-AA00-AC65BE513FED}]
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{604B5E67-4DE2-41A7-AA00-AC65BE513FED}]
 "name"="Microsoft.Build.Framework"
 "codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.Framework.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
-"version"="15.1.0.0"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="15.1.0.0"

--- a/src/Utilities/Microsoft.Build.Utilities.Core.pkgdef
+++ b/src/Utilities/Microsoft.Build.Utilities.Core.pkgdef
@@ -1,6 +1,7 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{CCA70AFE-5E92-4B5E-940D-FAE11D564E72}]
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{CCA70AFE-5E92-4B5E-940D-FAE11D564E72}]
 "name"="Microsoft.Build.Utilities.Core"
 "codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.Utilities.Core.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
-"version"="15.1.0.0"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="15.1.0.0"

--- a/src/XMakeBuildEngine/Microsoft.Build.pkgdef
+++ b/src/XMakeBuildEngine/Microsoft.Build.pkgdef
@@ -1,6 +1,7 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{0B54AF09-CDE4-40FD-9850-FFFED6E13680}]
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{0B54AF09-CDE4-40FD-9850-FFFED6E13680}]
 "name"="Microsoft.Build"
 "codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
-"version"="15.1.0.0"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="15.1.0.0"

--- a/src/XMakeTasks/Microsoft.Build.Tasks.Core.pkgdef
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.Core.pkgdef
@@ -1,6 +1,7 @@
-[$RootKey$\RuntimeConfiguration\dependentAssembly\codeBase\{5BDA9EB8-561A-405C-A482-2CD328059DEA}]
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{5BDA9EB8-561A-405C-A482-2CD328059DEA}]
 "name"="Microsoft.Build.Tasks.Core"
 "codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.Tasks.Core.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
-"version"="15.1.0.0"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="15.1.0.0"


### PR DESCRIPTION
This change will tell Visual Studio where to find MSBuild as well as
providing a binding redirect in devenv.exe.config.