### PR TITLE
Add MSBuildFrameworkToolsPath64 to app.config

### DIFF
--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -42,17 +42,22 @@
         <property name="MSBuildRuntimeVersion" value="4.0.30319" />
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPath64" value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
         <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
         <property name="SDK35ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86@InstallationFolder))" />
         <property name="SDK40ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86@InstallationFolder)" />
         <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
-
-        <!-- TODO: hacks (remove ..\ )-->
         <property name="VSInstallRoot" value="$(MSBuildToolsPath)\..\..\.." />
         <property name="MSBuildToolsRoot" value="$(VSInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath" value="$(VSInstallRoot)\MSBuild" />
         <property name="MSBuildExtensionsPath32" value="$(VSInstallRoot)\MSBuild" />
+
+        <!-- VC Specific Paths -->
         <property name="VCTargetsPath" value="$(VSInstallRoot)\Common7\IDE\VC\VCTargets" />
+        <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V140\'))" />
+        <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V120\'))" />
+        <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V110\'))" />
+        <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\'))" />
 
         <projectImportSearchPaths>
           <searchPaths os="windows">


### PR DESCRIPTION
Also updated VCTargetsPaths to match current installed toolset.

@yuehuang010 can you also review the `VCTargetsPath` for legacy? The current `VCTargetsPath` points to the low-impact location.

Closes #679 