### PR TITLE
Exec: Convert dos line endings to unix ones when running on Unix.

### DIFF
--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -58,13 +58,25 @@ namespace Microsoft.Build.Tasks
         private readonly List<ITaskItem> _nonEmptyOutput = new List<ITaskItem>();
         private Encoding _standardErrorEncoding;
         private Encoding _standardOutputEncoding;
+        private string _command;
 
         #endregion
 
         #region Properties
 
         [Required]
-        public string Command { get; set; }
+        public string Command
+        {
+            get { return _command; }
+            set
+            {
+                _command = value;
+                if (Path.DirectorySeparatorChar == '/')
+                {
+                    _command = _command.Replace("\r\n", "\n");
+                }
+            }
+        }
 
         public string WorkingDirectory { get; set; }
 


### PR DESCRIPTION
The contents of `Command` are put into a script file and having `\r` an
empty line causes bash to complain, like:

    <Exec Command="^M
    echo hello
    ^M
    "/>

.. when built :

    /Users/ankit/test/msbuild/exec.proj(4,3): error MSB3073: The command "
    /Users/ankit/test/msbuild/exec.proj(4,3): error MSB3073: echo hello
    /Users/ankit/test/msbuild/exec.proj(4,3): error MSB3073:
    /Users/ankit/test/msbuild/exec.proj(4,3): error MSB3073: " exited with code 127.