### PR TITLE
Respect $(TargetFrameworkRootPath) in ToolLocationHelper APIs

### DIFF
--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -2472,6 +2472,106 @@ namespace Microsoft.Build.UnitTests
         }
 #endif
 
+        [Fact]
+        public void GetPathToStandardLibrariesWithCustomTargetFrameworkRoot()
+        {
+            string frameworkName = "Foo Framework";
+            string frameworkVersion = "v0.1";
+            string rootDir = Path.Combine(Path.GetTempPath(), "framework-root");
+
+            try {
+                string asmPath = CreateNewFrameworkAndGetAssembliesPath(frameworkName, frameworkVersion, rootDir);
+
+                string stdLibPath = ToolLocationHelper.GetPathToStandardLibraries(frameworkName, frameworkVersion, String.Empty, null, rootDir);
+                Assert.Equal(asmPath, stdLibPath);
+            } finally {
+                FileUtilities.DeleteDirectoryNoThrow(rootDir, recursive:true);
+            }
+        }
+
+        [Fact]
+        public void GetPathToStandardLibrariesWithNullTargetFrameworkRootPath()
+        {
+            string frameworkName = ".NETFramework";
+            string frameworkVersion = "v4.5";
+
+            string v45Path = ToolLocationHelper.GetPathToStandardLibraries(frameworkName, frameworkVersion, String.Empty);
+            // This look up should fall back the default path with the .NET frameworks
+            string v45PathWithNullRoot = ToolLocationHelper.GetPathToStandardLibraries(frameworkName, frameworkVersion, String.Empty, null);
+
+            Assert.Equal(v45Path, v45PathWithNullRoot);
+        }
+
+        [Fact]
+        public void GetPathToReferenceAssembliesWithCustomTargetFrameworkRoot()
+        {
+            string frameworkName = "Foo Framework";
+            string frameworkVersion = "v0.1";
+            string rootDir = Path.Combine(Path.GetTempPath(), "framework-root");
+
+            try {
+                string asmPath = CreateNewFrameworkAndGetAssembliesPath(frameworkName, frameworkVersion, rootDir);
+
+                var stdLibPaths = ToolLocationHelper.GetPathToReferenceAssemblies(frameworkName, frameworkVersion, String.Empty, rootDir);
+                if (NativeMethodsShared.IsMono)
+                {
+                    Assert.Equal(2, stdLibPaths.Count);
+                    Assert.Equal(Path.Combine(rootDir, frameworkName, frameworkVersion) + Path.DirectorySeparatorChar.ToString(), stdLibPaths[0]);
+                    Assert.Equal(asmPath + Path.DirectorySeparatorChar.ToString(), stdLibPaths[1]);
+                }
+                else
+                {
+                    Assert.Equal(1, stdLibPaths.Count);
+                    Assert.Equal(Path.Combine(rootDir, frameworkName, frameworkVersion) + Path.DirectorySeparatorChar.ToString(), stdLibPaths[0]);
+                }
+
+            } finally {
+                FileUtilities.DeleteDirectoryNoThrow(rootDir, recursive:true);
+            }
+        }
+
+        [Fact]
+        public void GetPathToReferenceAssembliesWithNullTargetFrameworkRootPath()
+        {
+            string frameworkName = ".NETFramework";
+            string frameworkVersion = "v4.5";
+
+            var v45Paths = ToolLocationHelper.GetPathToReferenceAssemblies(frameworkName, frameworkVersion, String.Empty);
+
+            // This look up should fall back the default path with the .NET frameworks
+            var v45PathsWithNullRoot = ToolLocationHelper.GetPathToReferenceAssemblies(frameworkName, frameworkVersion, String.Empty, null);
+
+            Assert.Equal(v45Paths, v45PathsWithNullRoot);
+        }
+
+        string CreateNewFrameworkAndGetAssembliesPath(string frameworkName, string frameworkVersion, string rootDir)
+        {
+            string frameworkListXml = null;
+            if (NativeMethodsShared.IsMono)
+            {
+                // Mono uses an extra attribute to point to the location of the corresponding
+                // assemblies
+                frameworkListXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                    <FileList  Name=""{0}"" TargetFrameworkDirectory=""..\assemblies"" />";
+            }
+            else
+            {
+                frameworkListXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                    <FileList  Name=""{0}""/>";
+            }
+
+            string redistPath = Path.Combine(rootDir, frameworkName, frameworkVersion, "RedistList");
+            string asmPath = Path.Combine(rootDir, frameworkName, frameworkVersion, NativeMethodsShared.IsMono ? "assemblies" : String.Empty);
+
+            Directory.CreateDirectory(redistPath);
+            Directory.CreateDirectory(asmPath);
+
+            File.WriteAllText(Path.Combine(redistPath, "FrameworkList.xml"), String.Format(frameworkListXml, frameworkName));
+            File.WriteAllText(Path.Combine(asmPath, "mscorlib.dll"), String.Empty);
+
+            return asmPath;
+        }
+
         /*
         * Method:   GetDirectories
         *

--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -78,7 +78,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- The FrameworkPathOverride is required for the inproc visual basic compiler to initialize when targeting target frameworks less than 4.0. If .net 2.0 is not installed then the property value above will not provide the location
              of mscorlib. This is also true if the build author overrides this property to some other directory which does not contain mscorlib.dll. In the case we cannot find mscorlib.dll at the correct location
              we need to find a directory which does contain mscorlib to allow the inproc compiler to initialize and give us the chance to show certain dialogs in the IDE (which only happen after initialization).-->
-    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget)))</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath)))</FrameworkPathOverride>
     <FrameworkPathOverride Condition="!Exists('$(FrameworkPathOverride)\mscorlib.dll')">$(MSBuildFrameworkToolsPath)</FrameworkPathOverride>
   </PropertyGroup>
 


### PR DESCRIPTION
`FrameworkPathOverride` set in `Microsoft.Common.CurrentVersion.targets`,
does not use the `$(TargetFrameworkRootPath)` while calling
`ToolLocationHelper.GetPathToStandardLibraries(...)` .

    <FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget)))</FrameworkPathOverride>

This means that if the project is targeting a custom framework,
which is installed in a directory different from the default root path,
then it won't be able to find the framework and eventually,
`FrameworkPathOverride` will be set to an incorrect path. This can be
seen with mono/osx which has an alternate directory for
Xamarin mobile frameworks, set on the command line like `/p:TargetFrameworkRootPath=/Library/Frameworks/Mono.framework/External/xbuild-frameworks` .

This manifests as an `_ExplicitReference` getting added to
`mscorlib.dll` but with the wrong path, causing compilation to fail.