### PR TITLE
gitignore: Ignore VS Code-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,6 @@ ApiPort/
 ref/
 Differences.txt
 Tools/
+
+# Visual Studio Code
+.vscode/


### PR DESCRIPTION
Noticed that the `.vscode` directory was showing up in `git status` after making my changes; this should help it ignore such directories, for users of VS Code.