### PR TITLE
Update nuspecs from targetting dotnet to targetting netstandard1.3

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -21,7 +21,7 @@
 
   <!-- Tool versions -->
   <PropertyGroup>
-    <NuSpecReferenceGeneratorVersion>1.3.1</NuSpecReferenceGeneratorVersion>
+    <NuSpecReferenceGeneratorVersion>1.4.2</NuSpecReferenceGeneratorVersion>
     <XunitVersion>2.1.0</XunitVersion>
     <CompilerToolsVersion>1.2.0-beta1-20160108-01</CompilerToolsVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
@@ -52,6 +52,9 @@
     <!-- nuget cache location. Used by packageresolve.targets -->
     <PackagesDir Condition="'$(OsEnvironment)'=='Windows_NT'">$([System.IO.Path]::Combine($(USERPROFILE), '.nuget', 'packages'))</PackagesDir>
     <PackagesDir Condition="'$(OsEnvironment)'!='Windows_NT'">$([System.IO.Path]::Combine($(HOME), '.nuget', 'packages'))</PackagesDir>
+    
+    <!-- target framework for msbuild nuget packages. Used by Nuspec.ReferenceGenerator.targets to update corefx dependencies-->
+    <NuSpecTfm>netstandard1.3</NuSpecTfm>
 
     <!-- NuSpec.ReferenceGenerator targets use SolutionDir -->
     <SolutionDir>$(SourceDir)</SolutionDir>

--- a/src/.nuget/project.json
+++ b/src/.nuget/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "xunit.runner.console": "2.1.0",
-    "NuSpec.ReferenceGenerator": "1.3.1",
+    "NuSpec.ReferenceGenerator": "1.4.2",
     "Microsoft.Net.Compilers" : "1.2.0-beta1-20160108-01",
     "MicroBuild.Core" : "0.2.0"
   },

--- a/src/nuget/MSBuild.nuspec
+++ b/src/nuget/MSBuild.nuspec
@@ -16,7 +16,7 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="dotnet">
+      <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="Microsoft.Build" />
         <dependency id="Microsoft.Build.Utilities.Core" />
@@ -61,7 +61,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="_._" target="lib\dotnet" />
+    <file src="_._" target="lib\netstandard1.3" />
     <file src="MSBuild.exe" target="runtimes\any\native" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Framework.nuspec
+++ b/src/nuget/Microsoft.Build.Framework.nuspec
@@ -16,8 +16,7 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="dotnet">
-        <dependency id="System.Runtime.InteropServices.PInvoke" version="4.0.0-rc3-23908" />
+      <group targetFramework="netstandard1.3">
         <dependency id="System.Collections" version="4.0.11-rc3-24109-00" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11-rc3-24109-00" />
         <dependency id="System.Globalization" version="4.0.11-rc3-24109-00" />
@@ -29,6 +28,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.Build.Framework.dll" target="lib\dotnet" />
+    <file src="Microsoft.Build.Framework.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Targets.nuspec
+++ b/src/nuget/Microsoft.Build.Targets.nuspec
@@ -16,7 +16,7 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="dotnet">
+      <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.Build.Framework" />
         <dependency id="Microsoft.Build" />
         <dependency id="Microsoft.Build.Utilities.Core" />
@@ -29,7 +29,7 @@
     </contentFiles>
   </metadata>
   <files>
-    <file src="_._" target="lib\dotnet" />
+    <file src="_._" target="lib\netstandard1.3" />
     <file src="Microsoft.Common.CurrentVersion.targets" target="runtimes\any\native" />
     <file src="Microsoft.Common.targets" target="runtimes\any\native" />
     <file src="Microsoft.CSharp.CurrentVersion.targets" target="runtimes\any\native" />

--- a/src/nuget/Microsoft.Build.Tasks.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Tasks.Core.nuspec
@@ -16,12 +16,8 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="dotnet">
+      <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.Build.Framework" />
-        <dependency id="System.IO.FileSystem.DriveInfo" version="4.0.0-beta-23302" />
-        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23516" />
-        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1-beta-23516" />
-        <dependency id="System.Runtime.InteropServices.PInvoke" version="4.0.0-rc3-23908" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1-rc3-24109-00" />
         <dependency id="System.Collections" version="4.0.11-rc3-24109-00" />
         <dependency id="System.Collections.Concurrent" version="4.0.12-rc2-23805" />
@@ -60,6 +56,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.Build.Tasks.Core.dll" target="lib\dotnet" />
+    <file src="Microsoft.Build.Tasks.Core.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.Utilities.Core.nuspec
+++ b/src/nuget/Microsoft.Build.Utilities.Core.nuspec
@@ -16,9 +16,8 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="dotnet">
+      <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.Build.Framework" />
-        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23516" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1-rc3-24109-00" />
         <dependency id="System.Collections" version="4.0.11-rc3-24109-00" />
         <dependency id="System.Collections.Concurrent" version="4.0.12-rc3-24109-00" />
@@ -53,6 +52,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.Build.Utilities.Core.dll" target="lib\dotnet" />
+    <file src="Microsoft.Build.Utilities.Core.dll" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -16,10 +16,8 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group targetFramework="dotnet">
+      <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.Build.Framework" />
-        <dependency id="Microsoft.Tpl.Dataflow" version="4.5.24" />
-        <dependency id="Microsoft.Win32.Registry" version="4.0.0-beta-23516" />
         <dependency id="Microsoft.Win32.Primitives" version="4.0.1-rc3-24109-00" />
         <dependency id="System.AppContext" version="4.1.0-rc3-24109-00" />
         <dependency id="System.Collections" version="4.0.11-rc3-24109-00" />
@@ -66,6 +64,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.Build.dll" target="lib\dotnet" />
+    <file src="Microsoft.Build.dll" target="lib\netstandard1.3" />
   </files>
 </package>


### PR DESCRIPTION
The `dotnet` moniker is the deprecated moniker for `dnxcore50`, and `dnxcore50` is the deprecated moniker for `netcoreapp1.0`
Since we want msbuild packages to be referenceable from both `net46` and `netcoreapp1.0`, they should really target the intersection APIs, which is `netstandard1.3`