### PR TITLE
Toolset Translation Bug Fix

### DIFF
--- a/src/Shared/INodePacketTranslator.cs
+++ b/src/Shared/INodePacketTranslator.cs
@@ -291,6 +291,13 @@ namespace Microsoft.Build.BackEnd
             where T : class, INodePacketTranslatable;
 
         /// <summary>
+        /// Translates a dictionary of type { string, List {string} }
+        /// </summary>
+        /// <param name="dictionary">The dictionary to be translated.</param>
+        /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
+        void TranslateDictionaryList(ref Dictionary<string, List<string>> dictionary, IEqualityComparer<string> comparer);
+
+        /// <summary>
         /// Translates the boolean that says whether this value is null or not
         /// </summary>
         /// <param name="value">The object to test.</param>

--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -472,6 +472,32 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
+
+            /// <summary>
+            /// Translates a dictionary of type { string, List {string} }
+            /// </summary>
+            /// <param name="dictionary">The dictionary to be translated.</param>
+            /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
+            public void TranslateDictionaryList(ref Dictionary<string, List<string>> dictionary, IEqualityComparer<string> comparer)
+            {
+                if (!TranslateNullable(dictionary))
+                {
+                    return;
+                }
+
+                int count = _reader.ReadInt32();
+                dictionary = new Dictionary<string, List<string>>(count, comparer);
+
+                for (int i = 0; i < count; i++)
+                {
+                    string key = null;
+                    Translate(ref key);
+                    List<string> value = null;
+                    Translate(ref value);
+                    dictionary[key] = value;
+                }
+            }
+
             /// <summary>
             /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
             /// </summary>
@@ -947,6 +973,30 @@ namespace Microsoft.Build.BackEnd
                     Translate(ref key);
                     T value = pair.Value;
                     Translate(ref value, valueFactory);
+                }
+            }
+
+            /// <summary>
+            /// Translates a dictionary of type { string, List {string} }
+            /// </summary>
+            /// <param name="dictionary">The dictionary to be translated.</param>
+            /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
+            public void TranslateDictionaryList(ref Dictionary<string, List<string>> dictionary, IEqualityComparer<string> comparer)
+            {
+                if (!TranslateNullable(dictionary))
+                {
+                    return;
+                }
+
+                int count = dictionary.Count;
+                _writer.Write(count);
+
+                foreach (KeyValuePair<string, List<string>> pair in dictionary)
+                {
+                    string key = pair.Key;
+                    Translate(ref key);
+                    List<string> value = pair.Value;
+                    Translate(ref value);
                 }
             }
 

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -205,6 +205,11 @@ namespace Microsoft.Build.Evaluation
         private string _defaultSubToolsetVersion;
 
         /// <summary>
+        /// Map of MSBuildExtensionsPath properties to their list of fallback search paths
+        /// </summary>
+        private Dictionary<string, List<string>> _msBuildSearchPathsTable;
+
+        /// <summary>
         /// Constructor taking only tools version and a matching tools path
         /// </summary>
         /// <param name="toolsVersion">Name of the toolset</param>
@@ -349,17 +354,21 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Returns a copy of the list of search paths for a MSBuildExtensionsPath* property kind.
+        /// Returns a copy of the list of search paths for a MSBuildExtensionsPath* property.
+        /// <returns>List of search paths, else null</returns>
         /// </summary>
-        internal IList<string> GetMSBuildExtensionsPathSearchPathsFor(MSBuildExtensionsPathReferenceKind refKind)
+        internal List<string> GetMSBuildExtensionsPathSearchPathsFor(string refKind)
         {
-            IList<string> paths;
+            if (string.IsNullOrEmpty(refKind))
+                return null;
+
+            List<string> paths;
             if (MSBuildExtensionsPathSearchPathsTable != null && MSBuildExtensionsPathSearchPathsTable.TryGetValue(refKind, out paths))
             {
                 return new List<string>(paths);
             }
 
-            return new List<string>();
+            return null;
         }
 
         /// <summary>
@@ -573,9 +582,10 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Map of MSBuildExtensionsPath properties to their list of fallback search paths
         /// </summary>
-        internal Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> MSBuildExtensionsPathSearchPathsTable
+        internal Dictionary<string, List<string>> MSBuildExtensionsPathSearchPathsTable
         {
-            get; set;
+            get { return _msBuildSearchPathsTable; }
+            set { _msBuildSearchPathsTable = value; }
         }
 
         /// <summary>
@@ -591,6 +601,12 @@ namespace Microsoft.Build.Evaluation
             translator.TranslateDictionary(ref _subToolsets, StringComparer.OrdinalIgnoreCase, SubToolset.FactoryForDeserialization);
             translator.Translate(ref _overrideTasksPath);
             translator.Translate(ref _defaultOverrideToolsVersion);
+            translator.TranslateDictionaryList(ref _msBuildSearchPathsTable, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private void ListTranslate(List<string> list, INodePacketTranslator translator)
+        {
+            translator.Translate(ref list);
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -296,13 +296,14 @@ namespace Microsoft.Build.Evaluation
         {
             var msbuildExeConfig = FileUtilities.CurrentExecutableConfigurationFilePath;
 
-            // When running in VS, try to open MSBuild.exe.config first (if it exists)
-            if (FileUtilities.RunningInVisualStudio && File.Exists(msbuildExeConfig))
+            // When running from the command-line or from VS, use the msbuild.exe.config file
+            if (!FileUtilities.RunningTests && File.Exists(msbuildExeConfig))
             {
                 var configFile = new ExeConfigurationFileMap { ExeConfigFilename = msbuildExeConfig };
                 return ConfigurationManager.OpenMappedExeConfiguration(configFile, ConfigurationUserLevel.None);
             }
 
+            // When running tests or the expected config file doesn't exist, fall-back to default
             return ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
         }
     }

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
         /// </summary>
-        protected abstract Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os);
+        protected abstract Dictionary<string, List<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os);
 
         /// <summary>
         /// Reads all the toolsets and populates the given ToolsetCollection with them
@@ -642,7 +642,6 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal struct MSBuildExtensionsPathReferenceKind
     {
-
         /// <summary>
         /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath"
         /// </summary>
@@ -671,7 +670,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
         /// </summary>
-        public string StringRepresentation { get; private set; }
+        public string StringRepresentation { get; }
 
         /// <summary>
         /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
@@ -683,22 +682,22 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public static MSBuildExtensionsPathReferenceKind FindIn(string expression)
         {
-            if (expression.IndexOf("$(MSBuildExtensionsPath)") >= 0)
+            if (expression.IndexOf(Default.MSBuildPropertyName, StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                return MSBuildExtensionsPathReferenceKind.Default;
+                return Default;
             }
 
-            if (expression.IndexOf("$(MSBuildExtensionsPath32)") >= 0)
+            if (expression.IndexOf(Path32.MSBuildPropertyName, StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                return MSBuildExtensionsPathReferenceKind.Path32;
+                return Path32;
             }
 
-            if (expression.IndexOf("$(MSBuildExtensionsPath64)") >= 0)
+            if (expression.IndexOf(Path64.MSBuildPropertyName, StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                return MSBuildExtensionsPathReferenceKind.Path64;
+                return Path64;
             }
 
-            return MSBuildExtensionsPathReferenceKind.None;
+            return None;
         }
      }
 }

--- a/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
@@ -292,9 +292,9 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
         /// </summary>
-        protected override Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        protected override Dictionary<string, List<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
         {
-            return new Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>>();
+            return new Dictionary<string, List<string>>();
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -566,13 +566,13 @@ namespace Microsoft.Build.UnitTests.Definition
             string defaultOverrideToolsVersion = null;
             string defaultToolsVersion = reader.ReadToolsets(toolsets, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
 
-            Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable = toolsets["2.0"].MSBuildExtensionsPathSearchPathsTable;
+            Dictionary<string, List<string>> pathsTable = toolsets["2.0"].MSBuildExtensionsPathSearchPathsTable;
 #if XPLAT
             if (NativeMethodsShared.IsWindows)
 #endif
             {
-                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"c:\\foo"});
-                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path64, new string[] {"c:\\foo64", "c:\\bar64"});
+                CheckPathsTable(pathsTable, "MSBuildExtensionsPath", new string[] {"c:\\foo"});
+                CheckPathsTable(pathsTable, "MSBuildExtensionsPath64", new string[] {"c:\\foo64", "c:\\bar64"});
             }
 #if XPLAT
             else if (NativeMethodsShared.IsOSX)
@@ -587,7 +587,7 @@ namespace Microsoft.Build.UnitTests.Definition
 #endif
         }
 
-        private void CheckPathsTable(Dictionary<MSBuildExtensionsPathReferenceKind, IList<string>> pathsTable, MSBuildExtensionsPathReferenceKind kind, string[] expectedPaths)
+        private void CheckPathsTable(Dictionary<string, List<string>> pathsTable, string kind, string[] expectedPaths)
         {
             Assert.True(pathsTable.ContainsKey(kind));
             var paths = pathsTable[kind];

--- a/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
@@ -95,6 +95,10 @@ namespace Microsoft.Build.UnitTests.Definition
             subToolsets.Add("dogfood", new SubToolset("dogfood", subToolsetProperties));
 
             Toolset t = new Toolset("4.0", "c:\\bar", buildProperties, environmentProperties, globalProperties, subToolsets, "c:\\foo", "4.0");
+            t.MSBuildExtensionsPathSearchPathsTable = new Dictionary<string, List<string>>
+            {
+                ["MSBuildExtensionsPath"] = new List<string> {@"c:\foo"}
+            };
 
             ((INodePacketTranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
             Toolset t2 = Toolset.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -135,6 +139,10 @@ namespace Microsoft.Build.UnitTests.Definition
             }
 
             Assert.Equal(t.DefaultOverrideToolsVersion, t2.DefaultOverrideToolsVersion);
+
+            Assert.NotNull(t2.MSBuildExtensionsPathSearchPathsTable);
+            Assert.Equal(1, t2.MSBuildExtensionsPathSearchPathsTable.Count);
+            Assert.Equal(@"c:\foo", t2.GetMSBuildExtensionsPathSearchPathsFor("MSBuildExtensionsPath")[0]);
         }
 
         [Fact]


### PR DESCRIPTION
Quick fix for a bug I found in the fallback search paths. We can revisit the implementation, but I need to get this in to continue testing.

Basically converted the type to Dictionary<string, List<string>> since translation for those types already existed (added a simplified Dictionary translate method). I also added to the Toolset translation test functionality to include the fallback paths.