### PR TITLE
Rename setup package ID in files.swr

### DIFF
--- a/setup/files.swr
+++ b/setup/files.swr
@@ -1,6 +1,6 @@
 use vs
 
-package name=MSBuild
+package name=Microsoft.Build
         version=$(Version)
         vs.package.chip=neutral
         vs.package.language=neutral


### PR DESCRIPTION
Missed this in my rename of the setup package. This doesn't get caught until it tries to insert the package in the VS setup build.