### PR TITLE
Fix #610 - Update DebuggerDisplay for renamed fields

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.BackEnd
     /// This class represents a single target in the TargetBuilder.  It maintains the state machine for a particular target as well as
     /// relevant information on outputs generated while a target is running.
     /// </summary>
-    [DebuggerDisplay("Name={targetSpecification.TargetName} State={state} Result={targetResult.ResultCode}")]
+    [DebuggerDisplay("Name={_targetSpecification.TargetName} State={_state} Result={_targetResult.ResultCode}")]
     internal class TargetEntry : IEquatable<TargetEntry>
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Construction/ProjectOnErrorElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectOnErrorElement.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Construction
     /// <summary>
     /// ProjectUsingTaskElement represents the Import element in the MSBuild project.
     /// </summary>
-    [DebuggerDisplay("ExecuteTargets={ExecuteTargets}")]
+    [DebuggerDisplay("ExecuteTargetsAttribute={ExecuteTargetsAttribute}")]
     public class ProjectOnErrorElement : ProjectElement
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Construction/ProjectOutputElement.cs
+++ b/src/XMakeBuildEngine/Construction/ProjectOutputElement.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Construction
     /// <summary>
     /// ProjectOutputElement represents the Output element in the MSBuild project.
     /// </summary>
-    [DebuggerDisplay("Name={Name} TaskParameter={TaskParameter} ItemName={ItemName} PropertyName={PropertyName} Condition={Condition}")]
+    [DebuggerDisplay("TaskParameter={TaskParameter} ItemType={ItemType} PropertyName={PropertyName} Condition={Condition}")]
     public class ProjectOutputElement : ProjectElement
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/Project.cs
+++ b/src/XMakeBuildEngine/Definition/Project.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Evaluation
     /// <remarks>
     /// UNDONE: (Multiple configurations.) Protect against problems when attempting to edit, after edits were made to the same ProjectRootElement either directly or through other projects evaluated from that ProjectRootElement.
     /// </remarks>
-    [DebuggerDisplay("{FullPath} EffectiveToolsVersion={ToolsVersion} #GlobalProperties={data.globalProperties.Count} #Properties={data.Properties.Count} #ItemTypes={data.ItemTypes.Count} #ItemDefinitions={data.ItemDefinitions.Count} #Items={data.Items.Count} #Targets={data.Targets.Count}")]
+    [DebuggerDisplay("{FullPath} EffectiveToolsVersion={ToolsVersion} #GlobalProperties={_data._globalProperties.Count} #Properties={_data.Properties.Count} #ItemTypes={_data.ItemTypes.Count} #ItemDefinitions={_data.ItemDefinitions.Count} #Items={_data.Items.Count} #Targets={_data.Targets.Count}")]
     public class Project
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ProjectItemDefinition.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectItemDefinition.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Evaluation
     /// often will not point to a single ProjectItemDefinitionElement. The metadata within, however, will each point to a single
     /// ProjectMetadataElement, and these can be added, removed, and modified.
     /// </remarks>
-    [DebuggerDisplay("{itemType} #Metadata={MetadataCount}")]
+    [DebuggerDisplay("{_itemType} #Metadata={MetadataCount}")]
     public class ProjectItemDefinition : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadata>, IProjectMetadataParent
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/ProjectMetadata.cs
+++ b/src/XMakeBuildEngine/Definition/ProjectMetadata.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Evaluation
     /// <remarks>
     /// Never used to represent built-in metadata, like %(Filename). There is always a backing XML object.
     /// </remarks>
-    [DebuggerDisplay("{Name}={EvaluatedValue} [{xml.Value}]")]
+    [DebuggerDisplay("{Name}={EvaluatedValue} [{_xml.Value}]")]
     public class ProjectMetadata : IKeyed, IValued, IEquatable<ProjectMetadata>, IMetadatum
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/SubToolset.cs
+++ b/src/XMakeBuildEngine/Definition/SubToolset.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Evaluation
     /// <summary>
     /// Aggregation of a set of properties that correspond to a particular sub-toolset.  
     /// </summary>
-    [DebuggerDisplay("SubToolsetVersion={SubToolsetVersion} #Properties={properties.Count}")]
+    [DebuggerDisplay("SubToolsetVersion={SubToolsetVersion} #Properties={_properties.Count}")]
     public class SubToolset : INodePacketTranslatable
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Definition/Toolset.cs
+++ b/src/XMakeBuildEngine/Definition/Toolset.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Evaluation
     /// <remarks>
     /// UNDONE: Review immutability. If this is not immutable, add a mechanism to notify the project collection/s owning it to increment their toolsetVersion.
     /// </remarks>
-    [DebuggerDisplay("ToolsVersion={ToolsVersion} ToolsPath={ToolsPath} #Properties={properties.Count}")]
+    [DebuggerDisplay("ToolsVersion={ToolsVersion} ToolsPath={ToolsPath} #Properties={_properties.Count}")]
     public class Toolset : INodePacketTranslatable
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Evaluation/ProjectStringCache.cs
+++ b/src/XMakeBuildEngine/Evaluation/ProjectStringCache.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Construction
     /// <summary>
     /// This class will cache string values for loaded Xml files.
     /// </summary>
-    [DebuggerDisplay("#Strings={Count} #Documents={documents.Count}")]
+    [DebuggerDisplay("#Strings={Count} #Documents={_documents.Count}")]
     internal class ProjectStringCache
     {
         /// <summary>
@@ -228,7 +228,7 @@ namespace Microsoft.Build.Construction
         /// Represents an entry in the ProjectStringCache.
         /// Can't be a struct because the copy-by-value and the ref counting don't go well together.
         /// </summary>
-        [DebuggerDisplay("Count={refCount} String={cachedString}")]
+        [DebuggerDisplay("Count={_refCount} String={_cachedString}")]
         private class StringCacheEntry : IKeyed
         {
             /// <summary>

--- a/src/XMakeBuildEngine/Instance/HostServices.cs
+++ b/src/XMakeBuildEngine/Instance/HostServices.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Execution
     /// Implementation of HostServices that
     /// mediates access from the build to the host.
     /// </summary>
-    [DebuggerDisplay("#Entries={hostObjectMap.Count}")]
+    [DebuggerDisplay("#Entries={_hostObjectMap.Count}")]
     public class HostServices
     {
         /// <summary>
@@ -232,7 +232,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Bag holding host object information for a single project file.
         /// </summary>
-        [DebuggerDisplay("#HostObjects={hostObjects.Count}")]
+        [DebuggerDisplay("#HostObjects={_hostObjects.Count}")]
         private class HostObjects
         {
             /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectItemDefinitionInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectItemDefinitionInstance.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Execution
     /// An evaluated item definition for a particular item-type, divested of all references to XML.
     /// Immutable.
     /// </summary>
-    [DebuggerDisplay("{itemType} #Metadata={MetadataCount}")]
+    [DebuggerDisplay("{_itemType} #Metadata={MetadataCount}")]
     public class ProjectItemDefinitionInstance : IKeyed, IMetadataTable, IItemDefinition<ProjectMetadataInstance>
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectItemGroupTaskInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectItemGroupTaskInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Wraps an unevaluated itemgroup under a target.
     /// Immutable.
     /// </summary>
-    [DebuggerDisplay("Condition={condition}")]
+    [DebuggerDisplay("Condition={_condition}")]
     public class ProjectItemGroupTaskInstance : ProjectTargetInstanceChild
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectItemGroupTaskItemInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectItemGroupTaskItemInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Wraps an unevaluated item under an itemgroup in a target.
     /// Immutable.
     /// </summary>
-    [DebuggerDisplay("{itemType} Include={include} Exclude={exclude} Remove={remove} Condition={condition}")]
+    [DebuggerDisplay("{_itemType} Include={_include} Exclude={_exclude} Remove={_remove} Condition={_condition}")]
     public class ProjectItemGroupTaskItemInstance
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectItemGroupTaskMetadataInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectItemGroupTaskMetadataInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Wraps an unevaluated metadatum under an item in an itemgroup in a target
     /// Immutable.
     /// </summary>
-    [DebuggerDisplay("{name} Value={value} Condition={condition}")]
+    [DebuggerDisplay("{_name} Value={_value} Condition={_condition}")]
     public class ProjectItemGroupTaskMetadataInstance
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectMetadataInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectMetadataInstance.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Execution
     /// Added and removed via methods on the ProjectItemInstance object.
     /// IMMUTABLE OBJECT.
     /// </summary>
-    [DebuggerDisplay("{name}={EvaluatedValue}")]
+    [DebuggerDisplay("{_name}={EvaluatedValue}")]
     public class ProjectMetadataInstance : IKeyed, IValued, IEquatable<ProjectMetadataInstance>, INodePacketTranslatable, IMetadatum, IDeepCloneable<ProjectMetadataInstance>, IImmutable
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectOnErrorInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectOnErrorInstance.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Execution
     /// <remarks>
     /// This is an immutable class
     /// </remarks>
-    [DebuggerDisplay("ExecuteTargets={executeTargets} Condition={condition}")]
+    [DebuggerDisplay("ExecuteTargets={_executeTargets} Condition={_condition}")]
     public sealed class ProjectOnErrorInstance : ProjectTargetInstanceChild
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectPropertyGroupTaskInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectPropertyGroupTaskInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Wraps an unevaluated propertygroup under a target.
     /// Immutable.
     /// </summary>
-    [DebuggerDisplay("Condition={condition}")]
+    [DebuggerDisplay("Condition={_condition}")]
     public class ProjectPropertyGroupTaskInstance : ProjectTargetInstanceChild
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectPropertyGroupTaskPropertyInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectPropertyGroupTaskPropertyInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// Wraps an unevaluated property under an propertygroup in a target.
     /// Immutable.
     /// </summary>
-    [DebuggerDisplay("{name}={Value} Condition={condition}")]
+    [DebuggerDisplay("{_name}={Value} Condition={_condition}")]
     public class ProjectPropertyGroupTaskPropertyInstance
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectPropertyInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectPropertyInstance.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Execution
     /// Wraps an evaluated property for build purposes.
     /// Added and removed via methods on the ProjectInstance object.
     /// </summary>
-    [DebuggerDisplay("{name}={escapedValue}")]
+    [DebuggerDisplay("{_name}={_escapedValue}")]
     public class ProjectPropertyInstance : IKeyed, IValued, IProperty, IEquatable<ProjectPropertyInstance>, INodePacketTranslatable, IDeepCloneable<ProjectPropertyInstance>
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectTargetInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectTargetInstance.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Execution
     /// <remarks>
     /// This is an immutable class.
     /// </remarks>
-    [DebuggerDisplay("Name={name} Count={children.Count} Condition={condition} Inputs={inputs} Outputs={outputs} DependsOnTargets={dependsOnTargets}")]
+    [DebuggerDisplay("Name={_name} Count={_children.Count} Condition={_condition} Inputs={_inputs} Outputs={_outputs} DependsOnTargets={_dependsOnTargets}")]
     public sealed class ProjectTargetInstance : IImmutable, IKeyed
     {
         /// <summary>

--- a/src/XMakeBuildEngine/Instance/ProjectTaskInstance.cs
+++ b/src/XMakeBuildEngine/Instance/ProjectTaskInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Execution
     /// <remarks>
     /// This is an immutable class
     /// </remarks>
-    [DebuggerDisplay("Name={name} Condition={condition} ContinueOnError={continueOnError} MSBuildRuntime={MSBuildRuntime} MSBuildArchitecture={MSBuildArchitecture} #Parameters={parameters.Count} #Outputs={outputs.Count}")]
+    [DebuggerDisplay("Name={_name} Condition={_condition} ContinueOnError={_continueOnError} MSBuildRuntime={MSBuildRuntime} MSBuildArchitecture={MSBuildArchitecture} #Parameters={_parameters.Count} #Outputs={_outputs.Count}")]
     public sealed class ProjectTaskInstance : ProjectTargetInstanceChild
     {
         /// <summary>


### PR DESCRIPTION
Fix #610.

I used Resharper to find invalid names.
Please note that there are still 3 unresolved symbols:

    XMakeBuildEngine\Construction\ProjectOnErrorElement.cs:23 Cannot resolve symbol 'ExecuteTargets'
    XMakeBuildEngine\Construction\ProjectOutputElement.cs:22 Cannot resolve symbol 'Name'
    XMakeBuildEngine\Construction\ProjectOutputElement.cs:22 Cannot resolve symbol 'ItemName'

I do not know how to fix them (there is no corresponding property)