### PR TITLE
Detecting Host Process to launch new instances of msbuild when /m is passed in

### DIFF
--- a/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/XMakeBuildEngine/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -490,12 +490,13 @@ namespace Microsoft.Build.BackEnd
             CommunicationsUtilities.Trace("Launching node from {0}", msbuildLocation);
 
 #if RUNTIME_TYPE_NETCORE
-            string coreRunName = NativeMethodsShared.IsUnixLike ? "corerun" : "CoreRun.exe";
-            string exeName = Path.Combine(Path.GetDirectoryName(msbuildLocation), coreRunName);
+            // Run the child process with the same host as the currently-running process.
+            string pathToHost;
+            using (Process currentProcess = Process.GetCurrentProcess()) pathToHost = currentProcess.MainModule.FileName;
             commandLineArgs = "\"" + msbuildLocation + "\" " + commandLineArgs;
 
             ProcessStartInfo processStartInfo = new ProcessStartInfo();
-            processStartInfo.FileName = exeName;
+            processStartInfo.FileName = pathToHost;
             processStartInfo.Arguments = commandLineArgs;
             processStartInfo.CreateNoWindow = (creationFlags | BackendNativeMethods.CREATENOWINDOW) == BackendNativeMethods.CREATENOWINDOW;
             processStartInfo.UseShellExecute = false;


### PR DESCRIPTION
We are currently trying to move all the tools that are used to build corefx(which includes MSBuild) to run on the DotNet CLI and the shared framework that comes with it. The problem with MSBuild, is that when `\m` is passed in, it always tries to look for corerun.exe (or corerun in non-Windows) to lunch new processes like `corerun.exe MSBuild.exe ...`. With my change, msbuild will now detect the host process that was used originally, and use the same one for its children. For example:
```
>dotnet.exe msbuild.exe /m build.proj
//That will cause that the children processes will be like:
>dotnet.exe msbuild.exe ...
```

PTAL: @cdmihai @rainersigwald @dsplaisted 
FYI: @weshaggard @stephentoub