### PR TITLE
Allow derived exceptions in PassEmptyAndNullTPM

### DIFF
--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Framework;
 
 using ProjectCollection = Microsoft.Build.Evaluation.ProjectCollection;
 using Xunit;
+using Xunit.Abstractions;
 
 
 namespace Microsoft.Build.UnitTests
@@ -45,6 +46,7 @@ namespace Microsoft.Build.UnitTests
         private List<BuildMessageEventArgs> _buildMessageEvents = new List<BuildMessageEventArgs>();
         private List<BuildStartedEventArgs> _buildStartedEvents = new List<BuildStartedEventArgs>();
         private List<BuildFinishedEventArgs> _buildFinishedEvents = new List<BuildFinishedEventArgs>();
+        private ITestOutputHelper _testOutputHelper;
 
         /// <summary>
         /// Should the build finished event be logged in the log file. This is to work around the fact we have different
@@ -280,6 +282,16 @@ namespace Microsoft.Build.UnitTests
         }
         #endregion
 
+        public MockLogger()
+        {
+            _testOutputHelper = null;
+        }
+
+        public MockLogger(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
         /*
          * Method:  LoggerEventHandler
          *
@@ -465,7 +477,14 @@ namespace Microsoft.Build.UnitTests
             }
             if (index != contains.Length)
             {
-                Console.WriteLine(FullLog);
+                if (_testOutputHelper != null)
+                {
+                    _testOutputHelper.WriteLine(FullLog);
+                }
+                else
+                {
+                    Console.WriteLine(FullLog);
+                }
                 Assert.True(false, String.Format(CultureInfo.CurrentCulture, "Log was expected to contain '{0}', but did not.\n=======\n{1}\n=======", contains[index], FullLog));
             }
         }
@@ -478,7 +497,14 @@ namespace Microsoft.Build.UnitTests
         {
             if (FullLog.Contains(contains))
             {
-                Console.WriteLine(FullLog);
+                if (_testOutputHelper != null)
+                {
+                    _testOutputHelper.WriteLine(FullLog);
+                }
+                else
+                {
+                    Console.WriteLine(FullLog);
+                }
                 Assert.True(false, String.Format("Log was not expected to contain '{0}', but did.", contains));
             }
         }

--- a/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities/UnitTests/ToolLocationHelper_Tests.cs
@@ -2733,10 +2733,10 @@ namespace Microsoft.Build.UnitTests
         private static void VerifyExceptionOnEmptyOrNullPlatformAttributes(string identifier, Version version)
         {
 
-            Assert.Throws<ArgumentException>(
+            Assert.ThrowsAny<ArgumentException>(
                 () => ToolLocationHelper.GetPlatformExtensionSDKLocations(identifier, version));
 
-            Assert.Throws<ArgumentException>(
+            Assert.ThrowsAny<ArgumentException>(
                 () => ToolLocationHelper.GetPlatformSDKLocation(identifier, version));
         }
 

--- a/src/XMakeBuildEngine/UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/XMakeBuildEngine/UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Xml;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.OM.Instance
 {
@@ -24,6 +25,13 @@ namespace Microsoft.Build.UnitTests.OM.Instance
     /// </summary>
     public class ProjectInstance_Internal_Tests
     {
+        private readonly ITestOutputHelper _output;
+
+        public ProjectInstance_Internal_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         /// <summary>
         /// Read task registrations
         /// </summary>
@@ -522,7 +530,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 
             ProjectInstance projectInstance = GetProjectInstance(projectFileContent);
             List<ILogger> loggers = new List<ILogger>();
-            MockLogger mockLogger = new MockLogger();
+            MockLogger mockLogger = new MockLogger(_output);
             loggers.Add(mockLogger);
             bool success = projectInstance.Build("Build", loggers);
 


### PR DESCRIPTION
Converting this to be more "xunity" in 2c9f334 was wrong, because many of
the cases threw an exception *derived* from ArgumentException, not exactly
an ArgumentException. `ThrowsAny` describes that case.