### PR TITLE
Enable AssignLinkMetadata in .NET Core build

### DIFF
--- a/src/XMakeTasks/Microsoft.Build.Tasks.csproj
+++ b/src/XMakeTasks/Microsoft.Build.Tasks.csproj
@@ -328,6 +328,7 @@
     <Compile Include="AssemblyResources.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="AssignLinkMetadata.cs" />
     <Compile Include="AssignProjectConfiguration.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -518,7 +519,6 @@
     <Compile Include="AssemblyRegistrationCache.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="AssignLinkMetadata.cs" />
     <Compile Include="AxImp.cs" />
     <Compile Include="AxReference.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/XMakeTasks/UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="AssemblyIdentity_Tests.cs" />
     <Compile Include="AssemblyRefs.cs" />
     <Compile Include="AssignCulture_Tests.cs" />
+    <Compile Include="AssignLinkMetadata_Tests.cs" />
     <Compile Include="AssignTargetPath_Tests.cs" />
     <Compile Include="CallTarget_Tests.cs" />
     <Compile Include="CombinePath_Tests.cs" />
@@ -100,7 +101,6 @@
     <Compile Include="AppConfig_Tests.cs" />
     <Compile Include="AspNetCompiler_Tests.cs" />
     <Compile Include="AssemblyRegistrationCache_Tests.cs" />
-    <Compile Include="AssignLinkMetadata_Tests.cs" />
     <Compile Include="AssignProjectConfiguration_Tests.cs" />
     <Compile Include="AxImp_Tests.cs" />
     <Compile Include="AxTlbBaseTask_Tests.cs" />


### PR DESCRIPTION
Resolves #544