### PR TITLE
Support process trees with both 32- and 64-bit processes in FileTracker

### DIFF
--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -87,8 +87,9 @@ namespace Microsoft.Build.Utilities
         // The name of the standalone tracker tool.
         private static string s_TrackerFilename = "Tracker.exe";
 
-        // The name of the assembly that is injected into the executing process
-        private static string s_FileTrackerFilename = "FileTracker.dll";
+        // The name of the assembly that is injected into the executing process.
+        // Detours handles picking between FileTracker{32,64}.dll so only mention one.
+        private static string s_FileTrackerFilename = "FileTracker32.dll";
         #endregion
 
         #region Static constructor
@@ -587,60 +588,15 @@ namespace Microsoft.Build.Utilities
                 if (!File.Exists(trackerPath))
                 {
                     // if an override path was specified, that's it -- we don't want to fall back if the file
-                    // is not found there.  
+                    // is not found there.
                     trackerPath = null;
                 }
             }
             else
             {
-                switch (toolType)
-                {
-                    case ExecutableType.Native32Bit:
-                        // A native executable that's 32-bit.  Just return the 32-bit path 
-                        trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness32);
-                        break;
-                    case ExecutableType.Native64Bit:
-                        // A native executable that's 64-bit.  Just return the 64-bit path 
-                        trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness64);
-                        break;
-                    case ExecutableType.ManagedIL:
-                        // Next most likely -- the tool is a managed executable that has not been explicitly marked
-                        // either 32 or 64 bit.  
-                        // This case is slightly tricky -- we have to return the path to the 64-bit tracker if we're running 
-                        // on a 64-bit machine, and the 32-bit tracker if we're running on a 32-bit machine.  
-                        trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness64);
-
-                        // If the path is null, that means there is no 64-bit framework -- that's fine, return the 32-bit path instead. 
-                        if (trackerPath == null)
-                        {
-                            trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness32);
-                        }
-                        break;
-                    case ExecutableType.Managed32Bit:
-                        // A managed executable that has been explicitly marked 32-bit.  Just return the 32-bit path.  
-                        trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness32);
-                        break;
-                    case ExecutableType.Managed64Bit:
-                        // A managed executable that has been explicitly marked 64-bit.  Just return the 64-bit path.  If this 
-                        // is a 32-bit machine, then we will return null, and the error will be caught and handled appropriately 
-                        // elsewhere. 
-                        trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness64);
-                        break;
-                    case ExecutableType.SameAsCurrentProcess:
-                        // Figure out what bitness the current process is and return that bitness of Tracker.exe.  
-                        if (IntPtr.Size == sizeof(Int32))
-                        {
-                            trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness32);
-                        }
-                        else
-                        {
-                            trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Bitness64);
-                        }
-                        break;
-                    default:
-                        ErrorUtilities.ThrowInternalErrorUnreachable();
-                        return null;
-                }
+                // Since Detours can handle cross-bitness process launches, the toolType
+                // can be ignored; just return the path corresponding to the current architecture.
+                trackerPath = GetPath(filename, DotNetFrameworkArchitecture.Current);
             }
 
             return trackerPath;
@@ -655,8 +611,6 @@ namespace Microsoft.Build.Utilities
         /// <returns></returns>
         private static string GetPath(string filename, DotNetFrameworkArchitecture bitness)
         {
-            string trackerPath;
-
             // Make sure that if someone starts passing the wrong thing to this method we don't silently 
             // eat it and do something possibly unexpected. 
             ErrorUtilities.VerifyThrow(
@@ -666,31 +620,9 @@ namespace Microsoft.Build.Utilities
                                        filename
                                        );
 
-            // Look for FileTracker.dll/FileTracker.exe first in the MSBuild tools directory, then fall back to .NET framework directory
-            // and finally to .NET SDK directories.
-            trackerPath = ToolLocationHelper.GetPathToBuildToolsFile(filename, ToolLocationHelper.CurrentToolsVersion, bitness);
-
-            if (String.IsNullOrEmpty(trackerPath))
-            {
-                trackerPath = ToolLocationHelper.GetPathToDotNetFrameworkFile(filename, TargetDotNetFrameworkVersion.VersionLatest, bitness);
-
-                if ((String.IsNullOrEmpty(trackerPath) || !File.Exists(trackerPath)) && s_TrackerFilename.Equals(filename, StringComparison.OrdinalIgnoreCase))
-                {
-                    // fall back to looking in the SDK directory -- this is where Tracker.exe will be in the typical VS case.  First check 
-                    // in the SDK for the latest target framework and latest Visual Studio version, since we want to make sure that we get 
-                    // the most up-to-date version of FileTracker.  
-                    trackerPath = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(filename, TargetDotNetFrameworkVersion.Version45, VisualStudioVersion.VersionLatest, bitness);
-
-                    // If that didn't work, we may be in a scenario where, e.g., we have VS 10 on Windows 8, which comes with .NET 4.5
-                    // pre-installed.  In which case, the Dev11 (or other "latest" SDK) may not exist, but the Dev10 SDK might.  Check 
-                    // for that here. 
-                    if (trackerPath == null)
-                    {
-                        trackerPath = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(filename, TargetDotNetFrameworkVersion.Version40, bitness);
-                    }
-                }
-            }
-            return trackerPath;
+            // Look for FileTracker.dll/Tracker.exe in the MSBuild tools directory. They may exist elsewhere on disk,
+            // but other copies aren't guaranteed to be compatible with the latest.
+            return ToolLocationHelper.GetPathToBuildToolsFile(filename, ToolLocationHelper.CurrentToolsVersion, bitness);
         }
 
         /// <summary>

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -479,7 +479,6 @@ namespace Microsoft.Build.Utilities
         public static bool ForceOutOfProcTracking(ExecutableType toolType, string dllName, string cancelEventName)
         {
             bool trackOutOfProc = false;
-            string trackerPath = null;
 
             if (cancelEventName != null)
             {
@@ -489,37 +488,12 @@ namespace Microsoft.Build.Utilities
             else if (dllName != null)
             {
                 // If we have a DLL name, we need to track out of proc -- inproc tracking just uses
-                // the default FileTracker.dll from the path. 
+                // the default FileTracker
                 trackOutOfProc = true;
             }
-            else if (IntPtr.Size == sizeof(Int32))
-            {
-                // Current process is 32-bit.  So we need to spawn Tracker.exe if our tool is 
-                // explicitly marked as 64-bit OR is MSIL and we're installed on a 64-bit OS.  
-                if (toolType == ExecutableType.Managed64Bit || toolType == ExecutableType.Native64Bit)
-                {
-                    trackOutOfProc = true;
-                }
-                else if (toolType == ExecutableType.ManagedIL)
-                {
-                    trackerPath = ToolLocationHelper.GetPathToDotNetFrameworkFile(s_TrackerFilename, TargetDotNetFrameworkVersion.VersionLatest, DotNetFrameworkArchitecture.Bitness64);
 
-                    if (trackerPath != null)
-                    {
-                        // If we found a 64-bit path, we're on a 64-bit OS and need to use it.  Otherwise, we're fine. 
-                        trackOutOfProc = true;
-                    }
-                }
-            }
-            else if (IntPtr.Size == sizeof(Int64))
-            {
-                // Current process is 64-bit.  We need to spawn Tracker.exe if our tool is
-                // explicitly marked as 32-bit.  
-                if (toolType == ExecutableType.Managed32Bit || toolType == ExecutableType.Native32Bit)
-                {
-                    trackOutOfProc = true;
-                }
-            }
+            // toolType is not relevant now that Detours can handle child processes of a different
+            // bitness than the parent.
 
             return trackOutOfProc;
         }

--- a/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -783,6 +783,13 @@ class X
         {
             Console.WriteLine("Test: FileTrackerFindStrInX64X86ChainRepeatCommand");
 
+            if (!Environment.Is64BitOperatingSystem)
+            {
+                Console.WriteLine("FileTrackerFindStrInX64X86ChainRepeatCommand runs both 32-and 64-bit programs so it requires 64-bit Windows.");
+                Assert.IsTrue(true);
+                return;
+            }
+
             string[] tlogFiles = Directory.GetFiles(Environment.CurrentDirectory, "cmd*-findstr.*.1.tlog", SearchOption.TopDirectoryOnly);
             foreach (string tlogFile in tlogFiles)
             {
@@ -801,6 +808,13 @@ class X
         public void FileTrackerFindStrInX86X64ChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInX86X64ChainRepeatCommand");
+
+            if (!Environment.Is64BitOperatingSystem)
+            {
+                Console.WriteLine("FileTrackerFindStrInX86X64ChainRepeatCommand runs both 32-and 64-bit programs so it requires 64-bit Windows.");
+                Assert.IsTrue(true);
+                return;
+            }
 
             string[] tlogFiles = Directory.GetFiles(Environment.CurrentDirectory, "cmd*-findstr.*.1.tlog", SearchOption.TopDirectoryOnly);
             foreach (string tlogFile in tlogFiles)

--- a/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -412,6 +412,7 @@ namespace ConsoleApplication4
                 string fileTrackerPath = FileTracker.GetFileTrackerPath(ExecutableType.ManagedIL);
                 string commandArgs = "/d \"" + fileTrackerPath + "\" /u /c \"" + outputFile + "\"";
 
+                Console.WriteLine($"{trackerPath} {commandArgs}");
                 int exit = FileTrackerTestHelper.RunCommand(trackerPath, commandArgs);
                 Console.WriteLine("");
                 Assert.Equal(0, exit);
@@ -2230,7 +2231,7 @@ namespace ConsoleApplication4
             const string tlogRootName = "foo_inline";
             const string sourceFile = "inlinetrackingtest.txt";
             const string trackerResponseFile = "test-tracker.rsp";
-            const string fileTrackerParameters = "/d FileTracker.dll /r \"" + rootingMarker + "\"";
+            const string fileTrackerParameters = "/d FileTracker32.dll /r \"" + rootingMarker + "\"";
 
             File.Delete(toolReadTlog);
             File.Delete(sourceFile);

--- a/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -778,7 +778,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 
-        [TestMethod]
+        [Fact]
         public void FileTrackerFindStrInX64X86ChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInX64X86ChainRepeatCommand");
@@ -786,7 +786,7 @@ class X
             if (!Environment.Is64BitOperatingSystem)
             {
                 Console.WriteLine("FileTrackerFindStrInX64X86ChainRepeatCommand runs both 32-and 64-bit programs so it requires 64-bit Windows.");
-                Assert.IsTrue(true);
+                Assert.True(true);
                 return;
             }
 
@@ -800,11 +800,11 @@ class X
             int exit = FileTrackerTestHelper.RunCommand(s_defaultTrackerPath, "/d " + s_defaultFileTrackerPath + " /c " + s_cmd64Path + " /c " + s_cmd32Path + " /c findstr /ip foo test.in");
             tlogFiles = Directory.GetFiles(Environment.CurrentDirectory, "cmd*-findstr.read.1.tlog", SearchOption.TopDirectoryOnly);
             Console.WriteLine("");
-            Assert.AreEqual(0, exit);
+            Assert.Equal(0, exit);
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 
-        [TestMethod]
+        [Fact]
         public void FileTrackerFindStrInX86X64ChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInX86X64ChainRepeatCommand");
@@ -812,7 +812,7 @@ class X
             if (!Environment.Is64BitOperatingSystem)
             {
                 Console.WriteLine("FileTrackerFindStrInX86X64ChainRepeatCommand runs both 32-and 64-bit programs so it requires 64-bit Windows.");
-                Assert.IsTrue(true);
+                Assert.True(true);
                 return;
             }
 
@@ -826,7 +826,7 @@ class X
             int exit = FileTrackerTestHelper.RunCommand(s_defaultTrackerPath, "/d " + s_defaultFileTrackerPath + " /c " + s_cmd32Path + " /c " + s_cmd64Path + " /c findstr /ip foo test.in");
             tlogFiles = Directory.GetFiles(Environment.CurrentDirectory, "cmd*-findstr.read.1.tlog", SearchOption.TopDirectoryOnly);
             Console.WriteLine("");
-            Assert.AreEqual(0, exit);
+            Assert.Equal(0, exit);
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 

--- a/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
+++ b/src/Utilities/UnitTests/TrackedDependencies/FileTrackerTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             FileTrackerTestHelper.CleanTlogs();
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerHelp()
         {
             Console.WriteLine("Test: FileTracker");
@@ -84,7 +84,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.Equal(1, exit);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerBadArg()
         {
             Console.WriteLine("Test: FileTrackerBadArg");
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.True(log.Contains("TRK0000")); // bad arg
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerNoUIDll()
         {
             Console.WriteLine("Test: FileTrackerNoUIDll");
@@ -133,7 +133,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerNonexistentRspFile()
         {
             Console.WriteLine("Test: FileTrackerNonexistentRspFile");
@@ -154,7 +154,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.True(log.Contains("abc.rsp"));
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerWithDll()
         {
             Console.WriteLine("Test: FileTrackerWithDll");
@@ -164,7 +164,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.Equal(1, exit);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerReadOnlyTlog()
         {
             Console.WriteLine("Test: FileTrackerTlogWriteFailure");
@@ -196,7 +196,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrIn()
         {
             Console.WriteLine("Test: FileTrackerFindStrIn");
@@ -210,7 +210,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInOperations()
         {
             Console.WriteLine("Test: FileTrackerFindStrInOperations");
@@ -228,7 +228,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.True(foundW || foundA);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInOperationsExtended()
         {
             Console.WriteLine("Test: FileTrackerFindStrInOperationsExtended");
@@ -251,7 +251,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.True(foundCreateFileW || foundCreateFileA);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInOperationsExtended_AttributesOnly()
         {
             Console.WriteLine("Test: FileTrackerFindStrInOperationsExtended_AttributesOnly");
@@ -273,7 +273,7 @@ namespace Microsoft.Build.UnitTests.FileTracking
             Assert.True(foundCreateFileW || foundCreateFileA);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerExtendedDirectoryTracking()
         {
             Console.WriteLine("Test: FileTrackerExtendedDirectoryTracking");
@@ -395,7 +395,7 @@ namespace ConsoleApplication4
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInIncludeDuplicates()
         {
             Console.WriteLine("Test: FileTrackerFindStrInIncludeDuplicates");
@@ -436,7 +436,7 @@ namespace ConsoleApplication4
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "readtwice.read.1.tlog", 2);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerDoNotRecordWriteAsRead()
         {
             Console.WriteLine("Test: FileTrackerDoNotRecordWriteAsRead");
@@ -510,7 +510,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInCommandLine()
         {
             Console.WriteLine("Test: FileTrackerFindStrInCommandLine");
@@ -525,7 +525,7 @@ class X
             Assert.Equal("findstr /ip foo test.in", line);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInArgumentSpaces()
         {
             Console.WriteLine("Test: FileTrackerFindStrIn");
@@ -539,7 +539,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test file.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindUnicode()
         {
             Console.WriteLine("Test: FileTrackerFindUnicode");
@@ -554,7 +554,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("t\u1EBCst.in").ToUpperInvariant(), "find.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerStartProcessFindStrIn()
         {
             Console.WriteLine("Test: FileTrackerStartProcessFindStrIn");
@@ -570,7 +570,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerResponseFile()
         {
             Console.WriteLine("Test: FileTrackerResponseFile");
@@ -590,7 +590,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInRootFiles()
         {
             Console.WriteLine("Test: FileTrackerFindStrInRootFiles");
@@ -607,7 +607,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInRootFilesCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInRootFilesCommand");
@@ -627,7 +627,7 @@ class X
                                    FileTrackerTestHelper.ReadLineFromFile("findstr.command.1.tlog", 2));
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInRootFilesSpaces()
         {
             Console.WriteLine("Test: FileTrackerFindStrInRootFilesSpaces");
@@ -644,7 +644,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerHelperCommandLine()
         {
             Console.WriteLine("Test: FileTrackerHelperCommandLine");
@@ -661,7 +661,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerSortOut()
         {
             Console.WriteLine("Test: FileTrackerSortOut");
@@ -687,7 +687,7 @@ class X
                                    FileTrackerTestHelper.ReadLineFromFile("test.out", 1).ToUpperInvariant());
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerSortOutIntermediate()
         {
             Console.WriteLine("Test: FileTrackerSortOutIntermediate");
@@ -715,7 +715,7 @@ class X
         }
 
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerIntermediateDirMissing()
         {
             Console.WriteLine("Test: FileTrackerIntermediateDirMissing");
@@ -745,7 +745,7 @@ class X
                                    FileTrackerTestHelper.ReadLineFromFile("test.out", 1).ToUpperInvariant());
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInChain()
         {
             Console.WriteLine("Test: FileTrackerFindStrInChain");
@@ -759,7 +759,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), "cmd-findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInChainRepeatCommand");
@@ -778,7 +778,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInX64X86ChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInX64X86ChainRepeatCommand");
@@ -804,7 +804,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFindStrInX86X64ChainRepeatCommand()
         {
             Console.WriteLine("Test: FileTrackerFindStrInX86X64ChainRepeatCommand");
@@ -830,7 +830,7 @@ class X
             FileTrackerTestHelper.AssertFoundStringInTLog(Path.GetFullPath("test.in").ToUpperInvariant(), tlogFiles[0]);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFileIsUnderPath()
         {
             Console.WriteLine("Test: FileTrackerFileIsUnderPath");
@@ -876,7 +876,7 @@ class X
             Assert.Equal(false, FileTracker.FileIsUnderPath(@"c:\foo\rumble.cpp", @"c:\foo\rumble\"));
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void FileTrackerFileIsExcludedFromDependencies()
         {
             Console.WriteLine("Test: FileTrackerFileIsExcludedFromDependencies");
@@ -924,7 +924,7 @@ class X
             Assert.Equal(true, FileTracker.FileIsExcludedFromDependencies(testFile));
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTest1()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -947,7 +947,7 @@ class X
             File.Delete(tlogWriteFile);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTest2()
         {
             // Do test 1 twice in a row to make sure there is no leakage
@@ -955,7 +955,7 @@ class X
             InProcTrackingTest1();
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTestSuspendResume()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -992,7 +992,7 @@ class X
             File.Delete(sourceFile + "_r");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTestStopBeforeWrite()
         {
             Assert.Throws<COMException>(() =>
@@ -1015,7 +1015,7 @@ class X
             }
            );
         }
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTestNotStop()
         {
             InProcTrackingTesterNoStop(1);
@@ -1083,7 +1083,7 @@ class X
             File.Delete(sourceFile);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTestIteration()
         {
             for (int iter = 0; iter < 50; iter++)
@@ -1092,7 +1092,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingNonStopTestIteration()
         {
             for (int iter = 0; iter < 50; iter++)
@@ -1102,7 +1102,7 @@ class X
             FileTracker.StopTrackingAndCleanup();
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTwoContexts()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -1143,7 +1143,7 @@ class X
             File.Delete(tlogWriteFile2);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTwoContextsWithRoot()
         {
             string sourceFile = "inlinetrackingtest.txt";
@@ -1194,7 +1194,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingSpawnsOutOfProcTool()
         {
             string intermediateDir = Path.GetTempPath() + @"InProcTrackingSpawnsOutOfProcTool\";
@@ -1242,7 +1242,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingSpawnsOutOfProcTool_OverrideEnvironment()
         {
             string intermediateDir = Path.GetTempPath() + @"InProcTrackingSpawnsOutOfProcTool_OverrideEnvironment\";
@@ -1292,7 +1292,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingSpawnsToolWithTrackerResponseFile()
         {
             Console.WriteLine("Test: InProcTrackingSpawnsToolWithTrackerResponseFile");
@@ -1300,7 +1300,7 @@ class X
             InProcTrackingSpawnsToolWithTracker(true);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingSpawnsToolWithTrackerNoResponseFile()
         {
             Console.WriteLine("Test: InProcTrackingSpawnsToolWithTrackerNoResponseFile");
@@ -1308,7 +1308,7 @@ class X
             InProcTrackingSpawnsToolWithTracker(false);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingTwoContextsTwoEnds()
         {
             Assert.Throws<COMException>(() =>
@@ -1381,7 +1381,7 @@ class X
             File.Delete("InProcTrackingStartProcessFindStrIn-findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingStartProcessFindStrNullCommandLine()
         {
             Console.WriteLine("Test: InProcTrackingStartProcessFindStrNullCommandLine");
@@ -1428,7 +1428,7 @@ class X
         }
 
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingStartProcessFindStrInDefaultTaskName()
         {
             Console.WriteLine("Test: InProcTrackingStartProcessFindStrInDefaultTaskName");
@@ -1457,7 +1457,7 @@ class X
             File.Delete("InProcTrackingStartProcessFindStrIn-findstr.read.1.tlog");
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingChildThreadTrackedAuto()
         {
             FileTracker.SetThreadCount(1);
@@ -1498,7 +1498,7 @@ class X
             File.Delete(sourceFile);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingChildThreadTrackedManual()
         {
             FileTracker.SetThreadCount(1);
@@ -1537,7 +1537,7 @@ class X
             File.Delete(sourceFile);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingChildThreadNotTracked()
         {
             FileTracker.SetThreadCount(1);
@@ -1573,7 +1573,7 @@ class X
             File.Delete(sourceFile);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingChildThreadNotTrackedLocallyTracked()
         {
             FileTracker.SetThreadCount(1);
@@ -1635,7 +1635,7 @@ class X
         }
 
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void InProcTrackingChildCustomEnvironment()
         {
             string sourceFile = "allenvironment.txt";
@@ -1701,7 +1701,7 @@ class X
             File.Delete(commandFile);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void CreateFileDoesntRecordWriteIfNotWrittenTo()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "CreateFileDoesntRecordWriteIfNotWrittenTo");
@@ -1744,7 +1744,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void CopyAlwaysRecordsWrites()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "CopyAlwaysRecordsWrites");
@@ -1887,7 +1887,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleOfSameTool_SameCommand()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_SameCommand");
@@ -1919,7 +1919,7 @@ class X
             LaunchDuplicateToolsAndVerifyTlogExistsForEach(testDir, contextSpecifications, tlogPatterns, createTestDirectory: false);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleOfSameTool_DifferentCommands1()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands1");
@@ -1952,7 +1952,7 @@ class X
             LaunchDuplicateToolsAndVerifyTlogExistsForEach(testDir, contextSpecifications, tlogPatterns, createTestDirectory: false);
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleOfSameTool_DifferentCommands2()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands2");
@@ -2002,7 +2002,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleOfSameTool_DifferentCommands3()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands3");
@@ -2057,7 +2057,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleOfSameTool_DifferentCommands4()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentCommands4");
@@ -2111,7 +2111,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleDifferentTools()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleDifferentTools");
@@ -2160,7 +2160,7 @@ class X
             }
         }
 
-        [Fact]
+        [Fact(Skip = "FileTracker tests require VS2015 Update 3 or a packaged version of Tracker.exe https://github.com/Microsoft/msbuild/issues/649")]
         public void LaunchMultipleOfSameTool_DifferentContexts()
         {
             string testDir = Path.Combine(Path.GetTempPath(), "LaunchMultipleOfSameTool_DifferentContexts");


### PR DESCRIPTION
:memo: This is destined for the Update 3 branch. I'll merge to master in another PR after it's in there.

This ports internal changes made to support an update to `Tracker.exe` and `FileTracker.dll` that allows them to support a process tree that has mixed 64-bit and 32-bit processes.

These changes will not work without a build of Update 3 installed, because Tracker and FileTracker are built inside the Microsoft firewall and not publicly available. Filed #649 to track making them available. The tests can also be re-enabled by making Update 3 a requirement to build on Windows (once it exists outside the firewall).