### PR TITLE
Add tests for running portable tasks

### DIFF
--- a/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
+++ b/src/XMakeCommandLine/UnitTests/XMake_Tests.cs
@@ -816,7 +816,7 @@ namespace Microsoft.Build.UnitTests
             string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out successfulExit);
             Assert.False(successfulExit);
 
-            Assert.Contains(RunnerUtilities.PathToMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(RunnerUtilities.PathToCurrentlyRunningMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, output, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -830,7 +830,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                Directory.SetCurrentDirectory(Path.GetDirectoryName(RunnerUtilities.PathToMsBuildExe));
+                Directory.SetCurrentDirectory(Path.GetDirectoryName(RunnerUtilities.PathToCurrentlyRunningMsBuildExe));
 
                 var msbuildParameters = "\"" + _pathToArbitraryBogusFile + "\"" + (NativeMethodsShared.IsWindows ? " /v:diag" : " -v:diag");
 
@@ -843,7 +843,7 @@ namespace Microsoft.Build.UnitTests
                 Directory.SetCurrentDirectory(current);
             }
 
-            Assert.Contains(RunnerUtilities.PathToMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(RunnerUtilities.PathToCurrentlyRunningMsBuildExe + (NativeMethodsShared.IsWindows ? " /v:diag " : " -v:diag ") + _pathToArbitraryBogusFile, output, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -1845,9 +1845,9 @@ namespace Microsoft.Build.UnitTests
 
         private void CopyMSBuildExeToPath(string destPath)
         {
-            File.Copy(RunnerUtilities.PathToMsBuildExe, Path.Combine(destPath, "MSBuild.exe"));
+            File.Copy(RunnerUtilities.PathToCurrentlyRunningMsBuildExe, Path.Combine(destPath, "MSBuild.exe"));
 
-            var msbuildExeDir = Path.GetDirectoryName(RunnerUtilities.PathToMsBuildExe);
+            var msbuildExeDir = Path.GetDirectoryName(RunnerUtilities.PathToCurrentlyRunningMsBuildExe);
             var deps = new string[] {
                     "Microsoft.Build.dll",
                     "Microsoft.Build.Framework.dll",

--- a/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\..\Shared\FxCopExclusions\Microsoft.Build.Shared.Suppressions.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\..\Shared\UnitTests\AssemblyNameEx_Tests.cs" />
     <Compile Include="..\..\Shared\UnitTests\EscapingUtilities_Tests.cs" />
     <Compile Include="..\..\Shared\UnitTests\ErrorUtilities_Tests.cs" />
     <Compile Include="..\..\Shared\UnitTests\FileMatcher_Tests.cs" />
@@ -36,7 +37,9 @@
     </Compile>
     <Compile Include="..\..\Shared\UnitTests\ObjectModelHelpers.cs" />
     <Compile Include="..\..\Shared\UnitTests\ResourceUtilities_Tests.cs" />
-    <Compile Include="..\..\Shared\UnitTests\AssemblyNameEx_Tests.cs" />
+    <Compile Include="..\..\Shared\UnitTests\RunnerUtilities.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="..\..\Shared\QuotingUtilities.cs" />
     <Compile Include="AssemblyIdentity_Tests.cs" />
     <Compile Include="AssemblyRefs.cs" />
@@ -66,6 +69,7 @@
     <Compile Include="MockUnmanagedMemoryHelper.cs" />
     <Compile Include="Move_Tests.cs" />
     <Compile Include="MSBuild_Tests.cs" />
+    <Compile Include="PortableTasks_Tests.cs" />
     <Compile Include="PropertyParser_Tests.cs" />
     <Compile Include="ReadLinesFromFile_Tests.cs" />
     <Compile Include="RemoveDir_Tests.cs" />

--- a/src/XMakeTasks/UnitTests/PortableTasks_Tests.cs
+++ b/src/XMakeTasks/UnitTests/PortableTasks_Tests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Shared;
+using Microsoft.Build.SharedUtilities;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class PortableTasks_Tests
+    {
+        private static readonly string ProjectFilePath = Path.Combine(FileUtilities.CurrentExecutableDirectory, "portableTaskTest.proj");
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void TestDesktopMSBuildShouldRunPortableTask()
+        {
+            RunMSBuildOnProjectWithPortableTaskAndAssertOutput(true);
+        }
+
+        [Fact]
+        public static void TestNonDesktopMSBuildShouldRunPortableTask()
+        {
+            RunMSBuildOnProjectWithPortableTaskAndAssertOutput(false);
+        }
+
+        private static void RunMSBuildOnProjectWithPortableTaskAndAssertOutput(bool useDesktopMSBuild)
+        {
+            bool successfulExit;
+            string executionOutput;
+            
+            Assert.True(File.Exists(ProjectFilePath), $"Project file {ProjectFilePath} does not exist");
+
+            executionOutput = useDesktopMSBuild ? 
+                RunnerUtilities.RunProcessAndGetOutput("msbuild", ProjectFilePath, out successfulExit, shellExecute: true) : 
+                RunnerUtilities.ExecMSBuild(ProjectFilePath, out successfulExit);
+            
+            Assert.True(successfulExit, $"{(useDesktopMSBuild ? "Desktop MSBuild" : "Non Desktop MSBuild")} failed to execute the portable task");
+
+            var matches = Regex.Matches(executionOutput, @"Microsoft\.Build\.(\w+\.)+dll");
+
+            Assert.True(matches.Count > 1);
+        }
+    }
+}


### PR DESCRIPTION
An attempt to write some automated tests to check that tasks should be runnable by all msbuild flavors.
The tests invoke our sample portable task with the desktop msbuild, and with the non-desktop msbuilds.

Unfortunately this is not ideal. The ideal case would also check that msbuild's nuget packaging allows consumers of msbuild packages to target both `net46` and `netcoreapp1.0` / `netstandard1.3` and assert that the msbuild packages get successfully restored.

Unfortunately this requires a big change to xplat's build logic so it executes in 3 steps:
1) build and package msbuild
2) restore the sample projects using the local, freshly built packages
3) run msbuild tests (some of them depend on the sample projects)