### PR TITLE
Make the extensions path search/fallback generic.

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Build.Shared
         internal static int MAX_PATH = 260;
 
         /// <summary>
-        /// OS name that can be used for the msbuildExtensionsPathSearchPaths element
+        /// OS name that can be used for the projectImportSearchPaths element
         /// for a toolset
         /// </summary>
         internal static string GetOSNameForExtensionsPath()

--- a/src/Shared/ToolsetElement.cs
+++ b/src/Shared/ToolsetElement.cs
@@ -150,14 +150,14 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Collection of all the search paths for MSBuildExtensionsPath*, per OS
+        /// Collection of all the search paths for project imports, per OS
         /// </summary>
-        [ConfigurationProperty("msbuildExtensionsPathSearchPaths")]
-        public ExtensionsPathsElementCollection AllMSBuildExtensionPathsSearchPaths
+        [ConfigurationProperty("projectImportSearchPaths")]
+        public ExtensionsPathsElementCollection AllProjectImportSearchPaths
         {
             get
             {
-                return (ExtensionsPathsElementCollection)base["msbuildExtensionsPathSearchPaths"];
+                return (ExtensionsPathsElementCollection)base["projectImportSearchPaths"];
             }
         }
 

--- a/src/XMakeBuildEngine/Definition/ProjectImportPathMatch.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectImportPathMatch.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Struct representing a reference to a project import path with property fall-back
+    /// </summary>
+    internal struct ProjectImportPathMatch
+    {
+        /// <summary>
+        /// ProjectImportPathMatch instance representing no fall-back
+        /// </summary>
+        public static readonly ProjectImportPathMatch None = new ProjectImportPathMatch(string.Empty, new List<string>());
+
+        internal ProjectImportPathMatch(string propertyName, IEnumerable<string> searchPaths)
+        {
+            PropertyName = propertyName;
+            SearchPaths = searchPaths;
+            MsBuildPropertyFormat = $"$({PropertyName})";
+        }
+
+        /// <summary>
+        /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
+        /// </summary>
+        public string PropertyName { get; }
+
+        /// <summary>
+        /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
+        /// </summary>
+        public string MsBuildPropertyFormat { get; }
+
+        /// <summary>
+        /// Enumeration of the search paths for the property.
+        /// </summary>
+        public IEnumerable<string> SearchPaths { get; }
+    }
+}

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Build.Evaluation
         private DirectoryGetFiles _getFiles;
 
         /// <summary>
-        /// Delegate to check to see if a direcotry exists
+        /// Delegate to check to see if a directory exists
         /// </summary>
         private DirectoryExists _directoryExists = null;
 
@@ -205,9 +205,9 @@ namespace Microsoft.Build.Evaluation
         private string _defaultSubToolsetVersion;
 
         /// <summary>
-        /// Map of MSBuildExtensionsPath properties to their list of fallback search paths
+        /// Map of project import properties to their list of fall-back search paths
         /// </summary>
-        private Dictionary<string, List<string>> _msBuildSearchPathsTable;
+        private Dictionary<string, List<string>> _propertySearchPathsTable;
 
         /// <summary>
         /// Constructor taking only tools version and a matching tools path
@@ -278,6 +278,7 @@ namespace Microsoft.Build.Evaluation
             _environmentProperties = environmentProperties;
             _overrideTasksPath = msbuildOverrideTasksPath;
             _defaultOverrideToolsVersion = defaultOverrideToolsVersion;
+            
         }
 
         /// <summary>
@@ -289,33 +290,25 @@ namespace Microsoft.Build.Evaluation
         /// Properties that should be associated with the Toolset.
         /// May be null, in which case an empty property group will be used.
         /// </param>
-        internal Toolset(string toolsVersion, string toolsPath, PropertyDictionary<ProjectPropertyInstance> buildProperties, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, IDictionary<string, SubToolset> subToolsets, string msbuildOverrideTasksPath, string defaultOverrideToolsVersion)
+        internal Toolset(string toolsVersion, string toolsPath, PropertyDictionary<ProjectPropertyInstance> buildProperties, PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, IDictionary<string, SubToolset> subToolsets, string msbuildOverrideTasksPath, string defaultOverrideToolsVersion, Dictionary<string, List<string>> importSearchPathsTable = null)
             : this(toolsVersion, toolsPath, environmentProperties, globalProperties, msbuildOverrideTasksPath, defaultOverrideToolsVersion)
         {
             if (_properties == null)
             {
-                if (null != buildProperties)
-                {
-                    _properties = new PropertyDictionary<ProjectPropertyInstance>(buildProperties);
-                }
-                else
-                {
-                    _properties = new PropertyDictionary<ProjectPropertyInstance>();
-                }
+                _properties = buildProperties != null
+                    ? new PropertyDictionary<ProjectPropertyInstance>(buildProperties)
+                    : new PropertyDictionary<ProjectPropertyInstance>();
             }
 
             if (subToolsets != null)
             {
                 Dictionary<string, SubToolset> subToolsetsAsDictionary = subToolsets as Dictionary<string, SubToolset>;
+                _subToolsets = subToolsetsAsDictionary ?? new Dictionary<string, SubToolset>(subToolsets);
+            }
 
-                if (subToolsetsAsDictionary != null)
-                {
-                    _subToolsets = subToolsetsAsDictionary;
-                }
-                else
-                {
-                    _subToolsets = new Dictionary<string, SubToolset>(subToolsets);
-                }
+            if (importSearchPathsTable != null)
+            {
+                _propertySearchPathsTable = importSearchPathsTable;
             }
         }
 
@@ -354,33 +347,36 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Returns a copy of the list of search paths for a MSBuildExtensionsPath* property.
-        /// <returns>List of search paths, else null</returns>
+        /// Returns a ProjectImportPathMatch struct for the first property found in the expression for which
+        /// project import search paths is enabled.
+        /// <param name="expression">Expression to search for properties in (first level only, not recursive)</param>
+        /// <returns>List of search paths or ProjectImportPathMatch.None if empty</returns>
         /// </summary>
-        internal List<string> GetMSBuildExtensionsPathSearchPathsFor(string refKind)
+        internal ProjectImportPathMatch GetProjectImportSearchPaths(string expression)
         {
-            if (string.IsNullOrEmpty(refKind))
-                return null;
-
-            List<string> paths;
-            if (MSBuildExtensionsPathSearchPathsTable != null && MSBuildExtensionsPathSearchPathsTable.TryGetValue(refKind, out paths))
+            if (string.IsNullOrEmpty(expression) || ImportPropertySearchPathsTable == null)
             {
-                return new List<string>(paths);
+                return ProjectImportPathMatch.None;
             }
 
-            return null;
+            foreach (var searchPath in _propertySearchPathsTable)
+            {
+                if (expression.IndexOf($"$({searchPath.Key})", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return new ProjectImportPathMatch(searchPath.Key, searchPath.Value);
+                }
+            }
+
+            return ProjectImportPathMatch.None;
         }
 
         /// <summary>
         /// Name of this toolset
         /// </summary>
-        public string ToolsVersion
-        {
-            get { return _toolsVersion; }
-        }
+        public string ToolsVersion => _toolsVersion;
 
         /// <summary>
-        /// Path to this toolset's tasks and targets. Corresponds to $(MSBuildToolsPath) in a project or targets file. 
+        /// Path to this toolset's tasks and targets. Corresponds to $(MSBuildToolsPath) in a project or targets file.
         /// </summary>
         public string ToolsPath
         {
@@ -566,27 +562,17 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Path to look for msbuild override task files.
         /// </summary>
-        internal string OverrideTasksPath
-        {
-            get { return _overrideTasksPath; }
-        }
+        internal string OverrideTasksPath => _overrideTasksPath;
 
         /// <summary>
         /// ToolsVersion to use as the default ToolsVersion for this version of MSBuild
         /// </summary>
-        internal string DefaultOverrideToolsVersion
-        {
-            get { return _defaultOverrideToolsVersion; }
-        }
+        internal string DefaultOverrideToolsVersion => _defaultOverrideToolsVersion;
 
         /// <summary>
-        /// Map of MSBuildExtensionsPath properties to their list of fallback search paths
+        /// Map of properties to their list of fall-back search paths
         /// </summary>
-        internal Dictionary<string, List<string>> MSBuildExtensionsPathSearchPathsTable
-        {
-            get { return _msBuildSearchPathsTable; }
-            set { _msBuildSearchPathsTable = value; }
-        }
+        internal Dictionary<string, List<string>> ImportPropertySearchPathsTable => _propertySearchPathsTable;
 
         /// <summary>
         /// Function for serialization.
@@ -601,12 +587,7 @@ namespace Microsoft.Build.Evaluation
             translator.TranslateDictionary(ref _subToolsets, StringComparer.OrdinalIgnoreCase, SubToolset.FactoryForDeserialization);
             translator.Translate(ref _overrideTasksPath);
             translator.Translate(ref _defaultOverrideToolsVersion);
-            translator.TranslateDictionaryList(ref _msBuildSearchPathsTable, StringComparer.OrdinalIgnoreCase);
-        }
-
-        private void ListTranslate(List<string> list, INodePacketTranslator translator)
-        {
-            translator.Translate(ref list);
+            translator.TranslateDictionaryList(ref _propertySearchPathsTable, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -660,18 +641,13 @@ namespace Microsoft.Build.Evaluation
                 property = subToolset.Properties[propertyName];
             }
 
-            if (property == null)
-            {
-                property = Properties[propertyName];
-            }
-
-            return property;
+            return property ?? (Properties[propertyName]);
         }
 
         /// <summary>
         /// Factory for deserialization.
         /// </summary>
-        static internal Toolset FactoryForDeserialization(INodePacketTranslator translator)
+        internal static Toolset FactoryForDeserialization(INodePacketTranslator translator)
         {
             Toolset toolset = new Toolset(translator);
             return toolset;
@@ -818,12 +794,7 @@ namespace Microsoft.Build.Evaluation
 
             // Solution version also didn't work out, so fall back to default. 
             // If subToolsetVersion is null, there simply wasn't a matching solution version. 
-            if (subToolsetVersion == null)
-            {
-                subToolsetVersion = DefaultSubToolsetVersion;
-            }
-
-            return subToolsetVersion;
+            return subToolsetVersion ?? (DefaultSubToolsetVersion);
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetConfigurationReader.cs
@@ -9,9 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
-using System.Text;
-using System.Globalization;
-using System.Reflection;
+using System.Linq;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
@@ -19,15 +17,9 @@ using Microsoft.Build.Shared;
 
 using ErrorUtilities = Microsoft.Build.Shared.ErrorUtilities;
 using InvalidToolsetDefinitionException = Microsoft.Build.Exceptions.InvalidToolsetDefinitionException;
-using Microsoft.Build.Internal;
 
 namespace Microsoft.Build.Evaluation
 {
-    /// <summary>
-    /// Delegate for unit test purposes only
-    /// </summary>
-    internal delegate Configuration ReadApplicationConfiguration();
-
     /// <summary>
     /// Class used to read toolset configurations.
     /// </summary>
@@ -41,7 +33,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Delegate used to read application configurations
         /// </summary>
-        private ReadApplicationConfiguration _readApplicationConfiguration = null;
+        private readonly Func<Configuration> _readApplicationConfiguration;
 
         /// <summary>
         /// Flag indicating that an attempt has been made to read the configuration
@@ -55,27 +47,27 @@ namespace Microsoft.Build.Evaluation
         private char _separatorForExtensionsPathSearchPaths = ';';
 
         /// <summary>
-        /// map of MSBuildExtensionsPath property kind to list of fallback search paths, per toolsVersion
+        /// Cached values of tools version -> project import search paths table
         /// </summary>
-        private Dictionary<string, Dictionary<string, List<string>>> _kindToPathsCachePerToolsVersion;
+        private readonly Dictionary<string, Dictionary<string, List<string>>> _projectImportSearchPathsCache;
 
         /// <summary>
         /// Default constructor
         /// </summary>
         internal ToolsetConfigurationReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties)
-            : this(environmentProperties, globalProperties, new ReadApplicationConfiguration(ToolsetConfigurationReader.ReadApplicationConfiguration))
+            : this(environmentProperties, globalProperties, ReadApplicationConfiguration)
         {
         }
 
         /// <summary>
         /// Constructor taking a delegate for unit test purposes only
         /// </summary>
-        internal ToolsetConfigurationReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, ReadApplicationConfiguration readApplicationConfiguration)
+        internal ToolsetConfigurationReader(PropertyDictionary<ProjectPropertyInstance> environmentProperties, PropertyDictionary<ProjectPropertyInstance> globalProperties, Func<Configuration> readApplicationConfiguration)
             : base(environmentProperties, globalProperties)
         {
             ErrorUtilities.VerifyThrowArgumentNull(readApplicationConfiguration, "readApplicationConfiguration");
             _readApplicationConfiguration = readApplicationConfiguration;
-            _kindToPathsCachePerToolsVersion = new Dictionary<string, Dictionary<string, List<string>>>(StringComparer.OrdinalIgnoreCase);
+            _projectImportSearchPathsCache = new Dictionary<string, Dictionary<string, List<string>>>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -99,46 +91,24 @@ namespace Microsoft.Build.Evaluation
                         yield return new ToolsetPropertyDefinition(toolset.toolsVersion, string.Empty, location);
                     }
                 }
-                else
-                {
-                    yield break;
-                }
             }
         }
 
         /// <summary>
         /// Returns the default tools version, or null if none was specified
         /// </summary>
-        protected override string DefaultToolsVersion
-        {
-            get
-            {
-                return (ConfigurationSection == null ? null : ConfigurationSection.Default);
-            }
-        }
+        protected override string DefaultToolsVersion => ConfigurationSection?.Default;
 
         /// <summary>
-        /// Returns the path to find overridetasks, or null if none was specified
+        /// Returns the path to find override tasks, or null if none was specified
         /// </summary>
-        protected override string MSBuildOverrideTasksPath
-        {
-            get
-            {
-                return (ConfigurationSection == null ? null : ConfigurationSection.MSBuildOverrideTasksPath);
-            }
-        }
+        protected override string MSBuildOverrideTasksPath => ConfigurationSection?.MSBuildOverrideTasksPath;
 
         /// <summary>
-        /// DefaultOverrideToolsVersion attribute on msbuildToolsets element, specifying the toolsversion that should be used by 
+        /// DefaultOverrideToolsVersion attribute on msbuildToolsets element, specifying the tools version that should be used by 
         /// default to build projects with this version of MSBuild.
         /// </summary>
-        protected override string DefaultOverrideToolsVersion
-        {
-            get
-            {
-                return (ConfigurationSection == null ? null : ConfigurationSection.DefaultOverrideToolsVersion);
-            }
-        }
+        protected override string DefaultOverrideToolsVersion => ConfigurationSection?.DefaultOverrideToolsVersion;
 
         /// <summary>
         /// Lazy getter for the ToolsetConfigurationSection
@@ -199,11 +169,11 @@ namespace Microsoft.Build.Evaluation
 
         /// <summary>
         /// Provides an enumerator over the set of sub-toolset names available to a particular
-        /// toolsversion.  MSBuild config files do not currently support sub-toolsets, so 
+        /// tools version.  MSBuild config files do not currently support sub-toolsets, so
         /// we return nothing. 
         /// </summary>
         /// <param name="toolsVersion">The tools version.</param>
-        /// <returns>An enumeration of the sub-toolsets that belong to that toolsversion.</returns>
+        /// <returns>An enumeration of the sub-toolsets that belong to that tools version.</returns>
         protected override IEnumerable<string> GetSubToolsetVersions(string toolsVersion)
         {
             yield break;
@@ -223,59 +193,53 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
+        /// Returns a map of project property names / list of search paths for the specified toolsVersion and os
         /// </summary>
-        protected override Dictionary<string, List<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        protected override Dictionary<string, List<string>> GetProjectImportSearchPathsTable(string toolsVersion, string os)
         {
             Dictionary<string, List<string>> kindToPathsCache;
             var key = toolsVersion + ":" + os;
-            if (_kindToPathsCachePerToolsVersion.TryGetValue(key, out kindToPathsCache))
+            if (_projectImportSearchPathsCache.TryGetValue(key, out kindToPathsCache))
             {
                 return kindToPathsCache;
             }
 
             // Read and populate the map
             kindToPathsCache = new Dictionary<string, List<string>>();
-            _kindToPathsCachePerToolsVersion[key] = kindToPathsCache;
+            _projectImportSearchPathsCache[key] = kindToPathsCache;
 
             ToolsetElement toolsetElement = ConfigurationSection.Toolsets.GetElement(toolsVersion);
-            var propertyCollection = toolsetElement?.AllMSBuildExtensionPathsSearchPaths?.GetElement(os)?.PropertyElements;
+            var propertyCollection = toolsetElement?.AllProjectImportSearchPaths?.GetElement(os)?.PropertyElements;
             if (propertyCollection == null || propertyCollection.Count == 0)
             {
                 return kindToPathsCache;
             }
 
-            kindToPathsCache = ComputeDistinctListOfFallbackPathsFor(propertyCollection);
+            kindToPathsCache = ComputeDistinctListOfSearchPaths(propertyCollection);
 
             return kindToPathsCache;
         }
 
         /// <summary>
-        /// Returns a list of the search paths for a given MSBuildExtensionsPathReferenceKind
+        /// Returns a list of the search paths for a given search path property collection
         /// </summary>
-        private Dictionary<string, List<string>> ComputeDistinctListOfFallbackPathsFor(ToolsetElement.PropertyElementCollection propertyCollection)
+        private Dictionary<string, List<string>> ComputeDistinctListOfSearchPaths(ToolsetElement.PropertyElementCollection propertyCollection)
         {
             var pathsTable = new Dictionary<string, List<string>>();
 
             foreach (ToolsetElement.PropertyElement property in propertyCollection)
             {
-                //FIXME: handle ; in path on Unix
-                var kind = MSBuildExtensionsPathReferenceKind.FindIn($"$({property.Name})");
-                if (kind.Equals(MSBuildExtensionsPathReferenceKind.None))
+                if (string.IsNullOrEmpty(property.Value) || string.IsNullOrEmpty(property.Name))
                 {
                     continue;
                 }
 
-                var paths = new List<string>();
-                foreach (var extnPath in property.Value.Split(new [] { _separatorForExtensionsPathSearchPaths }, StringSplitOptions.RemoveEmptyEntries))
-                {
-                    if (!paths.Contains(extnPath))
-                    {
-                        paths.Add(extnPath);
-                    }
-                }
+                //FIXME: handle ; in path on Unix
+                var paths =
+                    property.Value.Split(new[] {_separatorForExtensionsPathSearchPaths},
+                        StringSplitOptions.RemoveEmptyEntries).Distinct();
 
-                pathsTable.Add(kind.StringRepresentation, paths);
+                pathsTable.Add(property.Name, paths.ToList());
             }
 
             return pathsTable;

--- a/src/XMakeBuildEngine/Definition/ToolsetReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetReader.cs
@@ -6,16 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
-
 using Microsoft.Build.Shared;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
-using Microsoft.Build.Evaluation;
-using Microsoft.Win32;
-
 using error = Microsoft.Build.Shared.ErrorUtilities;
 using InvalidToolsetDefinitionException = Microsoft.Build.Exceptions.InvalidToolsetDefinitionException;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -279,7 +274,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
         /// </summary>
-        protected abstract Dictionary<string, List<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os);
+        protected abstract Dictionary<string, List<string>> GetProjectImportSearchPathsTable(string toolsVersion, string os);
 
         /// <summary>
         /// Reads all the toolsets and populates the given ToolsetCollection with them
@@ -382,8 +377,8 @@ namespace Microsoft.Build.Evaluation
 
             try
             {
-                toolset = new Toolset(toolsVersion.Name, toolsPath == null ? binPath : toolsPath, properties, _environmentProperties, globalProperties, subToolsets, MSBuildOverrideTasksPath, DefaultOverrideToolsVersion);
-                toolset.MSBuildExtensionsPathSearchPathsTable = GetMSBuildExtensionPathsSearchPathsTable(toolsVersion.Name, NativeMethodsShared.GetOSNameForExtensionsPath());
+                var importSearchPathsTable = GetProjectImportSearchPathsTable(toolsVersion.Name, NativeMethodsShared.GetOSNameForExtensionsPath());
+                toolset = new Toolset(toolsVersion.Name, toolsPath == null ? binPath : toolsPath, properties, _environmentProperties, globalProperties, subToolsets, MSBuildOverrideTasksPath, DefaultOverrideToolsVersion, importSearchPathsTable);
             }
             catch (ArgumentException e)
             {
@@ -636,68 +631,4 @@ namespace Microsoft.Build.Evaluation
             return path;
         }
     }
-
-    /// <summary>
-    /// struct representing a reference to MSBuildExtensionsPath* property
-    /// </summary>
-    internal struct MSBuildExtensionsPathReferenceKind
-    {
-        /// <summary>
-        /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath"
-        /// </summary>
-        public static readonly MSBuildExtensionsPathReferenceKind Default = new MSBuildExtensionsPathReferenceKind("MSBuildExtensionsPath");
-
-        /// <summary>
-        /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath32"
-        /// </summary>
-        public static readonly MSBuildExtensionsPathReferenceKind Path32 = new MSBuildExtensionsPathReferenceKind("MSBuildExtensionsPath32");
-
-        /// <summary>
-        /// MSBuildExtensionsPathReferenceKind instance for property named "MSBuildExtensionsPath64"
-        /// </summary>
-        public static readonly MSBuildExtensionsPathReferenceKind Path64 = new MSBuildExtensionsPathReferenceKind("MSBuildExtensionsPath64");
-
-        /// <summary>
-        /// MSBuildExtensionsPathReferenceKind instance representing no MSBuildExtensionsPath* property reference
-        /// </summary>
-        public static readonly MSBuildExtensionsPathReferenceKind None = new MSBuildExtensionsPathReferenceKind(String.Empty);
-
-        private MSBuildExtensionsPathReferenceKind(string value)
-        {
-            StringRepresentation = value;
-        }
-
-        /// <summary>
-        /// String representation of the property reference - eg. "MSBuildExtensionsPath32"
-        /// </summary>
-        public string StringRepresentation { get; }
-
-        /// <summary>
-        /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
-        /// </summary>
-        public string MSBuildPropertyName => String.Format($"$({StringRepresentation})");
-
-        /// <summary>
-        /// Tries to find a reference to MSBuildExtensionsPath* property in the given string
-        /// </summary>
-        public static MSBuildExtensionsPathReferenceKind FindIn(string expression)
-        {
-            if (expression.IndexOf(Default.MSBuildPropertyName, StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return Default;
-            }
-
-            if (expression.IndexOf(Path32.MSBuildPropertyName, StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return Path32;
-            }
-
-            if (expression.IndexOf(Path64.MSBuildPropertyName, StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return Path64;
-            }
-
-            return None;
-        }
-     }
 }

--- a/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
+++ b/src/XMakeBuildEngine/Definition/ToolsetRegistryReader.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Returns a map of MSBuildExtensionsPath* property names/kind to list of search paths
         /// </summary>
-        protected override Dictionary<string, List<string>> GetMSBuildExtensionPathsSearchPathsTable(string toolsVersion, string os)
+        protected override Dictionary<string, List<string>> GetProjectImportSearchPathsTable(string toolsVersion, string os)
         {
             return new Dictionary<string, List<string>>();
         }

--- a/src/XMakeBuildEngine/Evaluation/Evaluator.cs
+++ b/src/XMakeBuildEngine/Evaluation/Evaluator.cs
@@ -2016,38 +2016,31 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// If the project import references a $(MSBuildExtensionsPath*)
-        /// then this tries to find project files corresponding to that, using various search
-        /// paths. It relies on the ExpandAndLoadImportsFromUnescapedImportExpressionConditioned
-        /// to do the actual loading and parsing.
-        /// This is explained in detail in a comment with the method code.
-        ///
-        /// If the project import does not reference the $(MSBuildExtensionsPath*) property, then
-        /// it falls back to the default behavior.
-        ///
-        /// Caches the parsed import into the provided collection, so future
-        /// requests can be satisfied without re-parsing it.
+        /// Expands and loads project imports.
+        /// <remarks>
+        /// Imports may contain references to "projectImportSearchPaths" defined in the app.config 
+        /// toolset section. If this is the case, this method will search for the imported project
+        /// in those additional paths if the default fails.
+        /// </remarks>
         /// </summary>
         private List<ProjectRootElement> ExpandAndLoadImports(string directoryOfImportingFile, ProjectImportElement importElement)
         {
-            var refKindInProject = MSBuildExtensionsPathReferenceKind.FindIn(importElement.Project);
-            var fallbackExtensionPaths = _data.Toolset.GetMSBuildExtensionsPathSearchPathsFor(refKindInProject.StringRepresentation);
+            var fallbackSearchPathMatch = _data.Toolset.GetProjectImportSearchPaths(importElement.Project);
 
             // no reference or we need to lookup only the default path,
             // so, use the Import path
-            if (refKindInProject.Equals(MSBuildExtensionsPathReferenceKind.None) || fallbackExtensionPaths == null ||
-                fallbackExtensionPaths.Count == 0)
+            if (fallbackSearchPathMatch.Equals(ProjectImportPathMatch.None))
             {
                 List<ProjectRootElement> projects;
-                var result = ExpandAndLoadImportsFromUnescapedImportExpressionConditioned(directoryOfImportingFile,
-                    importElement, importElement.Project, out projects);
+                ExpandAndLoadImportsFromUnescapedImportExpressionConditioned(directoryOfImportingFile, importElement, importElement.Project, out projects);
                 return projects;
             }
 
-            // $(MSBuildExtensionsPath*) usually resolves to a single value, single default path. This can be overridden
-            // by the usual property overriding techniques.
+            // Note: Any property defined in the <projectImportSearchPaths> section can be replaced, MSBuildExtensionsPath
+            // is used here as an example of behavior.
+            // $(MSBuildExtensionsPath*) usually resolves to a single value, single default path
             //
-            // Eg. <Import Project='$(MSBuildExtensionsPath)\foo\extn.proj' />
+            //     Eg. <Import Project='$(MSBuildExtensionsPath)\foo\extn.proj' />
             //
             // But this feature allows that when it is used in an Import element, it will behave as a "search path", meaning
             // that the relative project path "foo\extn.proj" will be searched for, in more than one location.
@@ -2058,17 +2051,17 @@ namespace Microsoft.Build.Evaluation
             //
             // 1. The value of the MSBuildExtensionsPath* property
             //
-            // 2. Search paths available in the current toolset (via toolset.MSBuildExtensionsPathSearchPathsTable).
+            // 2. Search paths available in the current toolset (via toolset.ImportPropertySearchPathsTable).
             //    That may be loaded from app.config with a definition like:
             //
             //    <toolset .. >
-            //      <msbuildExtensionsPathSearchPaths>
+            //      <projectImportSearchPaths>
             //          <searchPaths os="osx">
             //              <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/;/tmp/foo"/>
             //              <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
             //              <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
             //          </searchPaths>
-            //      </msbuildExtensionsPathSearchPaths>
+            //      </projectImportSearchPaths>
             //    </toolset>
             //
             // This is available only when used in an Import element and it's Condition. So, the following common pattern
@@ -2077,7 +2070,7 @@ namespace Microsoft.Build.Evaluation
             //      <Import Project="$(MSBuildExtensionsPath)\foo\extn.proj" Condition="'Exists('$(MSBuildExtensionsPath)\foo\extn.proj')'" />
             //
             // The value of the MSBuildExtensionsPath* property, will always be "visible" with it's default value, example, when read or
-            // referenced anywhere else. This is a very limited support, so, it doesn't come in to effect if the explcit reference to
+            // referenced anywhere else. This is a very limited support, so, it doesn't come in to effect if the explicit reference to
             // the $(MSBuildExtensionsPath) property is not present in the Project attribute of the Import element. So, the following is
             // not supported:
             //
@@ -2086,21 +2079,26 @@ namespace Microsoft.Build.Evaluation
             //
 
             // Adding the value of $(MSBuildExtensionsPath*) property to the list of search paths
-            var prop = _data.GetProperty(refKindInProject.StringRepresentation);
-            fallbackExtensionPaths.Insert(0, prop.EvaluatedValue);
+            var prop = _data.GetProperty(fallbackSearchPathMatch.PropertyName);
 
-            string extensionPropertyRefAsString = refKindInProject.MSBuildPropertyName;
+            var pathsToSearch =
+                // The actual value of the property, with no fallbacks
+                new[] {prop.EvaluatedValue}
+                // The list of fallbacks, in order
+                .Concat(fallbackSearchPathMatch.SearchPaths).ToList();
+
+            string extensionPropertyRefAsString = fallbackSearchPathMatch.MsBuildPropertyFormat;
 
             _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "SearchPathsForMSBuildExtensionsPath",
                                         extensionPropertyRefAsString,
-                                        String.Join(Path.PathSeparator.ToString(), fallbackExtensionPaths));
+                                        String.Join(Path.PathSeparator.ToString(), pathsToSearch));
 
             bool atleastOneExactFilePathWasLookedAtAndNotFound = false;
 
             // Try every extension search path, till we get a Hit:
             // 1. 1 or more project files loaded
             // 2. 1 or more project files *found* but ignored (like circular, self imports)
-            foreach (var extensionPath in fallbackExtensionPaths)
+            foreach (var extensionPath in pathsToSearch)
             {
                 string extensionPathExpanded = _data.ExpandString(extensionPath);
 
@@ -2150,7 +2148,7 @@ namespace Microsoft.Build.Evaluation
             // was a wildcard and it resolved to zero files!
             if (atleastOneExactFilePathWasLookedAtAndNotFound && (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) == 0)
             {
-                ThrowForImportedProjectFromExtensionsPathNotFound(refKindInProject.StringRepresentation, importElement);
+                ThrowForImportedProjectWithSearchPathsNotFound(fallbackSearchPathMatch, importElement);
             }
 
             return new List<ProjectRootElement>();
@@ -2514,35 +2512,33 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Throws InvalidProjectException because we failed to import a project from $(MSBuildExtensionsPath*)
-        /// <param name="refKindInProject">MSBuildExtensionsPath reference kind found in the Project attribute of the Import element</param>
+        /// Throws InvalidProjectException because we failed to import a project which contained a ProjectImportSearchPath fall-back.
+        /// <param name="searchPathMatch">MSBuildExtensionsPath reference kind found in the Project attribute of the Import element</param>
         /// <param name="importElement">The importing element for this import</param>
         /// </summary>
-        private void ThrowForImportedProjectFromExtensionsPathNotFound(string refKindInProject, ProjectImportElement importElement)
+        private void ThrowForImportedProjectWithSearchPathsNotFound(ProjectImportPathMatch searchPathMatch, ProjectImportElement importElement)
         {
-            string extensionsPathPropValue = _data.GetProperty(refKindInProject).EvaluatedValue;
+            string extensionsPathPropValue = _data.GetProperty(searchPathMatch.PropertyName).EvaluatedValue;
 
             string importExpandedWithDefaultPath = _expander.ExpandIntoStringLeaveEscaped(
-                                                                    importElement.Project.Replace($"$({refKindInProject})", extensionsPathPropValue),
+                                                                    importElement.Project.Replace(searchPathMatch.MsBuildPropertyFormat, extensionsPathPropValue),
                                                                     ExpanderOptions.ExpandProperties, importElement.ProjectLocation);
 
             string relativeProjectPath = FileUtilities.MakeRelative(extensionsPathPropValue, importExpandedWithDefaultPath);
 
-            var onlyFallbackSearchPaths =
-                _data.Toolset.GetMSBuildExtensionsPathSearchPathsFor(refKindInProject)
-                    .Select(s => _data.ExpandString(s))
-                    .ToList();
+            var onlyFallbackSearchPaths = searchPathMatch.SearchPaths.Select(s => _data.ExpandString(s)).ToList();
 
             string stringifiedListOfSearchPaths = StringifyList(onlyFallbackSearchPaths);
 
             string configLocation = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
 
-            ProjectErrorUtilities.ThrowInvalidProject(importElement.ProjectLocation, "ImportedProjectFromExtensionsPathNotFoundFromAppConfig",
-                                                        importExpandedWithDefaultPath,
-                                                        relativeProjectPath,
-                                                        $"$({refKindInProject})",
-                                                        stringifiedListOfSearchPaths,
-                                                        configLocation);
+            ProjectErrorUtilities.ThrowInvalidProject(importElement.ProjectLocation,
+                "ImportedProjectFromExtensionsPathNotFoundFromAppConfig",
+                importExpandedWithDefaultPath,
+                relativeProjectPath,
+                searchPathMatch.MsBuildPropertyFormat,
+                stringifiedListOfSearchPaths,
+                configLocation);
         }
 
         /// <summary>
@@ -2559,7 +2555,7 @@ namespace Microsoft.Build.Evaluation
                 if (i > 0)
                 {
                     sb.Append(", ");
-                 }
+                }
 
                 sb.Append($"\"{strings[i]}\"");
             }

--- a/src/XMakeBuildEngine/Microsoft.Build.csproj
+++ b/src/XMakeBuildEngine/Microsoft.Build.csproj
@@ -149,6 +149,7 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="Definition\ProjectCollectionChangedEventArgs.cs" />
+    <Compile Include="Definition\ProjectImportPathMatch.cs" />
     <Compile Include="Evaluation\ItemsAndMetadataPair.cs" />
     <Compile Include="Evaluation\MetadataReference.cs" />
     <Compile Include="Evaluation\ProjectChangedEventArgs.cs" />

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
 
-            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 0);
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllProjectImportSearchPaths.Count, 0);
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
 
-            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 0);
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllProjectImportSearchPaths.Count, 0);
         }
         #endregion
 
@@ -516,7 +516,7 @@ namespace Microsoft.Build.UnitTests.Definition
                      <toolset toolsVersion=""2.0"">
                        <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v2.0.x86ret\""/>
                        <property name=""MSBuildToolsPath"" value=""D:\windows\Microsoft.NET\Framework\v2.0.x86ret\""/>
-                       <msbuildExtensionsPathSearchPaths>
+                       <projectImportSearchPaths>
                          <searchPaths os=""windows"">
                             <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
                             <property name=""MSBuildExtensionsPath64"" value=""c:\foo64;c:\bar64""/>
@@ -528,7 +528,7 @@ namespace Microsoft.Build.UnitTests.Definition
                          <searchPaths os=""unix"">
                             <property name=""MSBuildExtensionsPath"" value=""/tmp/bar""/>
                          </searchPaths>
-                       </msbuildExtensionsPathSearchPaths>
+                       </projectImportSearchPaths>
                      </toolset>
                    </msbuildToolsets>
                  </configuration>"));
@@ -544,8 +544,8 @@ namespace Microsoft.Build.UnitTests.Definition
             Assert.Equal(msbuildToolsetSection.Toolsets.GetElement("2.0").PropertyElements.GetElement("MSBuildBinPath").Value,
                                    @"D:\windows\Microsoft.NET\Framework\v2.0.x86ret\");
 
-            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths.Count, 3);
-            var allPaths = msbuildToolsetSection.Toolsets.GetElement(0).AllMSBuildExtensionPathsSearchPaths;
+            Assert.Equal(msbuildToolsetSection.Toolsets.GetElement(0).AllProjectImportSearchPaths.Count, 3);
+            var allPaths = msbuildToolsetSection.Toolsets.GetElement(0).AllProjectImportSearchPaths;
             Assert.Equal(allPaths.GetElement(0).OS, "windows");
             Assert.Equal(allPaths.GetElement(0).PropertyElements.Count, 2);
             Assert.Equal(allPaths.GetElement(0).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"c:\foo");
@@ -566,7 +566,7 @@ namespace Microsoft.Build.UnitTests.Definition
             string defaultOverrideToolsVersion = null;
             string defaultToolsVersion = reader.ReadToolsets(toolsets, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), true, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
 
-            Dictionary<string, List<string>> pathsTable = toolsets["2.0"].MSBuildExtensionsPathSearchPathsTable;
+            Dictionary<string, List<string>> pathsTable = toolsets["2.0"].ImportPropertySearchPathsTable;
 #if XPLAT
             if (NativeMethodsShared.IsWindows)
 #endif
@@ -577,12 +577,12 @@ namespace Microsoft.Build.UnitTests.Definition
 #if XPLAT
             else if (NativeMethodsShared.IsOSX)
             {
-                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/foo"});
-                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Path32, new string[] {"/tmp/foo32", "/tmp/bar32"});
+                CheckPathsTable(pathsTable, ProjectImportPathMatch.Default, new string[] {"/tmp/foo"});
+                CheckPathsTable(pathsTable, ProjectImportPathMatch.Path32, new string[] {"/tmp/foo32", "/tmp/bar32"});
             }
             else
             {
-                CheckPathsTable(pathsTable, MSBuildExtensionsPathReferenceKind.Default, new string[] {"/tmp/bar"});
+                CheckPathsTable(pathsTable, ProjectImportPathMatch.Default, new string[] {"/tmp/bar"});
             }
 #endif
         }
@@ -616,14 +616,14 @@ namespace Microsoft.Build.UnitTests.Definition
                      <toolset ToolsVersion=""2.0"">
                        <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v3.5.x86ret\""/>
 
-                       <msbuildExtensionsPathSearchPaths>
+                       <projectImportSearchPaths>
                          <searchPaths os=""windows"">
                             <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
                          </searchPaths>
                          <searchPaths os=""windows"">
                             <property name=""MSBuildExtensionsPath"" value=""c:\bar""/>
                          </searchPaths>
-                       </msbuildExtensionsPathSearchPaths>
+                       </projectImportSearchPaths>
                      </toolset>
                    </msbuildToolsets>
                  </configuration>"));
@@ -652,12 +652,12 @@ namespace Microsoft.Build.UnitTests.Definition
                      <toolset ToolsVersion=""2.0"">
                        <property name=""MSBuildBinPath"" value=""D:\windows\Microsoft.NET\Framework\v3.5.x86ret\""/>
 
-                       <msbuildExtensionsPathSearchPaths>
+                       <projectImportSearchPaths>
                          <searchPaths os=""windows"">
                             <property name=""MSBuildExtensionsPath"" value=""c:\foo""/>
                             <property name=""MSBuildExtensionsPath"" value=""c:\bar""/>
                          </searchPaths>
-                       </msbuildExtensionsPathSearchPaths>
+                       </projectImportSearchPaths>
                      </toolset>
                    </msbuildToolsets>
                  </configuration>"));
@@ -671,8 +671,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
         private ToolsetConfigurationReader GetStandardConfigurationReader()
         {
-            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
-                ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest);
         }
         #endregion
 

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
@@ -289,8 +289,7 @@ namespace Microsoft.Build.UnitTests.Definition
             {
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(@"");
 
-                ToolsetReader reader = new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
-                    ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+                ToolsetReader reader = new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest);
 
                 Dictionary<string, Toolset> values = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
 
@@ -2613,8 +2612,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
         private ToolsetConfigurationReader GetStandardConfigurationReader()
         {
-            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), new ReadApplicationConfiguration(
-                ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest));
+            return new ToolsetConfigurationReader(new ProjectCollection().EnvironmentProperties, new PropertyDictionary<ProjectPropertyInstance>(), ToolsetConfigurationReaderTestHelper.ReadApplicationConfigurationTest);
         }
     }
 

--- a/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/Toolset_Tests.cs
@@ -94,11 +94,11 @@ namespace Microsoft.Build.UnitTests.Definition
             Dictionary<string, SubToolset> subToolsets = new Dictionary<string, SubToolset>(StringComparer.OrdinalIgnoreCase);
             subToolsets.Add("dogfood", new SubToolset("dogfood", subToolsetProperties));
 
-            Toolset t = new Toolset("4.0", "c:\\bar", buildProperties, environmentProperties, globalProperties, subToolsets, "c:\\foo", "4.0");
-            t.MSBuildExtensionsPathSearchPathsTable = new Dictionary<string, List<string>>
-            {
-                ["MSBuildExtensionsPath"] = new List<string> {@"c:\foo"}
-            };
+            Toolset t = new Toolset("4.0", "c:\\bar", buildProperties, environmentProperties, globalProperties,
+                subToolsets, "c:\\foo", "4.0", new Dictionary<string, List<string>>
+                {
+                    ["MSBuildExtensionsPath"] = new List<string> {@"c:\foo"}
+                });
 
             ((INodePacketTranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
             Toolset t2 = Toolset.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -134,15 +134,15 @@ namespace Microsoft.Build.UnitTests.Definition
                 }
                 else
                 {
-                    Assert.True(false, string.Format("Sub-toolset {0} was lost in translation.", key));
+                    Assert.True(false, $"Sub-toolset {key} was lost in translation.");
                 }
             }
 
             Assert.Equal(t.DefaultOverrideToolsVersion, t2.DefaultOverrideToolsVersion);
 
-            Assert.NotNull(t2.MSBuildExtensionsPathSearchPathsTable);
-            Assert.Equal(1, t2.MSBuildExtensionsPathSearchPathsTable.Count);
-            Assert.Equal(@"c:\foo", t2.GetMSBuildExtensionsPathSearchPathsFor("MSBuildExtensionsPath")[0]);
+            Assert.NotNull(t2.ImportPropertySearchPathsTable);
+            Assert.Equal(1, t2.ImportPropertySearchPathsTable.Count);
+            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"][0]);
         }
 
         [Fact]

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -53,13 +53,14 @@
         <property name="VCTargetsPath" value="$(VSInstallRoot)\Common7\IDE\VC\VCTargets" />
         <property name="FrameworkSDKRoot" value="$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\" />
 
-        <msbuildExtensionsPathSearchPaths>
+        <projectImportSearchPaths>
           <searchPaths os="windows">
             <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
           </searchPaths>
-        </msbuildExtensionsPathSearchPaths>
+        </projectImportSearchPaths>
       </toolset>
       <toolset toolsVersion="14.0">
         <property name="MSBuildToolsPath" value="." />
@@ -69,13 +70,13 @@
       </toolset>
       <toolset toolsVersion="4.0">
         <property name="MSBuildToolsPath" value="." />
-        <msbuildExtensionsPathSearchPaths>
+        <projectImportSearchPaths>
             <searchPaths os="osx">
                 <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
                 <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
                 <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
             </searchPaths>
-        </msbuildExtensionsPathSearchPaths>
+        </projectImportSearchPaths>
       </toolset>
     </msbuildToolsets>
   </configuration>


### PR DESCRIPTION
Changed the implementation of the fallback search paths to be more
generic. It will now replace and fallback any property defined in the
config file.
 - Lots of renames to remove reference to MSBuildExtensionPath
 - Some small refactoring that bothered me while reviewing a lot of the
   code :)

I did this because ASP.NET has the following in their xproj files:
```XML
<PropertyGroup>
    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
  </PropertyGroup>
  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
```

I tried going down other routes that would fallback because `VSToolsPath` contained `MSBuildExtensionsPath32` but they ended up being way too messy. This kept the solution simple and similar to what @radical implemented, just more generic and allowed me to add fallback to `VSToolsPath`.