### PR TITLE
Make Delete non-sealed, just like Copy, Move, MakeDir, etc.

### DIFF
--- a/src/XMakeTasks/Delete.cs
+++ b/src/XMakeTasks/Delete.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Delete files from disk.
     /// </summary>
-    public sealed class Delete : TaskExtension, ICancelableTask
+    public class Delete : TaskExtension, ICancelableTask
     {
         #region Properties
 


### PR DESCRIPTION
Xamarin MSBuild-based remote infrastructure relies on inheriting and 
extending the base tasks to execute remotely (as well as locally). 

For consistency with the other build tasks, this should not be sealed 
either.