### PR TITLE
Update xunit version in dir.props

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -35,7 +35,7 @@
     <!-- Package version / directories -->
     <BuildToolsVersion>1.0.25-prerelease-00199</BuildToolsVersion>
     <CompilerToolsVersion>1.0.0</CompilerToolsVersion>
-    <XunitVersion>2.1.0-rc1-build3168</XunitVersion>
+    <XunitVersion>2.1.0</XunitVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <GitVersioningVersion>1.4.30</GitVersioningVersion>
 


### PR DESCRIPTION
This was missed in the update to xunit 2.1.0 RTM in a86122bd0. Tests
passed on machines that had the old package installed but failed on clean
machines.