### PR TITLE
Remove AssignLinkMetadata from targets

### DIFF
--- a/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/XMakeTasks/Microsoft.Common.CurrentVersion.targets
@@ -1024,7 +1024,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
-    <PrepareForBuildDependsOn>GetFrameworkPaths;GetReferenceAssemblyPaths;AssignLinkMetadata</PrepareForBuildDependsOn>
+    <PrepareForBuildDependsOn>GetFrameworkPaths;GetReferenceAssemblyPaths</PrepareForBuildDependsOn>
   </PropertyGroup>
   <Target
       Name="PrepareForBuild"


### PR DESCRIPTION
When the AssignLinkMetadata task is implemented this should be added
back, but until then it causes builds which don't depend on it
to fail unnecessarily. Works around #544