### PR TITLE
Use net45 version of BuildTools packaging tasks

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -40,6 +40,7 @@
 
     <!-- Tell build tools to use the full framework dlls that contain build tasks (like the nuget assets task) -->
     <BuildToolsTaskDir>$(ToolsDir)net45/</BuildToolsTaskDir>
+    <PackagingTaskDir>$(ToolsDir)net45/</PackagingTaskDir>
 
     <!-- Output directories -->
     <BinDir>$(RepoRoot)bin$([System.IO.Path]::DirectorySeparatorChar)</BinDir>


### PR DESCRIPTION
Apparently BuildTools separates tasks in two categories, build tasks and packaging tasks.

Build tasks were setup to use net46 published tasks, but packaging tasks were not. Fixed the mismatch by making both resolve to net46.

This caused the VSTS microbuild build to fail in the NugetPack task.