### PR TITLE
ToolTask: Preserve the temporary files if MSBUILDPRESERVETOOLTEMPFILES

### DIFF
--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Build.Utilities
     /// </remarks>
     public abstract class ToolTask : Task, ICancelableTask
     {
+        private static bool s_preserveTempFiles = String.Equals(Environment.GetEnvironmentVariable("MSBUILDPRESERVETOOLTEMPFILES"), "1", StringComparison.Ordinal);
+
         #region Constructors
 
         /// <summary>
@@ -930,6 +932,12 @@ namespace Microsoft.Build.Utilities
         /// <param name="filename">File to delete</param>
         protected void DeleteTempFile(string fileName)
         {
+            if (s_preserveTempFiles)
+            {
+                Log.LogMessageFromText($"Preserving temporary file '{fileName}'", MessageImportance.Low);
+                return;
+            }
+
             try
             {
                 File.Delete(fileName);
@@ -1648,7 +1656,7 @@ namespace Microsoft.Build.Utilities
                 // Clean up after ourselves.
                 if (_temporaryBatchFile != null && File.Exists(_temporaryBatchFile))
                 {
-                    File.Delete(_temporaryBatchFile);
+                    DeleteTempFile(_temporaryBatchFile);
                 }
             }
         } // Execute()


### PR DESCRIPTION
.. environment variable is set. This affects temporary files like
script/batch files, response files generated by Exec task or similar
temporary files generated by Tasks inheriting from ToolTask .