### PR TITLE
Replace uses of #!/bin/bash with #!/usr/bin/env bash

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1506,7 +1506,8 @@ namespace Microsoft.Build.Utilities
 
                     if (!runningOnWindows)
                     {
-                        File.AppendAllText(_temporaryBatchFile, "#!/bin/bash\n"); // first line for UNIX is ANSI
+                        // Use sh rather than bash, as not all 'nix systems necessarily have Bash installed
+                        File.AppendAllText(_temporaryBatchFile, "#!/bin/sh\n"); // first line for UNIX is ANSI
                         // This is a hack..!
                         File.AppendAllText(_temporaryBatchFile, commandLineCommands.Replace('\\', Path.DirectorySeparatorChar), EncodingUtilities.CurrentSystemOemEncoding);
                     }

--- a/src/XMakeTasks/Exec.cs
+++ b/src/XMakeTasks/Exec.cs
@@ -244,7 +244,8 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    sw.WriteLine("#!/bin/bash");
+                    // Use sh rather than bash, as not all 'nix systems necessarily have Bash installed
+                    sw.WriteLine("#!/bin/sh");
                 }
 
                 if (NativeMethodsShared.IsUnixLike && NativeMethodsShared.IsMono)


### PR DESCRIPTION
It's generally best practice to prefix a Bash script with `#!/usr/bin/env bash` rather than `#!/bin/bash`. Although 99% of the time the `bash` executable will be in `/bin` (or at least a symlink of it will be), in some cases it may not be-- see [this StackOverflow answer](http://stackoverflow.com/a/21613044/4077294) for an example.

Using `env` ensures we search through all the directories in $PATH for `bash`, rather than restricting it to just the one in `/bin`. Also, there shouldn't be a performance loss since `env` replaces its own process with the arguments it's given, rather than starting a new one (similar to the difference between `command` and [`exec command`](http://wiki.bash-hackers.org/commands/builtin/exec) in Bash).