### PR TITLE
Exec: Don't add `cd $working_dir` as that is set when the process is

### DIFF
--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -234,10 +234,6 @@ namespace Microsoft.Build.Tasks
                 else
                 {
                     sw.WriteLine("#!/bin/bash");
-                    if (!string.IsNullOrWhiteSpace(_workingDirectory))
-                    {
-                        sw.WriteLine("cd " + _workingDirectory);
-                    }
                 }
 
                 if (isUnix && NativeMethodsShared.IsMono)


### PR DESCRIPTION
started, so it isn't required and would be incorrect.