### PR TITLE
Build only MSBuild.exe platform specific

### DIFF
--- a/CreateBootstrappedMSBuild.cmd
+++ b/CreateBootstrappedMSBuild.cmd
@@ -1,12 +1,11 @@
 :: Usage:
-:: BuildAndCopy
+:: Rebuild the repo and copy to bin\bootstrap. Includes required MSBuild
+:: companion files copied from your local machine.
 :: 
-:: Example: BuildAndCopy.cmd
+:: Example: CreateBootstrappedMSBuild.cmd <AdditionalBuildCommand>
 
 @echo off
 setlocal
-
-set DebugBuildOutputPath=%~dp0bin\Windows_NT\Debug
 
 :: Check prerequisites
 if not defined VS140COMNTOOLS (
@@ -16,15 +15,14 @@ if not defined VS140COMNTOOLS (
 )
 
 if not "%1"=="" (
-    set OutputPath=%1
+    set AdditionalBuildCommand=%1
 )
 
 echo ** Building with the installed MSBuild
-echo ** Output Path: %DebugBuildOutputPath%
-echo ** Additional Build Parameters:%AdditionalBuildCommand%
+echo ** Additional Build Parameters: %AdditionalBuildCommand%
 echo.
 :: Build MSBuild
-call "%~dp0build.cmd" /t:Rebuild %AdditionalBuildCommand%
+call "%~dp0build.cmd" /t:Rebuild /p:Platform=x86 %AdditionalBuildCommand%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 
 :: Kill Roslyn, which may have handles open to files we want
@@ -38,7 +36,7 @@ if %BUILDERRORLEVEL% NEQ 0 (
 
 :: Make a copy of our build
 echo ** Copying bootstrapped MSBuild to the bootstrap folder
-msbuild /verbosity:minimal CreatePrivateMSBuildEnvironment.proj
+msbuild /verbosity:minimal CreatePrivateMSBuildEnvironment.proj /p:Platform=x86
 if %ERRORLEVEL% NEQ 0 (
     echo.
     echo Failed building CreatePrivateMSBuildEnvironment.proj with error %ERRORLEVEL%

--- a/RebuildWithLocalMSBuild.cmd
+++ b/RebuildWithLocalMSBuild.cmd
@@ -1,12 +1,10 @@
 :: This script will:
-::   1) Rebuild MSBuild source tree.
-::   2) Create a copy of the build output in bin\MSBuild
+::   1) Rebuild MSBuild source tree (x86 only).
+::   2) Create a "bootstrapped" copy of the build output in bin\MSBuild.
 ::   3) Build the source tree again with the MSBuild.exe in step 2.
 
 @echo off
 setlocal
-
-set MSBuildTempPath=%~dp0bin\MSBuild
 
 :: Check prerequisites
 if not defined VS140COMNTOOLS (
@@ -15,12 +13,13 @@ if not defined VS140COMNTOOLS (
     exit /b 1
 )
 
-:: Build and copy output to bin\bootstrap
+:: Build and create bootstrapped MSBuild to bin\bootstrap
+:: Note: This will always build with Platform=x86
 set MSBUILDLOGPATH=%~dp0msbuild_bootstrap.log
-call "%~dp0BuildAndCopy.cmd"
+call "%~dp0CreateBootstrappedMSBuild.cmd"
 if %ERRORLEVEL% NEQ 0 (
     echo.
-    echo BuildAndCopy.cmd failed with errorlevel %ERRORLEVEL% 1>&2
+    echo CreateBootstrappedMSBuild.cmd failed with errorlevel %ERRORLEVEL% 1>&2
     goto :error
 )
 

--- a/dir.props
+++ b/dir.props
@@ -77,8 +77,13 @@
   <!-- Set default Configuration and Platform -->
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' ==''">Debug</Configuration>
-    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
-    <PlatformTarget Condition="'$(PlatformTarget)'==''">$(Platform)</PlatformTarget>
+    <Platform Condition="'$(Platform)'==''">x86</Platform>
+
+    <!-- Only build for specific platforms when PlatformSpecificBuild == true. Otherwise
+         build for AnyCPU. Only MSBuild.exe and MSBuildTaskHost.exe should need this -->
+    <PlatformTarget Condition="'$(PlatformSpecificBuild)'!='true'">AnyCPU</PlatformTarget>
+    <PlatformTarget Condition="'$(PlatformSpecificBuild)'=='true'">$(Platform)</PlatformTarget>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
 
   <!-- Setup Default symbol and optimization for Configuration -->

--- a/src/XMakeCommandLine/MSBuild.csproj
+++ b/src/XMakeCommandLine/MSBuild.csproj
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PlatformSpecificBuild>true</PlatformSpecificBuild>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{23C9FD0E-70C5-4F1F-B08A-D2774240FB51}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/XMakeCommandLine/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PlatformSpecificBuild>true</PlatformSpecificBuild>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>


### PR DESCRIPTION
This change will build MSBuild.exe and MSBuildTaskHost.exe as x86/x64 and
all other assemblies AnyCPU. This matches the shipping configuration.

Also replaced AnyCPU default with x86 to match the the default in our
shipping code.

Closes #618

When building **x86**:

```
MSBuild.exe
Version   : v4.0.30319
CLR Header: 2.5
PE        : PE32
CorFlags  : 0xb
ILONLY    : 1
32BITREQ  : 1
32BITPREF : 0
Signed    : 1
```
```
Microsoft.Build.dll
Version   : v4.0.30319
CLR Header: 2.5
PE        : PE32
CorFlags  : 0x9
ILONLY    : 1
32BITREQ  : 0
32BITPREF : 0
Signed    : 1
```

When building **x64**:
```
Version   : v4.0.30319
CLR Header: 2.5
PE        : PE32+
CorFlags  : 0x9
ILONLY    : 1
32BITREQ  : 0
32BITPREF : 0
Signed    : 1
```
```
Version   : v4.0.30319
CLR Header: 2.5
PE        : PE32
CorFlags  : 0x9
ILONLY    : 1
32BITREQ  : 0
32BITPREF : 0
Signed    : 1
```