### PR TITLE
Update fopx setup package name

### DIFF
--- a/CreateSetupPackageLayout.proj
+++ b/CreateSetupPackageLayout.proj
@@ -4,8 +4,8 @@
   <Import Project="$(MicroBuildDir)MicroBuild.Core.props" />
 
   <PropertyGroup>
-      <SetupPackageLayoutDir>$(BinDir)Setup\</SetupPackageLayoutDir>
-      <SetupPackageOutputFile>$(SetupPackageLayoutDir)MSBuild-master-0001.fopx</SetupPackageOutputFile>
+      <SetupPackageLayoutDir>$(BinDir)Setup\layout\</SetupPackageLayoutDir>
+      <SetupPackageOutputFile>$(BinDir)Setup\MSBuild.fopx</SetupPackageOutputFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It doesn't need the version. Only used internally for setup.