### PR TITLE
Calculate a better MSBuild tools/extensions path.

### DIFF
--- a/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
+++ b/src/XMakeBuildEngine/Evaluation/IntrinsicFunctions.cs
@@ -349,6 +349,31 @@ namespace Microsoft.Build.Evaluation
             return false;
         }
 
+        public static string GetCurrentExecutableDirectory()
+        {
+            return FileUtilities.CurrentExecutableDirectory;
+        }
+
+        public static string GetVsInstallRoot()
+        {
+            var vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
+            var vsVersion = Environment.GetEnvironmentVariable("VisualStudioVersion");
+
+            if (!string.IsNullOrEmpty(vsInstallDir) && !string.IsNullOrEmpty(vsVersion))
+            {
+                if (vsVersion == "15.0" && Directory.Exists(vsInstallDir))
+                {
+                    return vsInstallDir;
+                }
+            }
+
+            // This assumes MSBuild is in VS\MSBuild\15.0\Bin.
+            var msbuildDir = FileUtilities.CurrentExecutableDirectory;
+            vsInstallDir = Path.GetFullPath(Path.Combine(msbuildDir, @"..\..\.."));
+
+            return vsInstallDir;
+        }
+
         #region Debug only intrinsics
 
         /// <summary>

--- a/src/XMakeCommandLine/app.config
+++ b/src/XMakeCommandLine/app.config
@@ -35,9 +35,9 @@
     <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
     <msbuildToolsets default="15.0">
       <toolset toolsVersion="15.0">
-        <property name="MSBuildToolsPath" value="." />
-        <property name="MSBuildToolsPath32" value="." />
-        <property name="MSBuildToolsPath64" value=".\amd64" />
+        <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentExecutableDirectory())" />
+        <property name="MSBuildToolsPath32" value="$(MSBuildToolsPath)" />
+        <property name="MSBuildToolsPath64" value="$(MSBuildToolsPath)\amd64" />
         <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
         <property name="MSBuildRuntimeVersion" value="4.0.30319" />
         <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
@@ -47,13 +47,13 @@
         <property name="SDK35ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86@InstallationFolder))" />
         <property name="SDK40ToolsPath" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86@InstallationFolder)" />
         <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
-        <property name="VSInstallRoot" value="$(MSBuildToolsPath)\..\..\.." />
-        <property name="MSBuildToolsRoot" value="$(VSInstallRoot)\MSBuild" />
-        <property name="MSBuildExtensionsPath" value="$(VSInstallRoot)\MSBuild" />
-        <property name="MSBuildExtensionsPath32" value="$(VSInstallRoot)\MSBuild" />
+        <property name="VsInstallRoot" value="$([MSBuild]::GetVsInstallRoot())" />
+        <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath" value="$(VsInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath32" value="$(VsInstallRoot)\MSBuild" />
 
         <!-- VC Specific Paths -->
-        <property name="VCTargetsPath" value="$(VSInstallRoot)\Common7\IDE\VC\VCTargets" />
+        <property name="VCTargetsPath" value="$(VsInstallRoot)\Common7\IDE\VC\VCTargets" />
         <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V140\'))" />
         <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V120\'))" />
         <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$(MSBuildExtensionsPath32)\Microsoft.Cpp\v4.0\V110\'))" />


### PR DESCRIPTION
Add a hook into the intrinsic functions to get the full path to the
MSBuild tools path and VS install root for the extensions path variables.

This is blocking some tests internally because the "." is getting read and evaluated to a different path. I also think it given that this logic is now somewhat more complicated that we should do something like this to calculate the paths rather than limit to a single line property evaluation as it was (I never liked the `..\..\..\` or `.` appearing in the variable).

Note: I'm looking for feedback and ideas on where to put this code, this is not complete. I may commit this to unblock the tests internally, but either way this needs to be updated.