### PR TITLE
Update ToolsVersion to 15.0

### DIFF
--- a/BuildAndCopy.cmd
+++ b/BuildAndCopy.cmd
@@ -47,4 +47,4 @@ if %ERRORLEVEL% NEQ 0 (
 
 echo.
 echo ** Packaging complete.
-echo ** MSBuild = %~dp0\bin\bootstrap\15.1\MSBuild.exe
+echo ** MSBuild = %~dp0\bin\bootstrap\15.0\MSBuild.exe

--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -26,7 +26,7 @@ if %ERRORLEVEL% NEQ 0 (
 
 :: Rebuild with bootstrapped msbuild
 set MSBUILDLOGPATH=%~dp0msbuild_local.log
-set MSBUILDCUSTOMPATH="%~dp0\bin\Bootstrap\15.1\Bin\MSBuild.exe"
+set MSBUILDCUSTOMPATH="%~dp0\bin\Bootstrap\15.0\Bin\MSBuild.exe"
 "%~dp0build.cmd" /t:RebuildAndTest /p:BootstrappedMSBuild=true
 if %ERRORLEVEL% NEQ 0 (
     echo.

--- a/dir.props
+++ b/dir.props
@@ -12,7 +12,7 @@
     <!-- This is to workaround an issue with a dependent assembly (Microsoft.Build.Tasks.CodeAnalysis.dll)
          copying its dependencies (which are in the GAC). -->
     <DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
-    <TargetMSBuildToolsVersion>15.1</TargetMSBuildToolsVersion>
+    <TargetMSBuildToolsVersion>15.0</TargetMSBuildToolsVersion>
   </PropertyGroup>
 
    <!-- Compiler config -->

--- a/src/Framework/Microsoft.Build.Framework.pkgdef
+++ b/src/Framework/Microsoft.Build.Framework.pkgdef
@@ -1,6 +1,6 @@
 [$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{604B5E67-4DE2-41A7-AA00-AC65BE513FED}]
 "name"="Microsoft.Build.Framework"
-"codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.Framework.dll"
+"codeBase"="$BaseInstallDir$\MSBuild\15.0\Bin\Microsoft.Build.Framework.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
 "oldVersion"="0.0.0.0-99.9.9.9"

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Shared
         /// The most current Visual Studio Version known to this version of MSBuild. 
         /// </summary>
 #if STANDALONEBUILD
-        internal const string CurrentVisualStudioVersion = "15.1";
+        internal const string CurrentVisualStudioVersion = "15.0";
 #else
         internal const string CurrentVisualStudioVersion = Microsoft.VisualStudio.Internal.BrandNames.VSGeneralVersion;
 #endif
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Shared
             get
             {
 #if STANDALONEBUILD
-                return "15.1";
+                return "15.0";
 #else
                 Version thisAssemblyVersion = new Version(ThisAssembly.Version);
                 // "12.0.0.0" --> "12.0"

--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -33,8 +33,8 @@
     </assemblyBinding>
   </runtime>
   <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
-  <msbuildToolsets default="15.1">
-    <toolset toolsVersion="15.1">
+  <msbuildToolsets default="15.0">
+    <toolset toolsVersion="15.0">
       <property name="MSBuildToolsPath" value="."/>
     </toolset>
     <toolset toolsVersion="12.0">

--- a/src/Utilities/Microsoft.Build.Utilities.Core.pkgdef
+++ b/src/Utilities/Microsoft.Build.Utilities.Core.pkgdef
@@ -1,6 +1,6 @@
 [$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{CCA70AFE-5E92-4B5E-940D-FAE11D564E72}]
 "name"="Microsoft.Build.Utilities.Core"
-"codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.Utilities.Core.dll"
+"codeBase"="$BaseInstallDir$\MSBuild\15.0\Bin\Microsoft.Build.Utilities.Core.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
 "oldVersion"="0.0.0.0-99.9.9.9"

--- a/src/XMakeBuildEngine/Microsoft.Build.pkgdef
+++ b/src/XMakeBuildEngine/Microsoft.Build.pkgdef
@@ -1,6 +1,6 @@
 [$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{0B54AF09-CDE4-40FD-9850-FFFED6E13680}]
 "name"="Microsoft.Build"
-"codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.dll"
+"codeBase"="$BaseInstallDir$\MSBuild\15.0\Bin\Microsoft.Build.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
 "oldVersion"="0.0.0.0-99.9.9.9"

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetReader_Tests.cs
@@ -1962,7 +1962,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
                 Project project = projectCollection.LoadProject(projectPath);
 
-                string defaultExpected = "15.1";
+                string defaultExpected = "15.0";
                 if (FrameworkLocationHelper.PathToDotNetFrameworkV20 == null)
                 {
                     defaultExpected = ObjectModelHelpers.MSBuildDefaultToolsVersion;

--- a/src/XMakeBuildEngine/UnitTests/Definition/ToolsetRegistryReader_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Definition/ToolsetRegistryReader_Tests.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Build.UnitTests.Definition
         [Fact]
         public void GetDefaultOverrideToolsVersionFromRegistry_Basic()
         {
-            _currentVersionRegistryKey.SetValue("DefaultOverrideToolsVersion", "15.1");
+            _currentVersionRegistryKey.SetValue("DefaultOverrideToolsVersion", "15.0");
 
             ToolsetReader reader = GetStandardRegistryReader();
             Dictionary<string, Toolset> values = new Dictionary<string, Toolset>(StringComparer.OrdinalIgnoreCase);
@@ -532,7 +532,7 @@ namespace Microsoft.Build.UnitTests.Definition
             string defaultOverrideToolsVersion = null;
             string defaultToolsVersion = reader.ReadToolsets(values, new PropertyDictionary<ProjectPropertyInstance>(), new PropertyDictionary<ProjectPropertyInstance>(), false, out msbuildOverrideTasksPath, out defaultOverrideToolsVersion);
 
-            Assert.Equal("15.1", defaultOverrideToolsVersion);
+            Assert.Equal("15.0", defaultOverrideToolsVersion);
         }
 
         /// <summary>

--- a/src/XMakeBuildEngine/UnitTests/TargetsFile_Test.cs
+++ b/src/XMakeBuildEngine/UnitTests/TargetsFile_Test.cs
@@ -623,7 +623,7 @@ namespace Microsoft.Build.UnitTests
 
                 Project project = ObjectModelHelpers.CreateInMemoryProject(
                     @"
-                   <Project DefaultTargets=`Build` ToolsVersion=`15.1` xmlns=`msbuildnamespace`>
+                   <Project DefaultTargets=`Build` ToolsVersion=`15.0` xmlns=`msbuildnamespace`>
                       <PropertyGroup>
                         <OutputPath>" + outputPath + @"</OutputPath>
                         <AssemblyName>MyAssembly</AssemblyName>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -33,8 +33,8 @@
       </assemblyBinding>
     </runtime>
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
-    <msbuildToolsets default="15.1">
-      <toolset toolsVersion="15.1">
+    <msbuildToolsets default="15.0">
+      <toolset toolsVersion="15.0">
         <property name="MSBuildToolsPath" value="." />
         <property name="MSBuildToolsPath32" value="." />
         <!--<property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A@InstallationFolder)" />-->

--- a/src/XMakeTasks/Microsoft.Build.Tasks.Core.pkgdef
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.Core.pkgdef
@@ -1,6 +1,6 @@
 [$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{5BDA9EB8-561A-405C-A482-2CD328059DEA}]
 "name"="Microsoft.Build.Tasks.Core"
-"codeBase"="$BaseInstallDir$\MSBuild\15.1\Bin\Microsoft.Build.Tasks.Core.dll"
+"codeBase"="$BaseInstallDir$\MSBuild\15.0\Bin\Microsoft.Build.Tasks.Core.dll"
 "publicKeyToken"="b03f5f7f11d50a3a"
 "culture"="neutral"
 "oldVersion"="0.0.0.0-99.9.9.9"


### PR DESCRIPTION
We want the assembly version to (for now at least) not be 15.0 which would
conflict with Visual Studio "15" Preview which is loaded in the GAC.
However, we do want to be compatible with the ToolsVersion. This change
updates the ToolsVersion from 15.1 to 15.0 and leaves the assembly version
at 15.1.0.0.