### PR TITLE
Xplat script improvements

### DIFF
--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -18,7 +18,7 @@ set MSBUILD_CUSTOM_PATH=%~dp0Tools\MSBuild.exe
 echo.
 echo ** Rebuilding MSBuild with binaries from BuildTools
 
-call "%~dp0build.cmd" /t:RebuildAndTest /p:Configuration=Debug-NetCore
+call "%~dp0build.cmd" /t:Rebuild /p:Configuration=Debug-NetCore
 
 if %ERRORLEVEL% NEQ 0 (
     echo.

--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -48,6 +48,7 @@ if %ERRORLEVEL% NEQ 0 (
 
 :: Rebuild with bootstrapped msbuild
 set MSBUILDLOGPATH=%~dp0msbuild_local_build.log
+set RUNTIME_HOST="%~dp0bin\Bootstrap\CoreRun.exe"
 set MSBUILD_CUSTOM_PATH="%~dp0bin\Bootstrap\MSBuild.exe"
 
 echo.

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -171,30 +171,28 @@ case $target in
 esac
 
 # Determine runtime host
-case $host in
-    CoreCLR)
-        RUNTIME_HOST="$TOOLS_DIR/corerun"
-        RUNTIME_HOST_ARGS=""
-        MSBUILD_EXE="$TOOLS_DIR/MSBuild.exe"
-        EXTRA_ARGS="$EXTRA_ARGS /m"
-        ;;
+until [[ "$RUNTIME_HOST" != "" ]]; do
+      case $host in
+          CoreCLR)
+              RUNTIME_HOST="$TOOLS_DIR/corerun"
+              RUNTIME_HOST_ARGS=""
+              MSBUILD_EXE="$TOOLS_DIR/MSBuild.exe"
+              EXTRA_ARGS="$EXTRA_ARGS /m"
+              ;;
 
-    Mono)
-        setMonoDir
-        RUNTIME_HOST="${MONO_BIN_DIR}mono"
-        MSBUILD_EXE="$PACKAGES_DIR/msbuild/MSBuild.exe"
+          Mono)
+              setMonoDir
+              RUNTIME_HOST="${MONO_BIN_DIR}mono"
+              MSBUILD_EXE="$PACKAGES_DIR/msbuild/MSBuild.exe"
 
-        downloadMSBuildForMono
-        ;;
-    *)
-        echo "Unsupported host detected: $host. Configuring as if for CoreCLR"
-        RUNTIME_HOST="$TOOLS_DIR/corerun"
-        RUNTIME_HOST_ARGS=""
-        MSBUILD_EXE="$TOOLS_DIR/MSBuild.exe"
-        EXTRA_ARGS="$EXTRA_ARGS /m"
-
-        ;;
-esac
+              downloadMSBuildForMono
+              ;;
+          *)
+              echo "Unsupported host detected: $host. Configuring as if for CoreCLR"
+              host=CoreCLR
+              ;;
+      esac
+done
 
 BUILD_MSBUILD_ARGS="$PROJECT_FILE_ARG /t:$TARGET_ARG /p:OS=$OS_ARG /p:Configuration=$CONFIGURATION /verbosity:minimal $EXTRA_ARGS"
 

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -85,6 +85,7 @@ MOVE_LOG_PATH="$THIS_SCRIPT_PATH"/"msbuild_move_bootstrap.log"
 
 PROJECT_FILE_ARG='"'"$THIS_SCRIPT_PATH/build.proj"'"'
 BOOTSTRAP_FILE_ARG='"'"$THIS_SCRIPT_PATH/BootStrapMSBuild.proj"'"'
+CORERUN_BOOTSTRAPPED_EXE='"'"$THIS_SCRIPT_PATH/bin/Bootstrap/corerun"'"'
 MSBUILD_BOOTSTRAPPED_EXE='"'"$THIS_SCRIPT_PATH/bin/Bootstrap/MSBuild.exe"'"'
 
 # Default msbuild arguments
@@ -212,6 +213,12 @@ echo
 echo "** Moving bootstrapped MSBuild to the bootstrap folder"
 MOVE_MSBUILD_ARGS="$BOOTSTRAP_FILE_ARG /p:OS=$OS_ARG /p:Configuration=$CONFIGURATION /verbosity:minimal"
 runMSBuildWith "$RUNTIME_HOST" "$RUNTIME_HOST_ARGS" "$MSBUILD_EXE" "$MOVE_MSBUILD_ARGS" "$MOVE_LOG_PATH"
+
+# Use the "current" coreclr runtime host; the one in tools/ may be
+# stale and incompatible.
+if [[ "$host" = "CoreCLR" ]]; then
+    RUNTIME_HOST=$CORERUN_BOOTSTRAPPED_EXE
+fi
 
 echo
 echo "** Rebuilding MSBuild with locally built binaries"

--- a/dir.props
+++ b/dir.props
@@ -197,7 +197,7 @@
   <PropertyGroup>
     <CSharpTargets>$(MSBuildToolsPath)\Microsoft.CSharp.targets</CSharpTargets>
     <CSharpPortableTargets>$(MSBuildExtensionsPath32)\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets</CSharpPortableTargets>
-    <CSharpPortableTargetsFallback>$(ToolsDir)extensions\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets</CSharpPortableTargetsFallback>
+    <CSharpPortableTargetsFallback>$(ToolsDir)Extensions\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets</CSharpPortableTargetsFallback>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetCoreSurface)' != 'true'">

--- a/dir.props
+++ b/dir.props
@@ -32,9 +32,7 @@
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <SourceDir>$(RepoRoot)src$([System.IO.Path]::DirectorySeparatorChar)</SourceDir>
     <SamplesDir>$(RepoRoot)Samples$([System.IO.Path]::DirectorySeparatorChar)</SamplesDir>
-    <ToolsDir Condition="'$(MSBuildRuntimeType)'!='Core'">$(RepoRoot)Tools$([System.IO.Path]::DirectorySeparatorChar)</ToolsDir>
-    <!-- When running in .NET Core, use the MSBuild bin path as the ToolsDir.  This supports the bootstrap scenario -->
-    <ToolsDir Condition="'$(MSBuildRuntimeType)'=='Core'">$(MSBuildBinPath)$([System.IO.Path]::DirectorySeparatorChar)</ToolsDir>
+    <ToolsDir>$(RepoRoot)Tools$([System.IO.Path]::DirectorySeparatorChar)</ToolsDir>
     <ToolPackagesDir>$(RepoRoot)packages$([System.IO.Path]::DirectorySeparatorChar)</ToolPackagesDir>
     <MicroBuildDir>$(ToolPackagesDir)\MicroBuild.Core\$(MicroBuildVersion)\build\</MicroBuildDir>
 

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __init_tools_log=$__scriptpath/init-tools.log
 __PACKAGES_DIR=$__scriptpath/packages

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -74,11 +74,11 @@ if [ ! -e $__PROJECT_JSON_FILE ]; then
     if [ ! -d "$__PROJECT_JSON_PATH" ]; then mkdir "$__PROJECT_JSON_PATH"; fi
     echo $__PROJECT_JSON_CONTENTS > "$__PROJECT_JSON_FILE"
 
-    if [ ! -e $__BUILD_TOOLS_PATH ]; then
+    if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then
         echo "Restoring BuildTools version $__BUILD_TOOLS_PACKAGE_VERSION..."
         echo "Running: $__DOTNET_CMD restore \"$__PROJECT_JSON_FILE\" --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE" >> $__init_tools_log
         $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE >> $__init_tools_log
-        if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."; fi
+        if [ ! -e "$__BUILD_TOOLS_PATH/init-tools.sh" ]; then echo "ERROR: Could not restore build tools correctly. See '$__init_tools_log' for more details."; rm "$__PROJECT_JSON_FILE"; exit 1; fi
     fi
 
     echo "Initializing BuildTools..."

--- a/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -894,7 +894,7 @@ namespace Microsoft.Build.UnitTests.Logging
                 new EventArgsEqualityComparer<BuildStartedEventArgs>());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/437")]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "mono-osx-failing")]
         public void LogBuildStartedCriticalOnly()

--- a/targets/BootStrapAppLocalMSBuild.proj
+++ b/targets/BootStrapAppLocalMSBuild.proj
@@ -5,6 +5,9 @@
   <Target Name="Build">
     <ItemGroup>
       <DeployedItems Include="$(DeploymentDir)\**\*.*"/>
+      <!-- Work around https://github.com/Microsoft/msbuild/issues/658
+           by making sure NuGet DLLs are next to MSBuild.exe -->
+      <DeployedItems Include="$(ToolsDir)\NuGet*.dll" />
     </ItemGroup>
 
     <RemoveDir

--- a/targets/BootStrapAppLocalMSBuild.proj
+++ b/targets/BootStrapAppLocalMSBuild.proj
@@ -14,6 +14,10 @@
           DestinationFolder="$(BootstrapDestination)\%(RecursiveDir)"
           />
 
+    <!-- Microsoft.Portable.CSharp.targets imports this file with a capital T -->
+    <Copy SourceFiles="$(DeploymentDir)\Microsoft.CSharp.targets"
+          DestinationFiles="$(BootstrapDestination)\Microsoft.CSharp.Targets" />
+
     <RemoveDir
             Directories="$(BaseOutputPathWithConfig)" />
   </Target>


### PR DESCRIPTION
A few script fixes:

* Use the just-restored `corerun` for the second (post-bootstrap) build, for better test coverage and since that's required after the merge from master.
* Make `init-tools.sh` actually fail in more failure cases.

Fixes #628 and #590.

Thanks, @akoeplinger!