### PR TITLE
Revert "Merge pull request #668 from cdmihai/enableLinuxCITests"

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -9,7 +9,7 @@ def project = GithubProject
     ['Windows_NT', 'OSX', 'Ubuntu'].each {osName ->
         def isPR = false
         def newJobName = ''
-        def skipTestResultArchivalWhenResultsNotFound = true
+        def skipTestsWhenResultsNotFound = true
 
         if (branch == 'pr') {
             isPR = true
@@ -32,7 +32,7 @@ def project = GithubProject
                         batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" && RebuildWithLocalMSBuild.cmd")
                     }
 
-                    skipTestResultArchivalWhenResultsNotFound = false
+                    skipTestsWhenResultsNotFound = false
                 }
 
                 break;
@@ -45,9 +45,11 @@ def project = GithubProject
 
                 break;
             case 'Ubuntu':
+
+                // Do not run tests on Ubuntu. We don't yet have a green test baseline.
                 newJob.with{
                     steps{
-                        shell("./cibuild.sh --scope Test")
+                        shell("./cibuild.sh --scope Compile")
                     }
                 }
 
@@ -55,7 +57,7 @@ def project = GithubProject
         }
 
         // Add xunit result archiving. Skip if no results found.
-        Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml', skipTestResultArchivalWhenResultsNotFound)
+        Utilities.addXUnitDotNETResults(newJob, 'bin/**/*_TestResults.xml', skipTestsWhenResultsNotFound)
         Utilities.setMachineAffinity(newJob, osName, 'latest-or-auto')
         Utilities.standardJobSetup(newJob, project, isPR, branch)
         // Add archiving of logs (even if the build failed)


### PR DESCRIPTION

Xunit does not report *some* test failures on Ubuntu. Our build scripts use the same arguments for xunit on osx and ubuntu, so the problem seems to be somewhere else (xunit, coreclr, corefx, etc). I am reverting enabling Linux tests until I find out what is happening.